### PR TITLE
fix: AutoLayout layout was wrong when using the "SpaceBetween" mode

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -302,7 +302,7 @@ namespace Uno.Toolkit.UI.Controls
 				}
 
 				// Process "space between"
-				if (isSpaceBetween)
+				if (isSpaceBetween && !atLeastOneChildFillAvailableSpaceInPrimaryAxis)
 				{
 					for (var i = 1; i < gridDefinitionsCount; i += 2)
 					{
@@ -368,7 +368,7 @@ namespace Uno.Toolkit.UI.Controls
 				}
 
 				// Process "space between"
-				if (isSpaceBetween)
+				if (isSpaceBetween && !atLeastOneChildFillAvailableSpaceInPrimaryAxis)
 				{
 					for (var i = 1; i < gridDefinitionsCount; i += 2)
 					{
@@ -380,7 +380,7 @@ namespace Uno.Toolkit.UI.Controls
 			// Set container alignments
 			if (isVertical)
 			{
-				if (atLeastOneChildFillAvailableSpaceInPrimaryAxis)
+				if (atLeastOneChildFillAvailableSpaceInPrimaryAxis || isSpaceBetween)
 				{
 					_grid.ClearValue(VerticalAlignmentProperty);
 				}
@@ -392,7 +392,7 @@ namespace Uno.Toolkit.UI.Controls
 			}
 			else
 			{
-				if (atLeastOneChildFillAvailableSpaceInPrimaryAxis)
+				if (atLeastOneChildFillAvailableSpaceInPrimaryAxis || isSpaceBetween)
 				{
 					_grid.ClearValue(HorizontalAlignmentProperty);
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): N/A

# Bugfix
The AutoLayout were not behaving correctly when the `Justify="SpaceBetween"` were used.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
