### PR TITLE
chore: Changed the default value for CounterAlignment to Stretch instead of Start

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -90,7 +90,7 @@ namespace Uno.Toolkit.UI.Controls
 			"CounterAlignment",
 			typeof(AutoLayoutAlignment),
 			typeof(AutoLayout),
-			new PropertyMetadata(default(AutoLayoutAlignment), propertyChangedCallback: UpdateAttachedCallback));
+			new PropertyMetadata(AutoLayoutAlignment.Stretch, propertyChangedCallback: UpdateAttachedCallback));
 
 		public static void SetCounterAlignment(DependencyObject element, AutoLayoutAlignment value)
 		{


### PR DESCRIPTION
# Feature

## What is the new behavior?
Default value for the `AutoLayout.CounterAlignment` attached property is now `Stretch` instead of `Start`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
