### PR TITLE
fix: Move Card to Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # Uno.Toolkit
-A set of controls for the UWP, WinUI and the Uno Platform
+A set of custom controls for the UWP, WinUI and the Uno Platform not offered out of the box by WinUI, such as Card for example.
+
+### Material Styles for custom controls
+| **Controls**              | **StyleNames**                                                                |
+|---------------------------|-------------------------------------------------------------------------------|
+| Card                      | MaterialOutlinedCardStyle <br> MaterialElevatedCardStyle <br> MaterialAvatarOutlinedCardStyle <br> MaterialAvatarElevatedCardStyle <br> MaterialSmallMediaOutlinedCardStyle <br> MaterialSmallMediaElevatedCardStyle |
+
+#### Start using the styles in your pages!
+To use styles, just find the name of the style from our documentation or sample app and use it like this:
+
+Here is how to use our custom controls like a Card
+```xaml
+xmlns:utu="using:Uno.Toolkit.UI.Controls"
+
+[...]
+
+<material:Card Header="Outlined card"
+	      SubHeader="With title and subitle"
+	      Style="{StaticResource MaterialOutlinedCardStyle}" />
+```

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardSamplePage.xaml
@@ -1,0 +1,249 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.Controls.CardSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:sample="using:Uno.Toolkit.Samples"
+	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<!--  Sample Button Styles  -->
+		<Style x:Key="IconsSampleButtonStyle"
+			   BasedOn="{StaticResource MaterialTextButtonStyle}"
+			   TargetType="Button">
+			<Setter Property="Margin"
+					Value="6" />
+			<Setter Property="Padding"
+					Value="8,12" />
+			<Setter Property="HorizontalContentAlignment"
+					Value="Center" />
+		</Style>
+
+		<!--  Text Sample  -->
+		<x:String x:Key="SupportingTextSample">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.</x:String>
+
+		<!--  Sample Supporting Content With Buttons Template  -->
+		<DataTemplate x:Key="SupportingWithButtonsTemplate">
+			<StackPanel>
+				<TextBlock Text="{Binding}"
+						   Margin="16,4,16,0"
+						   Style="{ThemeResource MaterialBody2}" />
+				<StackPanel Orientation="Horizontal">
+					<Button Content="ACTION 1"
+							Margin="6"
+							Padding="10,2"
+							Style="{StaticResource MaterialTextButtonStyle}" />
+					<Button Content="ACTION 2"
+							Margin="6"
+							Padding="10,2"
+							Style="{StaticResource MaterialTextButtonStyle}" />
+				</StackPanel>
+			</StackPanel>
+		</DataTemplate>
+
+		<!--  Sample Top Icon Template  -->
+		<DataTemplate x:Key="TopIconsTemplate">
+			<Button Content="{Binding}"
+					Style="{StaticResource IconsSampleButtonStyle}">
+				<Button.ContentTemplate>
+					<DataTemplate>
+						<!--  Material more icon  -->
+						<Path Fill="{StaticResource MaterialOnSurfaceBrush}"
+							  Data="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+					</DataTemplate>
+				</Button.ContentTemplate>
+			</Button>
+		</DataTemplate>
+
+		<!--  Sample Bottom Icon Template  -->
+		<DataTemplate x:Key="BottomIconTemplate">
+			<Button Content="{Binding}"
+					VerticalAlignment="Bottom"
+					HorizontalAlignment="Right"
+					Style="{StaticResource IconsSampleButtonStyle}">
+				<Button.ContentTemplate>
+					<DataTemplate>
+						<!--  Material share icon  -->
+						<Path Fill="{StaticResource MaterialOnSurfaceBrush}"
+							  Data="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
+					</DataTemplate>
+				</Button.ContentTemplate>
+			</Button>
+		</DataTemplate>
+	</Page.Resources>
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<sample:SamplePageLayout>
+			<sample:SamplePageLayout.MaterialTemplate>
+				<DataTemplate>
+					<StackPanel Padding="0,20"
+								Spacing="20">
+
+						<!--  Card Outlined  -->
+						<utu:Card HeaderContent="Outlined card"
+								  SubHeaderContent="With title and subtitle only"
+								  Style="{StaticResource MaterialOutlinedCardStyle}" />
+
+						<!--  Outlined disabled Card  -->
+						<utu:Card HeaderContent="Outlined disabled Card"
+								  SubHeaderContent="With title and subtitle only"
+								  Style="{StaticResource MaterialOutlinedCardStyle}"
+								  IsEnabled="False" />
+
+						<!--  Card Elevated  -->
+						<utu:Card HeaderContent="Elevated card"
+								  SubHeaderContent="With title and subtitle only"
+								  Style="{StaticResource MaterialElevatedCardStyle}" />
+
+						<!--  Elevated disabled Card  -->
+						<utu:Card HeaderContent="Elevated disabled Card"
+								  SubHeaderContent="With title and subtitle only"
+								  Style="{StaticResource MaterialElevatedCardStyle}"
+								  IsEnabled="False" />
+
+						<!--  Card Outlined With supporting text  -->
+						<utu:Card HeaderContent="Outlined card"
+								  SubHeaderContent="With supporting text"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  Style="{StaticResource MaterialOutlinedCardStyle}" />
+
+						<!--  Card Elevated With supporting text  -->
+						<utu:Card HeaderContent="Elevated card"
+								  SubHeaderContent="With supporting text"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  Style="{StaticResource MaterialElevatedCardStyle}" />
+
+						<!--  Card Outlined with media  -->
+						<utu:Card HeaderContent="Outlined card"
+								  SubHeaderContent="With media"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  Style="{StaticResource MaterialOutlinedCardStyle}" />
+
+						<!--  Card Elevated with media  -->
+						<utu:Card HeaderContent="Elevated card"
+								  SubHeaderContent="With media"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  Style="{StaticResource MaterialElevatedCardStyle}" />
+
+						<!--  Card Outlined with media and supporting text  -->
+						<utu:Card HeaderContent="Outlined card"
+								  SubHeaderContent="With media and supporting text"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  Style="{StaticResource MaterialOutlinedCardStyle}" />
+
+						<!--  Card Elevated with media and supporting text  -->
+						<utu:Card HeaderContent="Elevated card"
+								  SubHeaderContent="With media and supporting text"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  Style="{StaticResource MaterialElevatedCardStyle}" />
+
+						<!--  Card Outlined with media, supporting text and action buttons  -->
+						<utu:Card HeaderContent="Outlined card"
+								  SubHeaderContent="With media, supporting text and action buttons"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  SupportingContentTemplate="{StaticResource SupportingWithButtonsTemplate}"
+								  Style="{StaticResource MaterialOutlinedCardStyle}" />
+
+						<!--  Card Elevated with media, supporting text and action buttons  -->
+						<utu:Card HeaderContent="Elevated card"
+								  SubHeaderContent="With media, supporting text and action buttons"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  SupportingContentTemplate="{StaticResource SupportingWithButtonsTemplate}"
+								  Style="{StaticResource MaterialElevatedCardStyle}" />
+
+						<!--  Card Outlined with media, supporting text, action buttons and supplemental action buttons  -->
+						<utu:Card HeaderContent="Outlined card"
+								  SubHeaderContent="With media, supporting text, action buttons and supplemental action buttons"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  SupportingContentTemplate="{StaticResource SupportingWithButtonsTemplate}"
+								  IconsContentTemplate="{StaticResource BottomIconTemplate}"
+								  Style="{StaticResource MaterialOutlinedCardStyle}" />
+
+						<!--  Card Elevated with media, supporting text, action buttons and supplemental action buttons  -->
+						<utu:Card HeaderContent="Elevated card"
+								  SubHeaderContent="With media, supporting text, action buttons and supplemental action buttons"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  SupportingContentTemplate="{StaticResource SupportingWithButtonsTemplate}"
+								  IconsContentTemplate="{StaticResource BottomIconTemplate}"
+								  Style="{StaticResource MaterialElevatedCardStyle}" />
+
+						<!--  Card Outlined with small media and supporting text  -->
+						<utu:Card HeaderContent="Outlined card"
+								  SubHeaderContent="With small media and supporting text"
+								  MediaContent="ms-appx:///Assets/Media/SmallMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  Style="{StaticResource MaterialSmallMediaOutlinedCardStyle}" />
+
+						<!--  Card Outlined disabled with small media and supporting text  -->
+						<utu:Card HeaderContent="Disabled outlined card"
+								  SubHeaderContent="With small media and supporting text"
+								  MediaContent="ms-appx:///Assets/Media/SmallMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  Style="{StaticResource MaterialSmallMediaOutlinedCardStyle}"
+								  IsEnabled="False" />
+
+						<!--  Card Elevated with small media and supporting text  -->
+						<utu:Card HeaderContent="Elevated card"
+								  SubHeaderContent="With small media and supporting text"
+								  MediaContent="ms-appx:///Assets/Media/SmallMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  Style="{StaticResource MaterialSmallMediaElevatedCardStyle}" />
+
+						<!--  Card Elevated disabled with small media and supporting text  -->
+						<utu:Card HeaderContent="Disabled elevated card"
+								  SubHeaderContent="With small media and supporting text"
+								  MediaContent="ms-appx:///Assets/Media/SmallMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  Style="{StaticResource MaterialSmallMediaElevatedCardStyle}"
+								  IsEnabled="False" />
+
+						<!--  Card Outlined with Avatar  -->
+						<utu:Card HeaderContent="Outlined card"
+								  SubHeaderContent="With avatar"
+								  AvatarContent="ms-appx:///Assets/Avatar.png"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  IconsContentTemplate="{StaticResource TopIconsTemplate}"
+								  Style="{StaticResource MaterialAvatarOutlinedCardStyle}" />
+
+						<!--  Card Outlined disabled with Avatar  -->
+						<utu:Card HeaderContent="Disabled outlined card"
+								  SubHeaderContent="With avatar"
+								  AvatarContent="ms-appx:///Assets/Avatar.png"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  IconsContentTemplate="{StaticResource TopIconsTemplate}"
+								  Style="{StaticResource MaterialAvatarOutlinedCardStyle}"
+								  IsEnabled="False" />
+
+						<!--  Card Elevated with Avatar  -->
+						<utu:Card HeaderContent="Elevated card"
+								  SubHeaderContent="With avatar"
+								  AvatarContent="ms-appx:///Assets/Avatar.png"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  IconsContentTemplate="{StaticResource TopIconsTemplate}"
+								  Style="{StaticResource MaterialAvatarElevatedCardStyle}" />
+
+						<!--  Card Elevated disabled with Avatar  -->
+						<utu:Card HeaderContent="Disabled elevated card"
+								  SubHeaderContent="With avatar"
+								  AvatarContent="ms-appx:///Assets/Avatar.png"
+								  MediaContent="ms-appx:///Assets/Media/LargeMedia.png"
+								  SupportingContent="{StaticResource SupportingTextSample}"
+								  IconsContentTemplate="{StaticResource TopIconsTemplate}"
+								  Style="{StaticResource MaterialAvatarElevatedCardStyle}"
+								  IsEnabled="False" />
+					</StackPanel>
+				</DataTemplate>
+			</sample:SamplePageLayout.MaterialTemplate>
+		</sample:SamplePageLayout>
+	</Grid>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardSamplePage.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.Toolkit.Samples.Entities;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+#if IS_WINUI
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+#else
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.Controls
+{
+	[SamplePage(SampleCategory.Controls, "Card", SourceSdk.UnoMaterial, Description = "This control is used to display content and actions about a single item.", DocumentationLink = "https://material.io/components/cards")]
+	public sealed partial class CardSamplePage : Page
+	{
+		public CardSamplePage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
@@ -19,6 +19,9 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)App.xaml.Navigation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\CardSamplePage.xaml.cs">
+      <DependentUpon>CardSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\ChipSamplePage.xaml.cs">
       <DependentUpon>ChipSamplePage.xaml</DependentUpon>
     </Compile>
@@ -96,6 +99,10 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)Content\Controls\CardSamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Content\Controls\ChipSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#if IS_WINUI
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.UI.Controls
+{
+	public partial class Card : Control
+	{
+#if __ANDROID__
+		private static readonly Windows.UI.Color _defaultShadowColor = Colors.Black;
+#else
+		private static readonly Windows.UI.Color _defaultShadowColor = Windows.UI.Color.FromArgb(64, 0, 0, 0);
+#endif
+
+#region HeaderContent and HeaderContentTemplate
+		public object HeaderContent
+		{
+			get { return (object)GetValue(HeaderContentProperty); }
+			set { SetValue(HeaderContentProperty, value); }
+		}
+
+		public static readonly DependencyProperty HeaderContentProperty =
+			DependencyProperty.Register("HeaderContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+
+		public DataTemplate HeaderContentTemplate
+		{
+			get { return (DataTemplate)GetValue(HeaderContentTemplateProperty); }
+			set { SetValue(HeaderContentTemplateProperty, value); }
+		}
+
+		public static readonly DependencyProperty HeaderContentTemplateProperty =
+			DependencyProperty.Register("HeaderContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
+#endregion
+
+#region SubHeaderContent and SubHeaderContentTemplate
+		public object SubHeaderContent
+		{
+			get { return (object)GetValue(SubHeaderContentProperty); }
+			set { SetValue(SubHeaderContentProperty, value); }
+		}
+
+		public static readonly DependencyProperty SubHeaderContentProperty =
+			DependencyProperty.Register("SubHeaderContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+
+		public DataTemplate SubHeaderContentTemplate
+		{
+			get { return (DataTemplate)GetValue(SubHeaderContentTemplateProperty); }
+			set { SetValue(SubHeaderContentTemplateProperty, value); }
+		}
+
+		public static readonly DependencyProperty SubHeaderContentTemplateProperty =
+			DependencyProperty.Register("SubHeaderContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
+#endregion
+
+#region AvatarContent and AvatarContentTemplate
+		public object AvatarContent
+		{
+			get { return (object)GetValue(AvatarContentProperty); }
+			set { SetValue(AvatarContentProperty, value); }
+		}
+
+		public static readonly DependencyProperty AvatarContentProperty =
+			DependencyProperty.Register("AvatarContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+
+		public DataTemplate AvatarContentTemplate
+		{
+			get { return (DataTemplate)GetValue(AvatarContentTemplateProperty); }
+			set { SetValue(AvatarContentTemplateProperty, value); }
+		}
+
+		public static readonly DependencyProperty AvatarContentTemplateProperty =
+			DependencyProperty.Register("AvatarContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
+#endregion
+
+#region MediaContent and MediaContentTemplate
+		public object MediaContent
+		{
+			get { return (object)GetValue(MediaContentProperty); }
+			set { SetValue(MediaContentProperty, value); }
+		}
+
+		public static readonly DependencyProperty MediaContentProperty =
+			DependencyProperty.Register("MediaContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+
+		public DataTemplate MediaContentTemplate
+		{
+			get { return (DataTemplate)GetValue(MediaContentTemplateProperty); }
+			set { SetValue(MediaContentTemplateProperty, value); }
+		}
+
+		public static readonly DependencyProperty MediaContentTemplateProperty =
+			DependencyProperty.Register("MediaContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
+#endregion
+
+#region SupportingContent and SupportingContentTemplate
+		public object SupportingContent
+		{
+			get { return (object)GetValue(SupportingContentProperty); }
+			set { SetValue(SupportingContentProperty, value); }
+		}
+
+		public static readonly DependencyProperty SupportingContentProperty =
+			DependencyProperty.Register("SupportingContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+
+		public DataTemplate SupportingContentTemplate
+		{
+			get { return (DataTemplate)GetValue(SupportingContentTemplateProperty); }
+			set { SetValue(SupportingContentTemplateProperty, value); }
+		}
+
+		public static readonly DependencyProperty SupportingContentTemplateProperty =
+			DependencyProperty.Register("SupportingContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
+#endregion
+
+#region IconsContent and IconsContentTemplate
+		public object IconsContent
+		{
+			get { return (object)GetValue(IconsContentProperty); }
+			set { SetValue(IconsContentProperty, value); }
+		}
+
+		public static readonly DependencyProperty IconsContentProperty =
+			DependencyProperty.Register("IconsContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+
+		public DataTemplate IconsContentTemplate
+		{
+			get { return (DataTemplate)GetValue(IconsContentTemplateProperty); }
+			set { SetValue(IconsContentTemplateProperty, value); }
+		}
+
+		public static readonly DependencyProperty IconsContentTemplateProperty =
+			DependencyProperty.Register("IconsContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
+#endregion
+
+#region Elevation
+		public double Elevation
+		{
+			get { return (double)GetValue(ElevationProperty); }
+			set { SetValue(ElevationProperty, value); }
+		}
+
+		public static readonly DependencyProperty ElevationProperty =
+			DependencyProperty.Register("Elevation", typeof(double), typeof(Card), new PropertyMetadata(0));
+#endregion
+
+#region ShadowColor
+		public Windows.UI.Color ShadowColor
+		{
+			get { return (Windows.UI.Color)GetValue(ShadowColorProperty); }
+			set { SetValue(ShadowColorProperty, value); }
+		}
+
+		public static readonly DependencyProperty ShadowColorProperty =
+			DependencyProperty.Register("ShadowColor", typeof(Windows.UI.Color), typeof(Card), new PropertyMetadata(_defaultShadowColor));
+#endregion
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.cs
@@ -1,0 +1,80 @@
+﻿using Windows.ApplicationModel.Store;
+using Windows.Foundation;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+#endif
+
+namespace Uno.Toolkit.UI.Controls
+{
+	public partial class Card : Control
+	{
+		public Card()
+		{
+			DefaultStyleKey = typeof(Card);
+		}
+
+		protected override void OnApplyTemplate()
+		{
+			if (IsEnabled)
+			{
+				VisualStateManager.GoToState(this, "Normal", true);
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, "Disabled", true);
+			}
+
+			base.OnApplyTemplate();
+		}
+
+		protected override void OnPointerEntered(PointerRoutedEventArgs e)
+		{
+			VisualStateManager.GoToState(this, "PointerOver", true);
+
+			base.OnPointerEntered(e);
+		}
+
+		protected override void OnPointerExited(PointerRoutedEventArgs e)
+		{
+			VisualStateManager.GoToState(this, "Normal", true);
+
+			base.OnPointerExited(e);
+		}
+
+		protected override void OnPointerPressed(PointerRoutedEventArgs e)
+		{
+			VisualStateManager.GoToState(this, "Pressed", true);
+
+			base.OnPointerPressed(e);
+		}
+
+		protected override void OnPointerReleased(PointerRoutedEventArgs e)
+		{
+			VisualStateManager.GoToState(this, "Normal", true);
+
+			base.OnPointerReleased(e);
+		}
+
+		protected override void OnGotFocus(RoutedEventArgs e)
+		{
+			VisualStateManager.GoToState(this, "Focused", true);
+			VisualStateManager.GoToState(this, "PointerFocused", true);
+
+			base.OnGotFocus(e);
+		}
+
+		protected override void OnLostFocus(RoutedEventArgs e)
+		{
+			VisualStateManager.GoToState(this, "Unfocused", true);
+
+			base.OnLostFocus(e);
+		}
+	}
+}

--- a/src/library/Uno.Toolkit.Material/MaterialToolkitResources.cs
+++ b/src/library/Uno.Toolkit.Material/MaterialToolkitResources.cs
@@ -35,9 +35,11 @@ namespace Uno.Toolkit.UI.Material
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{PackageName}/Styles/Controls/TopTabBar.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{PackageName}/Styles/Controls/NavigationBar.xaml") });
 #endif
+
+			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{PackageName}/Styles/Controls/Card.xaml") });
+			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{PackageName}/Styles/Controls/CardContentControl.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{PackageName}/Styles/Controls/Chip.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{PackageName}/Styles/Controls/ChipGroup.xaml") });
-			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{PackageName}/Styles/Controls/CardContentControl.xaml") });
 			this.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{PackageName}/Styles/Controls/Divider.xaml") });
 		}
 	}

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/Card.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/Card.xaml
@@ -1,0 +1,1349 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:controls="using:Uno.Material.Controls"
+					xmlns:toolkit="using:Uno.UI.Toolkit">
+
+	<!--  Card Variables  -->
+	<CornerRadius x:Key="MaterialCardCornerRadius">4</CornerRadius>
+	<Thickness x:Key="MaterialCardBorderThickness">1</Thickness>
+	<x:Double x:Key="MaterialCardElevation">6</x:Double>
+	<Thickness x:Key="MaterialCardElevationMargin">6</Thickness>
+
+	<DataTemplate x:Key="DefaultHeaderContentTemplate">
+		<TextBlock Text="{Binding}"
+				   MaxLines="1"
+				   Margin="16,14,16,0"
+				   Style="{ThemeResource MaterialHeadline6}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultSubHeaderContentTemplate">
+		<TextBlock Text="{Binding}"
+				   MaxLines="2"
+				   Margin="16,0,16,14"
+				   Style="{ThemeResource MaterialBody2}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultSupportingContentTemplate">
+		<TextBlock Text="{Binding}"
+				   Margin="16,0,16,14"
+				   Style="{ThemeResource MaterialBody2}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultAvatarSupportingContentTemplate">
+		<TextBlock Text="{Binding}"
+				   Margin="16,12,16,14"
+				   Style="{ThemeResource MaterialBody2}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultSmallMediaSupportingContentTemplate">
+		<Border BorderThickness="0,1,0,0"
+				BorderBrush="{StaticResource MaterialOnSurfaceFocusedBrush}">
+			<TextBlock Text="{Binding}"
+					   Margin="16,12,16,14"
+					   Style="{ThemeResource MaterialBody2}" />
+		</Border>
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultMediaContentTemplate">
+		<Image Source="{Binding}"
+			   Stretch="Uniform"
+			   MaxHeight="194" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultSmallMediaContentTemplate">
+		<Image Source="{Binding}"
+			   Stretch="Uniform"
+			   MaxHeight="94"
+			   VerticalAlignment="Top" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="DefaultAvatarContentTemplate">
+		<Image Source="{Binding}"
+			   Stretch="Uniform"
+			   MaxHeight="40" />
+	</DataTemplate>
+
+
+
+	<Style x:Key="MaterialBaseCardStyle"
+		   TargetType="utu:Card">
+		<Setter Property="HeaderContentTemplate"
+				Value="{StaticResource DefaultHeaderContentTemplate}" />
+		<Setter Property="SubHeaderContentTemplate"
+				Value="{StaticResource DefaultSubHeaderContentTemplate}" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultSupportingContentTemplate}" />
+		<Setter Property="MediaContentTemplate"
+				Value="{StaticResource DefaultMediaContentTemplate}" />
+	</Style>
+
+	<Style x:Key="MaterialOutlinedCardStyle"
+		   TargetType="utu:Card"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}">
+
+		<Setter Property="MinHeight"
+				Value="72" />
+		<Setter Property="MaxWidth"
+				Value="344" />
+		<Setter Property="Margin"
+				Value="{StaticResource MaterialCardElevationMargin}" />
+		<Setter Property="Padding"
+				Value="16,14" />
+		<Setter Property="Background"
+				Value="{StaticResource MaterialSurfaceBrush}" />
+		<Setter Property="BorderBrush"
+				Value="{ThemeResource MaterialOnSurfaceMediumBrush}" />
+		<Setter Property="BorderThickness"
+				Value="{StaticResource MaterialCardBorderThickness}" />
+		<Setter Property="CornerRadius"
+				Value="{StaticResource MaterialCardCornerRadius}" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Stretch" />
+
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:Card">
+					<Grid x:Name="GridRoot"
+						  MinWidth="{TemplateBinding MinWidth}"
+						  MinHeight="{TemplateBinding MinHeight}"
+						  MaxWidth="{TemplateBinding MaxWidth}"
+						  MaxHeight="{TemplateBinding MaxHeight}"
+						  Margin="{TemplateBinding Margin}"
+						  Background="{TemplateBinding Background}"
+						  BorderBrush="{TemplateBinding BorderBrush}"
+						  CornerRadius="{TemplateBinding CornerRadius}"
+						  BorderThickness="{TemplateBinding BorderThickness}"
+						  HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<DoubleAnimation Storyboard.TargetName="FocusedOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+										<Setter Target="GridRoot.Opacity"
+												Value="0.38" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerFocused" />
+								<VisualState x:Name="Unfocused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+						</Grid.RowDefinitions>
+
+						<!--  Border for PointerOver State  -->
+						<Border Grid.RowSpan="4"
+								x:Name="HoverOverlay"
+								Background="{StaticResource MaterialOnSurfaceHoverBrush}"
+								Opacity="0" />
+
+						<!--  Border for Focused State  -->
+						<Border Grid.RowSpan="4"
+								x:Name="FocusedOverlay"
+								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
+								Opacity="0" />
+
+						<!--  Media content part  -->
+						<ContentPresenter x:Name="MediaContentPresenter"
+										  Content="{TemplateBinding MediaContent}"
+										  ContentTemplate="{TemplateBinding MediaContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  IsHitTestVisible="False"
+										  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<!--  Header part  -->
+						<ContentPresenter Grid.Row="1"
+										  x:Name="HeaderContentPresenter"
+										  Content="{TemplateBinding HeaderContent}"
+										  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<!--  SubHeader part  -->
+						<ContentPresenter Grid.Row="2"
+										  x:Name="SubHeaderContentPresenter"
+										  Content="{TemplateBinding SubHeaderContent}"
+										  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<!--  Ripple effect  -->
+						<controls:Ripple Grid.RowSpan="4"
+										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+										 BorderBrush="{TemplateBinding BorderBrush}"
+										 BorderThickness="{TemplateBinding BorderThickness}"
+										 CornerRadius="{StaticResource MaterialCardCornerRadius}"
+										 Padding="{TemplateBinding Padding}"
+										 AutomationProperties.AccessibilityView="Raw" />
+
+						<!--  Supporting Content part  -->
+						<ContentPresenter Grid.Row="3"
+										  x:Name="SupportingContentPresenter"
+										  Content="{TemplateBinding SupportingContent}"
+										  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<!--  Icons section part  -->
+						<ContentPresenter Grid.Row="3"
+										  x:Name="IconsContentPresenter"
+										  Content="{TemplateBinding IconsContent}"
+										  ContentTemplate="{TemplateBinding IconsContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}}" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialElevatedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
+		   TargetType="utu:Card">
+
+		<Setter Property="MinHeight"
+				Value="72" />
+		<Setter Property="MaxWidth"
+				Value="344" />
+		<Setter Property="Padding"
+				Value="16,14" />
+		<Setter Property="Background"
+				Value="{StaticResource MaterialSurfaceBrush}" />
+		<Setter Property="CornerRadius"
+				Value="{StaticResource MaterialCardCornerRadius}" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="Margin"
+				Value="{StaticResource MaterialCardElevationMargin}" />
+		<Setter Property="Elevation"
+				Value="{StaticResource MaterialCardElevation}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:Card">
+					<!--  Elevated View  -->
+					<toolkit:ElevatedView x:Name="ElevatedRoot"
+										  MinWidth="{TemplateBinding MinWidth}"
+										  MinHeight="{TemplateBinding MinHeight}"
+										  MaxWidth="{TemplateBinding MaxWidth}"
+										  MaxHeight="{TemplateBinding MaxHeight}"
+										  Margin="{TemplateBinding Margin}"
+										  Background="{TemplateBinding Background}"
+										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalAlignment}"
+										  CornerRadius="{TemplateBinding CornerRadius}"
+										  Elevation="{TemplateBinding Elevation}"
+										  ShadowColor="{TemplateBinding ShadowColor}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<DoubleAnimation Storyboard.TargetName="FocusedOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+										<Setter Target="GridRoot.Opacity"
+												Value="0.38" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerFocused" />
+								<VisualState x:Name="Unfocused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid x:Name="GridRoot"
+							  CornerRadius="{TemplateBinding CornerRadius}">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+
+							<!--  Border for PointerOver State  -->
+							<Border Grid.RowSpan="4"
+									x:Name="HoverOverlay"
+									Background="{StaticResource MaterialOnSurfaceHoverBrush}"
+									Opacity="0" />
+
+							<!--  Border for Focused State  -->
+							<Border Grid.RowSpan="4"
+									x:Name="FocusedOverlay"
+									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
+									Opacity="0" />
+
+							<!--  Media content part  -->
+							<ContentPresenter x:Name="MediaContentPresenter"
+											  Content="{TemplateBinding MediaContent}"
+											  ContentTemplate="{TemplateBinding MediaContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  IsHitTestVisible="False"
+											  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<!--  Header part  -->
+							<ContentPresenter Grid.Row="1"
+											  x:Name="HeaderContentPresenter"
+											  Content="{TemplateBinding HeaderContent}"
+											  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<!--  SubHeader part  -->
+							<ContentPresenter Grid.Row="2"
+											  x:Name="SubHeaderContentPresenter"
+											  Content="{TemplateBinding SubHeaderContent}"
+											  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<!--  Ripple effect  -->
+							<controls:Ripple Grid.RowSpan="4"
+											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+											 CornerRadius="{StaticResource MaterialCardCornerRadius}"
+											 Padding="{TemplateBinding Padding}"
+											 AutomationProperties.AccessibilityView="Raw" />
+
+							<!--  Supporting Content part  -->
+							<ContentPresenter Grid.Row="3"
+											  x:Name="SupportingContentPresenter"
+											  Content="{TemplateBinding SupportingContent}"
+											  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<!--  Icons section part  -->
+							<ContentPresenter Grid.Row="3"
+											  x:Name="IconsContentPresenter"
+											  Content="{TemplateBinding IconsContent}"
+											  ContentTemplate="{TemplateBinding IconsContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}}" />
+						</Grid>
+					</toolkit:ElevatedView>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialAvatarOutlinedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
+		   TargetType="utu:Card">
+		<Setter Property="MinHeight"
+				Value="72" />
+		<Setter Property="MaxWidth"
+				Value="344" />
+		<Setter Property="Margin"
+				Value="{StaticResource MaterialCardElevationMargin}" />
+		<Setter Property="Padding"
+				Value="16,14" />
+		<Setter Property="Background"
+				Value="{StaticResource MaterialSurfaceBrush}" />
+		<Setter Property="BorderBrush"
+				Value="{ThemeResource MaterialOnSurfaceMediumBrush}" />
+		<Setter Property="BorderThickness"
+				Value="{StaticResource MaterialCardBorderThickness}" />
+		<Setter Property="CornerRadius"
+				Value="{StaticResource MaterialCardCornerRadius}" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultAvatarSupportingContentTemplate}" />
+		<Setter Property="AvatarContentTemplate"
+				Value="{StaticResource DefaultAvatarContentTemplate}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:Card">
+					<Grid x:Name="GridRoot"
+						  MinWidth="{TemplateBinding MinWidth}"
+						  MinHeight="{TemplateBinding MinHeight}"
+						  MaxWidth="{TemplateBinding MaxWidth}"
+						  MaxHeight="{TemplateBinding MaxHeight}"
+						  Margin="{TemplateBinding Margin}"
+						  Background="{TemplateBinding Background}"
+						  BorderBrush="{TemplateBinding BorderBrush}"
+						  CornerRadius="{TemplateBinding CornerRadius}"
+						  BorderThickness="{TemplateBinding BorderThickness}"
+						  HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<DoubleAnimation Storyboard.TargetName="FocusedOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+										<Setter Target="GridRoot.Opacity"
+												Value="0.38" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerFocused" />
+								<VisualState x:Name="Unfocused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+						</Grid.RowDefinitions>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="Auto" />
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+
+						<!--  Border for PointedOver state  -->
+						<Border Grid.RowSpan="3"
+								Grid.ColumnSpan="3"
+								x:Name="HoverOverlay"
+								Background="{StaticResource MaterialOnSurfaceHoverBrush}"
+								Opacity="0" />
+
+						<!--  Border for Focus state  -->
+						<Border Grid.RowSpan="3"
+								Grid.ColumnSpan="3"
+								x:Name="FocusedOverlay"
+								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
+								Opacity="0" />
+
+						<!--  Avatart part  -->
+						<ContentPresenter x:Name="AvatarContentPresenter"
+										  Content="{TemplateBinding AvatarContent}"
+										  ContentTemplate="{TemplateBinding AvatarContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  IsHitTestVisible="False"
+										  Margin="16,0,0,0"
+										  Visibility="{Binding AvatarContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<StackPanel Grid.Column="1"
+									IsHitTestVisible="False">
+							<!--  Header part  -->
+							<ContentPresenter x:Name="HeaderContentPresenter"
+											  Content="{TemplateBinding HeaderContent}"
+											  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<!--  SubHeader part  -->
+							<ContentPresenter x:Name="SubHeaderContentPresenter"
+											  Content="{TemplateBinding SubHeaderContent}"
+											  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+						</StackPanel>
+
+						<!--  Ripple effect  -->
+						<controls:Ripple Grid.RowSpan="3"
+										 Grid.ColumnSpan="3"
+										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+										 BorderBrush="{TemplateBinding BorderBrush}"
+										 BorderThickness="{TemplateBinding BorderThickness}"
+										 CornerRadius="{StaticResource MaterialCardCornerRadius}"
+										 Padding="{TemplateBinding Padding}"
+										 AutomationProperties.AccessibilityView="Raw" />
+
+						<!--  Icons section part  -->
+						<ContentPresenter Grid.Column="2"
+										  x:Name="IconsContentPresenter"
+										  Content="{TemplateBinding IconsContent}"
+										  ContentTemplate="{TemplateBinding IconsContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<!--  Media content part  -->
+						<ContentPresenter Grid.Row="1"
+										  Grid.ColumnSpan="3"
+										  x:Name="MediaContentPresenter"
+										  Content="{TemplateBinding MediaContent}"
+										  ContentTemplate="{TemplateBinding MediaContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  IsHitTestVisible="False"
+										  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<!--  Supporting Content part  -->
+						<ContentPresenter Grid.Row="2"
+										  Grid.ColumnSpan="3"
+										  x:Name="SupportingContentPresenter"
+										  Content="{TemplateBinding SupportingContent}"
+										  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialAvatarElevatedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
+		   TargetType="utu:Card">
+		<Setter Property="MinHeight"
+				Value="72" />
+		<Setter Property="MaxWidth"
+				Value="344" />
+		<Setter Property="Padding"
+				Value="16,14" />
+		<Setter Property="Background"
+				Value="{StaticResource MaterialSurfaceBrush}" />
+		<Setter Property="CornerRadius"
+				Value="{StaticResource MaterialCardCornerRadius}" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="Margin"
+				Value="{StaticResource MaterialCardElevationMargin}" />
+		<Setter Property="Elevation"
+				Value="{StaticResource MaterialCardElevation}" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultAvatarSupportingContentTemplate}" />
+		<Setter Property="AvatarContentTemplate"
+				Value="{StaticResource DefaultAvatarContentTemplate}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:Card">
+					<!--  Elevated View  -->
+					<toolkit:ElevatedView x:Name="ElevatedRoot"
+										  MinWidth="{TemplateBinding MinWidth}"
+										  MinHeight="{TemplateBinding MinHeight}"
+										  MaxWidth="{TemplateBinding MaxWidth}"
+										  MaxHeight="{TemplateBinding MaxHeight}"
+										  Margin="{TemplateBinding Margin}"
+										  Background="{TemplateBinding Background}"
+										  BorderBrush="{TemplateBinding BorderBrush}"
+										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalAlignment}"
+										  CornerRadius="{TemplateBinding CornerRadius}"
+										  Elevation="{TemplateBinding Elevation}"
+										  ShadowColor="{TemplateBinding ShadowColor}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<DoubleAnimation Storyboard.TargetName="FocusedOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+										<Setter Target="GridRoot.Opacity"
+												Value="0.38" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerFocused" />
+								<VisualState x:Name="Unfocused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid x:Name="GridRoot"
+							  CornerRadius="{TemplateBinding CornerRadius}">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+
+							<!--  Border for PointedOver state  -->
+							<Border Grid.RowSpan="3"
+									Grid.ColumnSpan="3"
+									x:Name="HoverOverlay"
+									Background="{StaticResource MaterialOnSurfaceHoverBrush}"
+									Opacity="0" />
+
+							<!--  Border for Focus state  -->
+							<Border Grid.RowSpan="3"
+									Grid.ColumnSpan="3"
+									x:Name="FocusedOverlay"
+									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
+									Opacity="0" />
+
+							<!--  Avatart part  -->
+							<ContentPresenter x:Name="AvatarContentPresenter"
+											  Content="{TemplateBinding AvatarContent}"
+											  ContentTemplate="{TemplateBinding AvatarContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  IsHitTestVisible="False"
+											  Margin="16,0,0,0"
+											  Visibility="{Binding AvatarContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<StackPanel Grid.Column="1"
+										IsHitTestVisible="False">
+								<!--  Header part  -->
+								<ContentPresenter x:Name="HeaderContentPresenter"
+												  Content="{TemplateBinding HeaderContent}"
+												  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
+												  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+												  AutomationProperties.AccessibilityView="Raw"
+												  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+								<!--  SubHeader part  -->
+								<ContentPresenter x:Name="SubHeaderContentPresenter"
+												  Content="{TemplateBinding SubHeaderContent}"
+												  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
+												  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+												  AutomationProperties.AccessibilityView="Raw"
+												  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+							</StackPanel>
+							<!--  Ripple effect  -->
+							<controls:Ripple Grid.RowSpan="3"
+											 Grid.ColumnSpan="3"
+											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+											 CornerRadius="{StaticResource MaterialCardCornerRadius}"
+											 Padding="{TemplateBinding Padding}"
+											 AutomationProperties.AccessibilityView="Raw" />
+
+							<!--  Icons section part  -->
+							<ContentPresenter Grid.Column="2"
+											  x:Name="IconsContentPresenter"
+											  Content="{TemplateBinding IconsContent}"
+											  ContentTemplate="{TemplateBinding IconsContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}}" />
+
+							<!--  Media content part  -->
+							<ContentPresenter Grid.Row="1"
+											  Grid.ColumnSpan="3"
+											  x:Name="MediaContentPresenter"
+											  Content="{TemplateBinding MediaContent}"
+											  ContentTemplate="{TemplateBinding MediaContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  IsHitTestVisible="False"
+											  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<!--  Supporting Content part  -->
+							<ContentPresenter Grid.Row="2"
+											  Grid.ColumnSpan="3"
+											  x:Name="SupportingContentPresenter"
+											  Content="{TemplateBinding SupportingContent}"
+											  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+						</Grid>
+					</toolkit:ElevatedView>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialSmallMediaOutlinedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
+		   TargetType="utu:Card">
+
+		<Setter Property="MinHeight"
+				Value="72" />
+		<Setter Property="MaxWidth"
+				Value="344" />
+		<Setter Property="Margin"
+				Value="{StaticResource MaterialCardElevationMargin}" />
+		<Setter Property="Padding"
+				Value="0" />
+		<Setter Property="Background"
+				Value="{StaticResource MaterialSurfaceBrush}" />
+		<Setter Property="BorderBrush"
+				Value="{ThemeResource MaterialOnSurfaceMediumBrush}" />
+		<Setter Property="BorderThickness"
+				Value="{StaticResource MaterialCardBorderThickness}" />
+		<Setter Property="CornerRadius"
+				Value="{StaticResource MaterialCardCornerRadius}" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="MediaContentTemplate"
+				Value="{StaticResource DefaultSmallMediaContentTemplate}" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultSmallMediaSupportingContentTemplate}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:Card">
+					<Grid x:Name="GridRoot"
+						  MinWidth="{TemplateBinding MinWidth}"
+						  MinHeight="{TemplateBinding MinHeight}"
+						  MaxWidth="{TemplateBinding MaxWidth}"
+						  MaxHeight="{TemplateBinding MaxHeight}"
+						  Margin="{TemplateBinding Margin}"
+						  Background="{TemplateBinding Background}"
+						  BorderBrush="{TemplateBinding BorderBrush}"
+						  CornerRadius="{TemplateBinding CornerRadius}"
+						  BorderThickness="{TemplateBinding BorderThickness}"
+						  HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<DoubleAnimation Storyboard.TargetName="FocusedOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+										<Setter Target="GridRoot.Opacity"
+												Value="0.38" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerFocused" />
+								<VisualState x:Name="Unfocused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="Auto" />
+						</Grid.RowDefinitions>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="Auto" />
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+
+						<!--  Border for PointerOver State  -->
+						<Border Grid.RowSpan="3"
+								Grid.ColumnSpan="3"
+								x:Name="HoverOverlay"
+								Background="{StaticResource MaterialOnSurfaceHoverBrush}"
+								Opacity="0" />
+
+						<!--  Border for Focused State  -->
+						<Border Grid.RowSpan="3"
+								Grid.ColumnSpan="3"
+								x:Name="FocusedOverlay"
+								Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
+								Opacity="0" />
+
+						<!--  Media content part  -->
+						<ContentPresenter x:Name="MediaContentPresenter"
+										  Content="{TemplateBinding MediaContent}"
+										  ContentTemplate="{TemplateBinding MediaContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  IsHitTestVisible="False"
+										  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<StackPanel Grid.Column="1">
+							<!--  Header part  -->
+							<ContentPresenter x:Name="HeaderContentPresenter"
+											  Content="{TemplateBinding HeaderContent}"
+											  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<!--  SubHeader part  -->
+							<ContentPresenter x:Name="SubHeaderContentPresenter"
+											  Content="{TemplateBinding SubHeaderContent}"
+											  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+						</StackPanel>
+
+						<!--  Ripple effect  -->
+						<controls:Ripple Grid.RowSpan="3"
+										 Grid.ColumnSpan="3"
+										 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+										 BorderBrush="{TemplateBinding BorderBrush}"
+										 BorderThickness="{TemplateBinding BorderThickness}"
+										 CornerRadius="{StaticResource MaterialCardCornerRadius}"
+										 Padding="{TemplateBinding Padding}"
+										 AutomationProperties.AccessibilityView="Raw" />
+
+						<!--  Supporting Content part  -->
+						<ContentPresenter Grid.Row="1"
+										  Grid.ColumnSpan="3"
+										  x:Name="SupportingContentPresenter"
+										  Content="{TemplateBinding SupportingContent}"
+										  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+						<!--  Icons section part  -->
+						<ContentPresenter Grid.Row="2"
+										  Grid.ColumnSpan="3"
+										  x:Name="IconsContentPresenter"
+										  Content="{TemplateBinding IconsContent}"
+										  ContentTemplate="{TemplateBinding IconsContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw"
+										  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}}" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialSmallMediaElevatedCardStyle"
+		   BasedOn="{StaticResource MaterialBaseCardStyle}"
+		   TargetType="utu:Card">
+
+		<Setter Property="MinHeight"
+				Value="72" />
+		<Setter Property="MaxWidth"
+				Value="344" />
+		<Setter Property="Padding"
+				Value="0" />
+		<Setter Property="Background"
+				Value="{StaticResource MaterialSurfaceBrush}" />
+		<Setter Property="CornerRadius"
+				Value="{StaticResource MaterialCardCornerRadius}" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="Margin"
+				Value="{StaticResource MaterialCardElevationMargin}" />
+		<Setter Property="Elevation"
+				Value="{StaticResource MaterialCardElevation}" />
+		<Setter Property="MediaContentTemplate"
+				Value="{StaticResource DefaultSmallMediaContentTemplate}" />
+		<Setter Property="SupportingContentTemplate"
+				Value="{StaticResource DefaultSmallMediaSupportingContentTemplate}" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:Card">
+					<!--  Elevated View  -->
+					<toolkit:ElevatedView x:Name="ElevatedRoot"
+										  MinWidth="{TemplateBinding MinWidth}"
+										  MinHeight="{TemplateBinding MinHeight}"
+										  MaxWidth="{TemplateBinding MaxWidth}"
+										  MaxHeight="{TemplateBinding MaxHeight}"
+										  Margin="{TemplateBinding Margin}"
+										  Background="{TemplateBinding Background}"
+										  BorderBrush="{TemplateBinding BorderBrush}"
+										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalAlignment}"
+										  CornerRadius="{TemplateBinding CornerRadius}"
+										  Elevation="{TemplateBinding Elevation}"
+										  ShadowColor="{TemplateBinding ShadowColor}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<DoubleAnimation Storyboard.TargetName="FocusedOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialAnimationDuration}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity"
+												Value="0" />
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+										<Setter Target="GridRoot.Opacity"
+												Value="0.38" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerFocused" />
+								<VisualState x:Name="Unfocused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid x:Name="GridRoot"
+							  CornerRadius="{TemplateBinding CornerRadius}">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+
+							<!--  Border for PointerOver State  -->
+							<Border Grid.RowSpan="3"
+									Grid.ColumnSpan="3"
+									x:Name="HoverOverlay"
+									Background="{StaticResource MaterialOnSurfaceHoverBrush}"
+									Opacity="0" />
+
+							<!--  Border for Focused State  -->
+							<Border Grid.RowSpan="3"
+									Grid.ColumnSpan="3"
+									x:Name="FocusedOverlay"
+									Background="{StaticResource MaterialOnSurfaceFocusedBrush}"
+									Opacity="0" />
+
+							<!--  Media content part  -->
+							<ContentPresenter x:Name="MediaContentPresenter"
+											  Content="{TemplateBinding MediaContent}"
+											  ContentTemplate="{TemplateBinding MediaContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  IsHitTestVisible="False"
+											  Visibility="{Binding MediaContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<StackPanel Grid.Column="1">
+								<!--  Header part  -->
+								<ContentPresenter x:Name="HeaderContentPresenter"
+												  Content="{TemplateBinding HeaderContent}"
+												  ContentTemplate="{TemplateBinding HeaderContentTemplate}"
+												  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+												  AutomationProperties.AccessibilityView="Raw"
+												  Visibility="{Binding HeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+								<!--  SubHeader part  -->
+								<ContentPresenter x:Name="SubHeaderContentPresenter"
+												  Content="{TemplateBinding SubHeaderContent}"
+												  ContentTemplate="{TemplateBinding SubHeaderContentTemplate}"
+												  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+												  AutomationProperties.AccessibilityView="Raw"
+												  Visibility="{Binding SubHeaderContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+							</StackPanel>
+
+							<!--  Ripple effect  -->
+							<controls:Ripple Grid.RowSpan="3"
+											 Grid.ColumnSpan="3"
+											 Feedback="{StaticResource MaterialOnSurfaceFocusedBrush}"
+											 CornerRadius="{StaticResource MaterialCardCornerRadius}"
+											 Padding="{TemplateBinding Padding}"
+											 AutomationProperties.AccessibilityView="Raw" />
+
+							<!--  Supporting Content part  -->
+							<ContentPresenter Grid.Row="1"
+											  Grid.ColumnSpan="3"
+											  x:Name="SupportingContentPresenter"
+											  Content="{TemplateBinding SupportingContent}"
+											  ContentTemplate="{TemplateBinding SupportingContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding SupportingContent, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}" />
+
+							<!--  Icons section part  -->
+							<ContentPresenter Grid.Row="2"
+											  Grid.ColumnSpan="3"
+											  x:Name="IconsContentPresenter"
+											  Content="{TemplateBinding IconsContent}"
+											  ContentTemplate="{TemplateBinding IconsContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  Visibility="{Binding IconsContentTemplate, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}}" />
+						</Grid>
+					</toolkit:ElevatedView>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+</ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): #86 

## PR Type

What kind of change does this PR introduce?

- Other: Moving controls from Uno.Themes to Uno.Toolkit

## What is the current behavior?

Card is in Uno.Themes


## What is the new behavior?

Card is in Toolkit


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)