### PR TITLE
fix: uwp navbar crash

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.xaml
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.xaml
@@ -6,6 +6,7 @@
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
 					xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
 					xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
@@ -15,7 +16,7 @@
 					xmlns:contract12NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,12)"
 					xmlns:contract6NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,6)"
 					xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
-					mc:Ignorable="android ios">
+					mc:Ignorable="android ios not_win">
 
 
 	<Style x:Key="XamlDefaultNavigationBar"
@@ -1287,7 +1288,7 @@
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="*" />
 								<ColumnDefinition Width="Auto"
-												  MinWidth="{ThemeResource AppBarMoreButtonColumnMinWidth}" />
+												  not_win:MinWidth="{ThemeResource AppBarMoreButtonColumnMinWidth}" />
 							</Grid.ColumnDefinitions>
 							<Grid.RenderTransform>
 								<TranslateTransform x:Name="ContentTransform" />

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Base.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Base.xaml
@@ -335,7 +335,7 @@
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="*" />
 								<ColumnDefinition Width="Auto"
-												  MinWidth="{ThemeResource AppBarMoreButtonColumnMinWidth}" />
+												  not_win:MinWidth="{ThemeResource AppBarMoreButtonColumnMinWidth}" />
 							</Grid.ColumnDefinitions>
 							<Grid.RenderTransform>
 								<TranslateTransform x:Name="ContentTransform" />


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<utu:NavigationBar /> would cause the gallery uwp app to crash at MeasureOverride.

## What is the new behavior?

Should not happen anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
Temporarily fix until Gallery can update Microsoft.UI.Xaml.