### PR TITLE
chore: Update Uno and Uno.WinUI packages, add Uno.Material and Uno.Cupertino and Xamarin.AndroidX.Lifecycle.LiveData for Android

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
@@ -65,11 +65,23 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.33" />
+    <PackageReference Include="Uno.Cupertino">
+      <Version>1.0.0-dev.810</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.Material">
+      <Version>1.0.0-dev.810</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.UI" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources">
+      <Version>1.2.0.5</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData">
+      <Version>2.3.1.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Gtk/Uno.Toolkit.Samples.Skia.Gtk.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Gtk/Uno.Toolkit.Samples.Skia.Gtk.csproj
@@ -17,8 +17,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.UI.Skia.Gtk" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.Cupertino" Version="1.0.0-dev.810" />
+    <PackageReference Include="Uno.Material" Version="1.0.0-dev.810" />
+    <PackageReference Include="Uno.UI.Skia.Gtk" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Uno.Toolkit.UI\Uno.Toolkit.UI.csproj" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.UWP/Uno.Toolkit.Samples.UWP.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.UWP/Uno.Toolkit.Samples.UWP.csproj
@@ -11,8 +11,14 @@
       <Version>6.2.11</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.5.0" />
-    <PackageReference Include="Uno.Core" Version="2.3.0" />
-    <PackageReference Include="Uno.UI" Version="3.8.0-dev.280" />
+    <PackageReference Include="Uno.Core" Version="2.4.0" />
+    <PackageReference Include="Uno.Cupertino">
+      <Version>1.0.0-dev.810</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.Material">
+      <Version>1.0.0-dev.810</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.UI" Version="3.10.0-dev.593" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
   </ItemGroup>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Wasm/Uno.Toolkit.Samples.Wasm.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Wasm/Uno.Toolkit.Samples.Wasm.csproj
@@ -42,11 +42,13 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+		<PackageReference Include="Uno.Cupertino" Version="1.0.0-dev.810" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.0.1" />
-		<PackageReference Include="Uno.UI.WebAssembly" Version="3.8.0-dev.280" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.Wasm.Bootstrap" Version="2.0.0" />
-		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.0.0" />
+		<PackageReference Include="Uno.Material" Version="1.0.0-dev.810" />
+		<PackageReference Include="Uno.UI.WebAssembly" Version="3.10.0-dev.593" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.Wasm.Bootstrap" Version="2.1.0" />
+		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
 	</ItemGroup>
 	<ItemGroup>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.iOS/Uno.Toolkit.Samples.iOS.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.iOS/Uno.Toolkit.Samples.iOS.csproj
@@ -116,10 +116,16 @@
     <BundleResource Include="Resources\Fonts\uno-fluentui-assets.ttf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.Cupertino">
+      <Version>1.0.0-dev.810</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.Material">
+      <Version>1.0.0-dev.810</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.UI" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.0.1" />
+    <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.macOS/Uno.Toolkit.Samples.macOS.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.macOS/Uno.Toolkit.Samples.macOS.csproj
@@ -70,8 +70,14 @@
     <Reference Include="System.Memory" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.Cupertino">
+      <Version>1.0.0-dev.810</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.Material">
+      <Version>1.0.0-dev.810</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.UI" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/Uno.Toolkit.WinUI.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/Uno.Toolkit.WinUI.Samples.Droid.csproj
@@ -70,11 +70,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.33" />
+    <PackageReference Include="Uno.WinUI" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources">
+      <Version>1.2.0.5</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData">
+      <Version>2.3.1.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Skia.Gtk/Uno.Toolkit.WinUI.Samples.Skia.Gtk.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Skia.Gtk/Uno.Toolkit.WinUI.Samples.Skia.Gtk.csproj
@@ -24,8 +24,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Uno.Toolkit.UI\Uno.Toolkit.WinUI.csproj" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Wasm/Uno.Toolkit.WinUI.Samples.Wasm.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Wasm/Uno.Toolkit.WinUI.Samples.Wasm.csproj
@@ -42,10 +42,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.0.1" />
-    <PackageReference Include="Uno.WinUI.WebAssembly" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
-	  <PackageReference Include="Uno.Wasm.Bootstrap" Version="2.0.0" />
-	  <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.0.0" />
+    <PackageReference Include="Uno.WinUI.WebAssembly" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
+	  <PackageReference Include="Uno.Wasm.Bootstrap" Version="2.1.0" />
+	  <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0" />
 	  <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="0.5.0" />
 		<Manifest Include="$(ApplicationManifest)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.Core" Version="2.3.0" />
+		<PackageReference Include="Uno.Core" Version="2.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.iOS/Uno.Toolkit.WinUI.Samples.iOS.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.iOS/Uno.Toolkit.WinUI.Samples.iOS.csproj
@@ -119,10 +119,10 @@
     <BundleResource Include="Resources\Fonts\uno-fluentui-assets.ttf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.WinUI" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.0.1" />
+    <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.macOS/Uno.Toolkit.WinUI.Samples.macOS.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.macOS/Uno.Toolkit.WinUI.Samples.macOS.csproj
@@ -73,8 +73,8 @@
     <Reference Include="System.Memory" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="3.8.0-dev.280" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.8.0-dev.280" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.WinUI" Version="3.10.0-dev.593" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.10.0-dev.593" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>

--- a/src/Uno.Toolkit.UI/Uno.Toolkit.UI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.UI.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.UI" Version="3.8.0-dev.280" />
+		<PackageReference Include="Uno.UI" Version="3.10.0-dev.593" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">

--- a/src/Uno.Toolkit.UITest/Uno.Toolkit.UITest.csproj
+++ b/src/Uno.Toolkit.UITest/Uno.Toolkit.UITest.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Include="NUnit" Version="3.13.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0-beta.1" />
-		<PackageReference Include="Uno.UITest.Helpers" Version="1.1.0-dev.21" />
+		<PackageReference Include="Uno.UITest.Helpers" Version="1.1.0-dev.24" />
 		<PackageReference Include="Xamarin.UITest" Version="3.0.13" />
 	</ItemGroup>
 


### PR DESCRIPTION
GitHub Issue (If applicable): #55 

## PR Type

What kind of change does this PR introduce?

- Package update

## What is the current behavior?

Latest Uno and Uno.WinUI versions needed in addition to Uno.Material & Uno.Cupertino for Uno.UI.Toolkit


## What is the new behavior?

Update Uno and Uno.WinUI packages, add Uno.Material and Uno.Cupertino and Xamarin.AndroidX.Lifecycle.LiveData for Android


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)


