### PR TITLE
 fix(autolayout): Fixed the size of the background when the inner grid

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -302,11 +302,21 @@ namespace Uno.Toolkit.UI.Controls
 				}
 
 				// Process "space between"
-				if (isSpaceBetween && !atLeastOneChildFillAvailableSpaceInPrimaryAxis)
+				if (isSpaceBetween)
 				{
-					for (var i = 1; i < gridDefinitionsCount; i += 2)
+					if (atLeastOneChildFillAvailableSpaceInPrimaryAxis)
 					{
-						_grid.RowDefinitions[i].Height = new GridLength(1, GridUnitType.Star);
+						for (var i = 1; i < gridDefinitionsCount; i += 2)
+						{
+							_grid.RowDefinitions[i].Height = new GridLength(1, GridUnitType.Auto);
+						}
+					}
+					else
+					{
+						for (var i = 1; i < gridDefinitionsCount; i += 2)
+						{
+							_grid.RowDefinitions[i].Height = new GridLength(1, GridUnitType.Star);
+						}
 					}
 				}
 			}
@@ -368,11 +378,21 @@ namespace Uno.Toolkit.UI.Controls
 				}
 
 				// Process "space between"
-				if (isSpaceBetween && !atLeastOneChildFillAvailableSpaceInPrimaryAxis)
+				if (isSpaceBetween)
 				{
-					for (var i = 1; i < gridDefinitionsCount; i += 2)
+					if (atLeastOneChildFillAvailableSpaceInPrimaryAxis)
 					{
-						_grid.ColumnDefinitions[i].Width = new GridLength(1, GridUnitType.Star);
+						for (var i = 1; i < gridDefinitionsCount; i += 2)
+						{
+							_grid.ColumnDefinitions[i].Width = new GridLength(1, GridUnitType.Auto);
+						}
+					}
+					else
+					{
+						for (var i = 1; i < gridDefinitionsCount; i += 2)
+						{
+							_grid.ColumnDefinitions[i].Width = new GridLength(1, GridUnitType.Star);
+						}
 					}
 				}
 			}

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.xaml
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.xaml
@@ -7,12 +7,13 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="layout:AutoLayout">
-					<Grid x:Name="PART_RootGrid"
-						  Padding="{TemplateBinding Padding}"
-						  Background="{TemplateBinding Background}"
-						  BorderThickness="{TemplateBinding BorderThickness}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  CornerRadius="{TemplateBinding CornerRadius}"/>
+					<Border Background="{TemplateBinding Background}"
+							Padding="{TemplateBinding Padding}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							CornerRadius="{TemplateBinding CornerRadius}">
+						<Grid x:Name="PART_RootGrid"/>
+					</Border>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>


### PR DESCRIPTION
Fixed the size of the background when the inner grid is not filling the whole available space + fixed a problem with "SpaceBetween" where the inserted spacers are not reevaluated after each change in the children list.
