### PR TITLE
fix: Prevent TabBarItem FocusState from being reset when focus is lost

### DIFF
--- a/src/Uno.Toolkit.UI/TabBar/TabBarItem.cs
+++ b/src/Uno.Toolkit.UI/TabBar/TabBarItem.cs
@@ -45,9 +45,10 @@ namespace Uno.UI.ToolkitLib
 		{
 			DefaultStyleKey = typeof(TabBarItem);
 			Loaded += OnLoaded;
+            LostFocus += OnLostFocus;
 		}
 
-		private void OnLoaded(object sender, RoutedEventArgs e)
+        private void OnLoaded(object sender, RoutedEventArgs e)
 		{
 			UpdateCommonStates();
 		}
@@ -174,5 +175,10 @@ namespace Uno.UI.ToolkitLib
 			return state;
 		}
 
+		private void OnLostFocus(object sender, RoutedEventArgs e)
+		{
+			// Prevent VisualState from being reset to Normal upon lost focus
+			UpdateCommonStates();
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #43 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
- Bugfix

<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
When focus is lost, the selected TabBarItem's visual state can return to Normal, losing the critical distinction between selected and unselected items if a selection indicator isn't specified.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Instead of setting IsTabStop equal to False, this PR preserves keyboard accessibility. Instead, handling the LostFocus event to always set the correct VisualState.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
This pull request supports work being done with Material and Cupertino themes for TabBar.
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): N/A
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
