### PR TITLE
ci: adjust package name

### DIFF
--- a/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
@@ -12,7 +12,7 @@
 		<DefineConstants>$(DefineConstants);IS_WINUI</DefineConstants>
 		<AssemblyName>Uno.WinUI.ToolkitLib</AssemblyName>
 		<RootNamespace>Uno.UI.ToolkitLib</RootNamespace>
-		<PackageId>Uno.UI.Toolkit</PackageId>
+		<PackageId>Uno.WinUI.Toolkit</PackageId>
 	  <Nullable>enable</Nullable>
 	  <LangVersion>8.0</LangVersion>
 	</PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Build or CI related changes

## What is the current behavior?
Currently, both Uno.Toolkit.UI.csproj & Uno.Toolkit.WinUI.csproj generate the nuget package with the same id causing the WinUI version to ultimately overwrite the UI version...

## What is the new behavior?
There will be now 2 versions of toolkit packages one for UI and one for WinUI.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
```
src\Uno.Toolkit.UI\Uno.Toolkit.UI.csproj
src\Uno.Toolkit.UI\Uno.Toolkit.WinUI.csproj
   ^ both outputs the nupkg with same package name...:
      <PackageId>Uno.UI.Toolkit</PackageId>
   ^ with WinUI running last overwriting the UI
```