### PR TITLE
Move everything under the Uno.Toolkit.UI namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use styles, just find the name of the style from our documentation or sample 
 
 Here is how to use our custom controls like a Card
 ```xaml
-xmlns:utu="using:Uno.Toolkit.UI.Controls"
+xmlns:utu="using:Uno.Toolkit.UI"
 
 [...]
 

--- a/docs/controls/Chip.md
+++ b/docs/controls/Chip.md
@@ -34,7 +34,7 @@
 ### Chip
 
 ```xml
-xmlns:utu="using:Uno.Toolkit.UI.Controls"
+xmlns:utu="using:Uno.Toolkit.UI"
 ...
 <!-- Filled Input Material chip -->
 <utu:Chip Content="Chip"
@@ -54,7 +54,7 @@ xmlns:utu="using:Uno.Toolkit.UI.Controls"
 ### ChipGroup
 
 ```xml
-xmlns:utu="using:Uno.Toolkit.UI.Controls"
+xmlns:utu="using:Uno.Toolkit.UI"
 ...
 <!-- Filled Input Material ChipGroup with static items -->
 <utu:ChipGroup Style="{StaticResource MaterialFilledInputChipGroupStyle}">

--- a/docs/controls/SegmentedControls.md
+++ b/docs/controls/SegmentedControls.md
@@ -13,7 +13,7 @@ There are two segmented control styles that you can use to theme `TabBar` and it
 ### Sliding Segmented Control
 
 ```xml
-xmlns:utu="using:Uno.Toolkit.UI.Controls"
+xmlns:utu="using:Uno.Toolkit.UI"
 ...
 <utu:TabBar Style="{StaticResource CupertinoSlidingSegmentedStyle}">
 	<utu:TabBar.Items>
@@ -27,7 +27,7 @@ xmlns:utu="using:Uno.Toolkit.UI.Controls"
 ### Segmented Control
 
 ```xml
-xmlns:utu="using:Uno.Toolkit.UI.Controls"
+xmlns:utu="using:Uno.Toolkit.UI"
 ...
 <utu:TabBar Style="{StaticResource CupertinoSegmentedStyle}">
 	<utu:TabBar.Items>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardContentControlSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardContentControlSamplePage.xaml
@@ -5,7 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:sample="using:Uno.Toolkit.Samples"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardSamplePage.xaml
@@ -4,7 +4,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:sample="using:Uno.Toolkit.Samples"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d">
 
 	<Page.Resources>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ChipSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ChipSamplePage.xaml
@@ -4,7 +4,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:converters="using:Uno.Toolkit.Samples.Converters"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:android="http://uno.ui/android"
 	  xmlns:ios="http://uno.ui/ios"
 	  xmlns:sample="using:Uno.Toolkit.Samples"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ChipSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ChipSamplePage.xaml.cs
@@ -10,7 +10,8 @@ using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Uno.Toolkit.Samples.Entities.Data;
 using Uno.Toolkit.Samples.Entities;
-using Uno.Toolkit.UI.Controls;
+using Uno.Toolkit.UI;
+
 #if IS_WINUI
 using Microsoft.UI;
 using Microsoft.UI.Xaml;

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DividerSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DividerSamplePage.xaml
@@ -1,7 +1,7 @@
 ﻿<Page x:Class="Uno.Toolkit.Samples.Content.Controls.DividerSamplePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:sample="using:Uno.Toolkit.Samples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DividerSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DividerSamplePage.xaml.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.Toolkit.Samples.Entities;
-using Uno.Toolkit.UI.Controls;
+using Uno.Toolkit.UI;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 #if IS_WINUI

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DrawerControlSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DrawerControlSamplePage.xaml
@@ -5,8 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:sample="using:Uno.Toolkit.Samples"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
-	  xmlns:behaviors="using:Uno.Toolkit.UI.Behaviors"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DrawerControlSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DrawerControlSamplePage.xaml.cs
@@ -6,7 +6,8 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Windows.Input;
 using Uno.Toolkit.Samples.Entities;
-using Uno.Toolkit.UI.Controls;
+using Uno.Toolkit.UI;
+
 
 #if IS_WINUI
 using Microsoft.UI;

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SegmentedControlSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SegmentedControlSamplePage.xaml
@@ -5,7 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:sample="using:Uno.Toolkit.Samples"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarBehaviorSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarBehaviorSamplePage.xaml
@@ -5,9 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:sample="using:Uno.Toolkit.Samples"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
-	  xmlns:toolkitB="using:Uno.Toolkit.UI.Behaviors"
-	  xmlns:toolkitE="using:Uno.Toolkit.UI.Extensions"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -100,7 +98,7 @@
 									<utu:TabBar Style="{StaticResource TabBarWithSnapIndicatorStyle}"
 													x:Name="SnapTabBar"
 													AutomationProperties.AutomationId="SnapTabBar"
-													toolkitB:TabBarSelectorBehavior.Selector="{Binding ElementName=SnapFlipView}"
+													utu:TabBarSelectorBehavior.Selector="{Binding ElementName=SnapFlipView}"
 													Background="LightBlue">
 										<utu:TabBar.Items>
 											<utu:TabBarItem Content="Tab 1"
@@ -147,7 +145,7 @@
 						<utu:TabBar Style="{StaticResource TabBarWithSlideIndicatorStyle}"
 									x:Name="SlideTabBar"
 									AutomationProperties.AutomationId="SlideTabBar"
-									toolkitB:TabBarSelectorBehavior.Selector="{Binding ElementName=SlideFlipView}"
+									utu:TabBarSelectorBehavior.Selector="{Binding ElementName=SlideFlipView}"
 									Background="LightBlue">
 							<utu:TabBar.Items>
 								<utu:TabBarItem Content="Tab 1"
@@ -192,7 +190,7 @@
 											   Style="{StaticResource BodyTextBlockStyle}" />
 									<utu:TabBar x:Name="ListViewTabBar"
 													AutomationProperties.AutomationId="ListViewTabBar"
-													toolkitB:TabBarSelectorBehavior.Selector="{Binding ElementName=ListView}"
+													utu:TabBarSelectorBehavior.Selector="{Binding ElementName=ListView}"
 													Background="LightBlue">
 										<utu:TabBar.Items>
 											<utu:TabBarItem Content="Tab 1"
@@ -242,7 +240,7 @@
 											   Style="{StaticResource BodyTextBlockStyle}" />
 									<utu:TabBar x:Name="ListViewSkipTabBar"
 													AutomationProperties.AutomationId="ListViewSkipTabBar"
-													toolkitB:TabBarSelectorBehavior.Selector="{Binding ElementName=SkipListView}"
+													utu:TabBarSelectorBehavior.Selector="{Binding ElementName=SkipListView}"
 													Background="LightBlue">
 										<utu:TabBar.Items>
 											<utu:TabBarItem Content="Tab 1"
@@ -294,7 +292,7 @@
 									<utu:TabBar Style="{StaticResource TabBarWithSlideIndicatorStyle}"
 													x:Name="SlideSkipTabBar"
 													AutomationProperties.AutomationId="SlideSkipTabBar"
-													toolkitB:TabBarSelectorBehavior.Selector="{Binding ElementName=SlideSkipFlipView}"
+													utu:TabBarSelectorBehavior.Selector="{Binding ElementName=SlideSkipFlipView}"
 													Background="LightBlue">
 										<utu:TabBar.Items>
 											<utu:TabBarItem Content="Tab 1"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarBehaviorSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarBehaviorSamplePage.xaml.cs
@@ -7,8 +7,8 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Windows.Input;
 using Uno.Toolkit.Samples.Entities;
 using Uno.Toolkit.Samples.ViewModels;
-using Uno.Toolkit.UI;
-using Uno.Toolkit.UI.Behaviors;
+
+
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarSamplePage.xaml
@@ -5,7 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:sample="using:Uno.Toolkit.Samples"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d">
 
 	<sample:SamplePageLayout>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/CupertinoBottomBarSampleNestedPage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/CupertinoBottomBarSampleNestedPage.xaml
@@ -4,10 +4,8 @@
 	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  xmlns:toolkitB="using:Uno.Toolkit.UI.Behaviors"
-	  xmlns:toolkitE="using:Uno.Material.Extensions"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/CupertinoBottomBarSampleNestedPage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/CupertinoBottomBarSampleNestedPage.xaml.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.Toolkit.UI;
-using Uno.Toolkit.UI.Controls;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 #if IS_WINUI

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/MaterialBottomBarSampleNestedPage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/MaterialBottomBarSampleNestedPage.xaml
@@ -4,10 +4,7 @@
 	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
-	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  xmlns:toolkitB="using:Uno.Toolkit.UI.Behaviors"
-	  xmlns:toolkitE="using:Uno.Material.Extensions"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:ios="http://uno.ui/ios"
 	  mc:Ignorable="d ios"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/MaterialBottomBarSampleNestedPage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/MaterialBottomBarSampleNestedPage.xaml.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.Toolkit.UI;
-using Uno.Toolkit.UI.Controls;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 #if IS_WINUI

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/MaterialTopBarSampleNestedPage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/MaterialTopBarSampleNestedPage.xaml
@@ -5,10 +5,8 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:ios="http://uno.ui/ios"
-	  xmlns:toolkitB="using:Uno.Toolkit.UI.Behaviors"
-	  xmlns:toolkitE="using:Uno.Material.Extensions"
 	  mc:Ignorable="d ios"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -36,7 +34,7 @@
 		<utu:TabBar Grid.Row="1"
 					SelectedIndex="1"
 					Style="{StaticResource MaterialTopTabBarStyle}"
-					toolkitB:TabBarSelectorBehavior.Selector="{Binding ElementName=SlideFlipView}">
+					utu:TabBarSelectorBehavior.Selector="{Binding ElementName=SlideFlipView}">
 			<utu:TabBar.Items>
 				<utu:TabBarItem Content="Home" />
 				<utu:TabBarItem Content="Search" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_ModalPage1.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_ModalPage1.xaml
@@ -4,7 +4,7 @@
 	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 	<Grid>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_ModalPage2.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_ModalPage2.xaml
@@ -4,7 +4,7 @@
 	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_NestedPage1.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_NestedPage1.xaml
@@ -4,7 +4,7 @@
 	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_NestedPage2.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_NestedPage2.xaml
@@ -5,7 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-	  xmlns:utu="using:Uno.Toolkit.UI.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml.cs
@@ -2,7 +2,8 @@
 using Windows.UI.Core;
 using System.Threading.Tasks;
 using Uno.Toolkit.Samples.Content.NestedSamples;
-using Uno.Toolkit.UI.Helpers;
+using Uno.Toolkit.UI;
+
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Styles/SamplePageLayout.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Styles/SamplePageLayout.xaml
@@ -9,7 +9,7 @@
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:material="using:Uno.Material.Controls"
 					xmlns:wasm="http://uno.ui/wasm"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="xamarin ios android wasm">
 
 	<Thickness x:Key="SampleContentPadding">0,0,0,0</Thickness>

--- a/src/Uno.Toolkit.UI/Behaviors/DrawerControlBehavior.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/DrawerControlBehavior.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Uno.Toolkit.UI.Controls;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -15,7 +14,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Uno.Toolkit.UI.Behaviors
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// This class contains the attached properties that can be used to access/modify the same named dependency properties on <see cref="DrawerControl"/>

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehavior.Properties.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehavior.Properties.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Uno.Toolkit.UI.Controls;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -15,7 +14,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 #endif
 
-namespace Uno.Toolkit.UI.Behaviors
+namespace Uno.Toolkit.UI
 {
 	partial class TabBarSelectorBehavior
 	{

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehavior.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehavior.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Uno.Toolkit.UI.Controls;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -15,7 +14,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 #endif
 
-namespace Uno.Toolkit.UI.Behaviors
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// A behavior that, when attached to a <see cref="TabBar"/>, synchronizes the SelectedIndex of the <see cref="TabBar"/> to the specified <see cref="TabBarSelectorBehavior.SelectorProperty"/>

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.Android.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.Android.cs
@@ -8,7 +8,6 @@ using AndroidX.ViewPager.Widget;
 using System.Diagnostics;
 using Windows.Foundation;
 using Uno.Disposables;
-using Uno.Toolkit.UI.Controls;
 using Uno.UI;
 
 #if IS_WINUI
@@ -23,7 +22,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Behaviors
+namespace Uno.Toolkit.UI
 {
 	partial class TabBarSelectorBehaviorState
 	{

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.Uwp.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.Uwp.cs
@@ -4,10 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Uno.Toolkit.UI.Extensions;
 using Uno.Disposables;
 using System.Diagnostics;
-using Uno.Toolkit.UI.Controls;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -21,7 +19,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Uno.Toolkit.UI.Behaviors
+namespace Uno.Toolkit.UI
 {
 	partial class TabBarSelectorBehaviorState
 	{

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.cs
@@ -5,8 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Uno.Disposables;
 using Windows.Foundation;
-using Uno.Toolkit.UI.Extensions;
-using Uno.Toolkit.UI.Controls;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -20,7 +18,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Uno.Toolkit.UI.Behaviors
+namespace Uno.Toolkit.UI
 {
 	internal partial class TabBarSelectorBehaviorState
 	{

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.iOS.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.iOS.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using UIKit;
 using Uno.Disposables;
 using System.Diagnostics;
-using Uno.Toolkit.UI.Controls;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -21,7 +20,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Behaviors
+namespace Uno.Toolkit.UI
 {
 	partial class TabBarSelectorBehaviorState
 	{

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	[ContentProperty(Name = nameof(Children))]
 	[TemplatePart(Name = PART_RootGrid, Type = typeof(Grid))]

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.xaml
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls">
+					xmlns:utu="using:Uno.Toolkit.UI">
 
 	<Style TargetType="utu:AutoLayout"
 		   x:Key="DefaultAutoLayoutStyle">

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutAlignment.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutAlignment.cs
@@ -1,4 +1,4 @@
-﻿namespace Uno.Toolkit.UI.Controls
+﻿namespace Uno.Toolkit.UI
 {
 	public enum AutoLayoutAlignment
 	{

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutChildren.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutChildren.cs
@@ -6,7 +6,7 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class AutoLayoutChildren : List<FrameworkElement>
 	{

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutExtensions.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal static class AutoLayoutExtensions
 	{

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutJustify.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutJustify.cs
@@ -1,4 +1,4 @@
-﻿namespace Uno.Toolkit.UI.Controls
+﻿namespace Uno.Toolkit.UI
 {
 	public enum AutoLayoutJustify
 	{

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutPrimaryAlignment.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayoutPrimaryAlignment.cs
@@ -1,4 +1,4 @@
-﻿namespace Uno.Toolkit.UI.Controls
+﻿namespace Uno.Toolkit.UI
 {
 	public enum AutoLayoutPrimaryAlignment
 	{

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class Card : Control
 	{

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.cs
@@ -11,7 +11,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class Card : Control
 	{

--- a/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControl.cs
@@ -16,7 +16,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class CardContentControl : ContentControl
 	{

--- a/src/Uno.Toolkit.UI/Controls/Chips/Chip.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/Chip.cs
@@ -13,7 +13,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	[TemplatePart(Name = RemoveButtonName, Type = typeof(Button))]
 	public partial class Chip : ToggleButton

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.Properties.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class ChipGroup
 	{

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.cs
@@ -15,7 +15,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class ChipGroup : ItemsControl
 	{

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipSelectionMode.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipSelectionMode.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public enum ChipSelectionMode
 	{

--- a/src/Uno.Toolkit.UI/Controls/Chips/Chips.EventHandlers.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/Chips.EventHandlers.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	#region Chip event handlers
 	public delegate void ChipRemovingEventHandler(object sender, ChipRemovingEventArgs e);

--- a/src/Uno.Toolkit.UI/Controls/Divider/Divider.cs
+++ b/src/Uno.Toolkit.UI/Controls/Divider/Divider.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Divider = Uno.Toolkit.UI.Controls.Divider;
+using Divider = Uno.Toolkit.UI.Divider;
 #if IS_WINUI
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -12,7 +12,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class Divider : Control
 	{

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.Enhanced.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.Enhanced.xaml
@@ -1,8 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
-					xmlns:behaviors="using:Uno.Toolkit.UI.Behaviors"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 					xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
 					xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
@@ -39,30 +38,30 @@
 		<Setter Property="OpenPaneLength"
 				Value="320" />
 
-		<Setter Property="behaviors:DrawerControlBehavior.OpenDirection"
+		<Setter Property="utu:DrawerControlBehavior.OpenDirection"
 				Value="Right" />
-		<Setter Property="behaviors:DrawerControlBehavior.DrawerBackground"
+		<Setter Property="utu:DrawerControlBehavior.DrawerBackground"
 				Value="{StaticResource DrawerControlDrawerBackgroundBrush}" />
-		<Setter Property="behaviors:DrawerControlBehavior.LightDismissOverlayBackground"
+		<Setter Property="utu:DrawerControlBehavior.LightDismissOverlayBackground"
 				Value="{StaticResource SplitViewDrawerLightDismissOverlayBackgroundBrush}" />
-		<Setter Property="behaviors:DrawerControlBehavior.EdgeSwipeDetectionLength"
+		<Setter Property="utu:DrawerControlBehavior.EdgeSwipeDetectionLength"
 				Value="50" />
-		<Setter Property="behaviors:DrawerControlBehavior.IsGestureEnabled"
+		<Setter Property="utu:DrawerControlBehavior.IsGestureEnabled"
 				Value="True" />
-		<Setter Property="behaviors:DrawerControlBehavior.FitToDrawerContent"
+		<Setter Property="utu:DrawerControlBehavior.FitToDrawerContent"
 				Value="False" />
 
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="SplitView">
 					<utu:DrawerControl IsOpen="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsPaneOpen, Mode=TwoWay}"
-									   DrawerBackground="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(behaviors:DrawerControlBehavior.DrawerBackground)}"
+									   DrawerBackground="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(utu:DrawerControlBehavior.DrawerBackground)}"
 									   DrawerDepth="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=OpenPaneLength, Mode=TwoWay}"
-									   OpenDirection="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(behaviors:DrawerControlBehavior.OpenDirection)}"
-									   LightDismissOverlayBackground="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(behaviors:DrawerControlBehavior.LightDismissOverlayBackground)}"
-									   EdgeSwipeDetectionLength="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(behaviors:DrawerControlBehavior.EdgeSwipeDetectionLength)}"
-									   IsGestureEnabled="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(behaviors:DrawerControlBehavior.IsGestureEnabled)}"
-									   FitToDrawerContent="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(behaviors:DrawerControlBehavior.FitToDrawerContent)}"
+									   OpenDirection="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(utu:DrawerControlBehavior.OpenDirection)}"
+									   LightDismissOverlayBackground="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(utu:DrawerControlBehavior.LightDismissOverlayBackground)}"
+									   EdgeSwipeDetectionLength="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(utu:DrawerControlBehavior.EdgeSwipeDetectionLength)}"
+									   IsGestureEnabled="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(utu:DrawerControlBehavior.IsGestureEnabled)}"
+									   FitToDrawerContent="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(utu:DrawerControlBehavior.FitToDrawerContent)}"
 									   Background="{TemplateBinding Background}">
 						<utu:DrawerControl.Content>
 							<!-- workaround: required to prevent ios black screen when used inside a muxc:NavigationView -->
@@ -100,17 +99,17 @@
 		<Setter Property="CompactPaneLength"
 				Value="{ThemeResource NavigationViewCompactPaneLength}" />
 
-		<Setter Property="behaviors:DrawerControlBehavior.OpenDirection"
+		<Setter Property="utu:DrawerControlBehavior.OpenDirection"
 				Value="Right" />
-		<Setter Property="behaviors:DrawerControlBehavior.DrawerBackground"
+		<Setter Property="utu:DrawerControlBehavior.DrawerBackground"
 				Value="{StaticResource DrawerControlDrawerBackgroundBrush}" />
-		<Setter Property="behaviors:DrawerControlBehavior.LightDismissOverlayBackground"
+		<Setter Property="utu:DrawerControlBehavior.LightDismissOverlayBackground"
 				Value="{StaticResource NavigationViewDrawerLightDismissOverlayBackgroundBrush}" />
-		<Setter Property="behaviors:DrawerControlBehavior.EdgeSwipeDetectionLength"
+		<Setter Property="utu:DrawerControlBehavior.EdgeSwipeDetectionLength"
 				Value="50" />
-		<Setter Property="behaviors:DrawerControlBehavior.IsGestureEnabled"
+		<Setter Property="utu:DrawerControlBehavior.IsGestureEnabled"
 				Value="True" />
-		<Setter Property="behaviors:DrawerControlBehavior.FitToDrawerContent"
+		<Setter Property="utu:DrawerControlBehavior.FitToDrawerContent"
 				Value="False" />
 
 		<Setter Property="Template">
@@ -141,12 +140,12 @@
 									   OpenPaneLength="{TemplateBinding OpenPaneLength}"
 									   PaneBackground="{ThemeResource NavigationViewDefaultPaneBackground}"
 									   IsPaneOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPaneOpen, Mode=TwoWay}"
-									   behaviors:DrawerControlBehavior.OpenDirection="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(behaviors:DrawerControlBehavior.OpenDirection)}"
-									   behaviors:DrawerControlBehavior.DrawerBackground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(behaviors:DrawerControlBehavior.DrawerBackground)}"
-									   behaviors:DrawerControlBehavior.LightDismissOverlayBackground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(behaviors:DrawerControlBehavior.LightDismissOverlayBackground)}"
-									   behaviors:DrawerControlBehavior.EdgeSwipeDetectionLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(behaviors:DrawerControlBehavior.EdgeSwipeDetectionLength)}"
-									   behaviors:DrawerControlBehavior.IsGestureEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(behaviors:DrawerControlBehavior.IsGestureEnabled)}"
-									   behaviors:DrawerControlBehavior.FitToDrawerContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(behaviors:DrawerControlBehavior.FitToDrawerContent)}"
+									   utu:DrawerControlBehavior.OpenDirection="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(utu:DrawerControlBehavior.OpenDirection)}"
+									   utu:DrawerControlBehavior.DrawerBackground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(utu:DrawerControlBehavior.DrawerBackground)}"
+									   utu:DrawerControlBehavior.LightDismissOverlayBackground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(utu:DrawerControlBehavior.LightDismissOverlayBackground)}"
+									   utu:DrawerControlBehavior.EdgeSwipeDetectionLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(utu:DrawerControlBehavior.EdgeSwipeDetectionLength)}"
+									   utu:DrawerControlBehavior.IsGestureEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(utu:DrawerControlBehavior.IsGestureEnabled)}"
+									   utu:DrawerControlBehavior.FitToDrawerContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(utu:DrawerControlBehavior.FitToDrawerContent)}"
 									   Style="{StaticResource DrawerSplitViewStyle}">
 
 								<SplitView.Pane>

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.Properties.cs
@@ -14,7 +14,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class DrawerControl
 	{

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.cs
@@ -24,7 +24,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// Represents a container with two views; one view for the main content, 

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:not_win="http://uno.ui/not_win"
 					mc:Ignorable="not_win">
 

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerOpenDirection.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerOpenDirection.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// Defines constants that specify the direction in which the DrawerControl drawer opens.

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -12,8 +12,6 @@ using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Helpers;
 using Uno.Logging;
-using Uno.Toolkit.UI.Extensions;
-using Uno.Toolkit.UI.Helpers;
 using Uno.UI;
 using Windows.Foundation;
 using DrawableHelper = Uno.UI.DrawableHelper;
@@ -38,7 +36,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal class AppBarButtonRenderer : Renderer<AppBarButton, IMenuItem>
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
@@ -9,8 +9,6 @@ using UIKit;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Logging;
-using Uno.Toolkit.UI.Extensions;
-using Uno.Toolkit.UI.Helpers;
 using Windows.Foundation;
 
 #if IS_WINUI
@@ -34,7 +32,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal class AppBarButtonRenderer : Renderer<AppBarButton, UIBarButtonItem>
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/CommandBarExtensions.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/CommandBarExtensions.cs
@@ -11,7 +11,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	[Bindable]
 	public static class CommandBarExtensions

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/INavigationBarPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/INavigationBarPresenter.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public interface INavigationBarPresenter
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/LeftCommandMode.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/LeftCommandMode.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public enum MainCommandMode
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.Android.cs
@@ -32,7 +32,7 @@ using Windows.UI.Xaml.Navigation;
 using Windows.UI.Xaml.Media.Animation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class NativeFramePresenter : Grid // Inheriting from Grid is a hack to remove 1 visual layer (Android 4.4 stack size limits)
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
@@ -38,7 +38,7 @@ using Windows.UI.Xaml.Media.Animation;
 #endif
 
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class NativeFramePresenter : FrameworkElement
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.Android.cs
@@ -23,7 +23,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class NativeNavigationBarPresenter : ContentPresenter, INavigationBarPresenter
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
@@ -28,7 +28,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class NativeNavigationBarPresenter : ContentPresenter, INavigationBarPresenter
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationAppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationAppBarButtonRenderer.Android.cs
@@ -11,8 +11,6 @@ using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Helpers;
 using Uno.Logging;
-using Uno.Toolkit.UI.Extensions;
-using Uno.Toolkit.UI.Helpers;
 using Uno.UI;
 using Windows.Foundation;
 using DrawableHelper = Uno.UI.DrawableHelper;
@@ -37,7 +35,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal class NavigationAppBarButtonRenderer : Renderer<AppBarButton, Toolbar>
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.Native.xaml
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.Native.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.Properties.cs
@@ -23,7 +23,7 @@ using Windows.UI.Xaml.Navigation;
 #endif
 
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	partial class NavigationBar
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using Uno.Disposables;
 using Windows.Foundation;
 using Windows.UI.Core;
-using Uno.Toolkit.UI.Extensions;
 #if HAS_UNO
 using Uno.UI.Helpers;
 #endif
@@ -37,7 +36,7 @@ using Windows.UI.Xaml.Navigation;
 using Windows.UI.ViewManagement;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// Represents a specialized app bar that provides layout for AppBarButton and navigation logic.

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.xaml
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:android="http://uno.ui/android"

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarClosedDisplayMode.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarClosedDisplayMode.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public enum NavigationBarClosedDisplayMode
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarDefaultLabelPosition.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarDefaultLabelPosition.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public enum NavigationBarDefaultLabelPosition
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarElementCollection.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarElementCollection.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal class NavigationBarElementCollection : IObservableVector<ICommandBarElement>
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarHelper.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarHelper.iOS.cs
@@ -13,7 +13,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal static class NavigationBarHelper
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
@@ -10,7 +10,6 @@ using Uno.Disposables;
 using Windows.Foundation;
 using Windows.UI.ViewManagement;
 using Windows.Foundation.Collections;
-using Uno.Toolkit.UI.Extensions;
 using Uno.Extensions;
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -30,7 +29,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal partial class NavigationBarNavigationItemRenderer : Renderer<NavigationBar, UINavigationItem>
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarOverflowButtonVisibility.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarOverflowButtonVisibility.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public enum NavigationBarOverflowButtonVisibility
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Uno.Disposables;
-using Uno.Toolkit.UI.Extensions;
 using Windows.Foundation.Collections;
 
 #if IS_WINUI
@@ -25,7 +24,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class NavigationBarPresenter : Control, INavigationBarPresenter
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.Android.cs
@@ -12,7 +12,6 @@ using Android.Views;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Logging;
-using Uno.Toolkit.UI.Extensions;
 using Windows.Foundation.Collections;
 using AndroidX.Core.Graphics.Drawable;
 using Windows.UI.Core;
@@ -20,7 +19,7 @@ using Android.Views.InputMethods;
 using Android.Content;
 using Uno.UI;
 using Windows.UI;
-using ColorHelper = Uno.Toolkit.UI.Helpers.ColorHelper;
+using ColorHelper = Uno.Toolkit.UI.ColorHelper;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -44,7 +43,7 @@ using Windows.UI.Xaml.Automation.Peers;
 using Uno.UI.Extensions;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal partial class NavigationBarRenderer : Renderer<NavigationBar, Toolbar>
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 using UIKit;
 using Uno.Disposables;
 using Uno.Extensions;
-using Uno.Toolkit.UI.Extensions;
-using Uno.Toolkit.UI.Helpers;
 using Windows.Foundation;
 
 #if IS_WINUI
@@ -30,7 +28,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal partial class NavigationBarRenderer : Renderer<NavigationBar, UINavigationBar>
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarTemplateSettings.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarTemplateSettings.cs
@@ -18,7 +18,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class NavigationBarTemplateSettings : DependencyObject
 	{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
@@ -25,7 +25,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal abstract class Renderer<TElement, TNative> : IDisposable
 			where TElement :

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/VectorChangedEventArgs.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/VectorChangedEventArgs.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Windows.Foundation.Collections;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	internal class VectorChangedEventArgs : IVectorChangedEventArgs
 	{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/IndicatorTransitionMode.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/IndicatorTransitionMode.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Uno.Toolkit.UI.Behaviors;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// Determines the method for which the selection indicator will move to the selected tab

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.Events.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.Events.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Windows.Foundation;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
     partial class TabBar
     {

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.Properties.cs
@@ -9,7 +9,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class TabBar
 	{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
@@ -26,7 +26,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// A control to display a set of <see cref="TabBarItem"/>s horizontally with the ability to display a custom view to denote selected state

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.xaml
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls">
+					xmlns:utu="using:Uno.Toolkit.UI">
 
 	<ResourceDictionary.ThemeDictionaries>
 		<ResourceDictionary x:Key="Dark">

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItem.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItem.Properties.cs
@@ -14,7 +14,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	partial class TabBarItem
 	{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItem.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItem.cs
@@ -15,7 +15,7 @@ using System;
 using Windows.UI.Core;
 using Windows.UI.Input;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// An item to be contained within a <see cref="TabBar"/>

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarListPanel.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarListPanel.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Windows.Foundation;
-using Uno.Toolkit.UI.Extensions;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -13,7 +12,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class TabBarListPanel : Panel
 	{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionChangedEventArgs.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionChangedEventArgs.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
     public partial class TabBarSelectionChangedEventArgs
     {

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.Properties.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	partial class TabBarSelectionIndicatorPresenter
 	{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.cs
@@ -5,8 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Uno.Disposables;
 using Windows.Foundation;
-using Uno.Toolkit.UI.Extensions;
-using Uno.Toolkit.UI.Behaviors;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -32,7 +30,7 @@ using Windows.UI;
 using Windows.UI.Xaml.Media.Animation;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// A Panel that is used to contain and translate a view being used as a selection indicator for a <see cref="TabBar"/>

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarTemplateSettings.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarTemplateSettings.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class TabBarTemplateSettings : DependencyObject
 	{

--- a/src/Uno.Toolkit.UI/Extensions/AppBarButtonExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/AppBarButtonExtensions.cs
@@ -26,7 +26,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Extensions
+namespace Uno.Toolkit.UI
 {
 	internal static class AppBarButtonExtensions
 	{

--- a/src/Uno.Toolkit.UI/Extensions/ColorExtensions.iOS.cs
+++ b/src/Uno.Toolkit.UI/Extensions/ColorExtensions.iOS.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UIKit;
 
-namespace Uno.Toolkit.UI.Extensions
+namespace Uno.Toolkit.UI
 {
 	internal static class UIColorExtensions
 	{

--- a/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
@@ -19,7 +19,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Uno.Toolkit.UI.Extensions
+namespace Uno.Toolkit.UI
 {
 	internal static class DependencyObjectExtensions
 	{

--- a/src/Uno.Toolkit.UI/Extensions/LayoutExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/LayoutExtensions.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.Foundation;
 
-namespace Uno.Toolkit.UI.Extensions
+namespace Uno.Toolkit.UI
 {
 	internal static class LayoutExtensions
 	{

--- a/src/Uno.Toolkit.UI/Extensions/SelectorExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/SelectorExtensions.cs
@@ -16,7 +16,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 #endif
 
-namespace Uno.Toolkit.UI.Extensions
+namespace Uno.Toolkit.UI
 {
 	/// <summary>
 	/// Extensions for <see cref="Selector"/>

--- a/src/Uno.Toolkit.UI/Extensions/UIBarButtonItemExtensions.iOS.cs
+++ b/src/Uno.Toolkit.UI/Extensions/UIBarButtonItemExtensions.iOS.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UIKit;
 
-namespace Uno.Toolkit.UI.Extensions
+namespace Uno.Toolkit.UI
 {
 	internal static class UIBarButtonItemExtensions
 	{

--- a/src/Uno.Toolkit.UI/Helpers/ColorHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/ColorHelper.cs
@@ -25,7 +25,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #endif
 
-namespace Uno.Toolkit.UI.Helpers
+namespace Uno.Toolkit.UI
 {
 	internal static class ColorHelper
 	{

--- a/src/Uno.Toolkit.UI/Helpers/ImageHelper.iOS.cs
+++ b/src/Uno.Toolkit.UI/Helpers/ImageHelper.iOS.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UIKit;
 
-namespace Uno.Toolkit.UI.Helpers
+namespace Uno.Toolkit.UI
 {
 	internal static class ImageHelper
 	{

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -15,7 +15,7 @@ using XamlWindow = Windows.UI.Xaml.Window;
 #endif
 
 
-namespace Uno.Toolkit.UI.Helpers
+namespace Uno.Toolkit.UI
 {
 	public static class SystemThemeHelper
 	{

--- a/src/Uno.Toolkit.UI/Themes/Generic.xaml
+++ b/src/Uno.Toolkit.UI/Themes/Generic.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:ios="http://uno.ui/ios"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:android="http://uno.ui/android"

--- a/src/library/Uno.Toolkit.Cupertino/Converters/InflateDimensionConverter.cs
+++ b/src/library/Uno.Toolkit.Cupertino/Converters/InflateDimensionConverter.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Cupertino.Converters
+namespace Uno.Toolkit.UI
 {
 	internal class InflateDimensionConverter : IValueConverter
 	{

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/BottomTabBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/BottomTabBar.Mobile.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/BottomTabBar.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/BottomTabBar.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="d">
 	<ResourceDictionary.MergedDictionaries>
 		<ToolkitResources xmlns="using:Uno.Toolkit.UI" />

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.Base.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.Base.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls">
+					xmlns:utu="using:Uno.Toolkit.UI">
 
 	<ResourceDictionary.MergedDictionaries>
 		<CupertinoColors xmlns="using:Uno.Cupertino" />

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.Mobile.xaml
@@ -7,7 +7,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					mc:Ignorable="d ios android wasm not_win">

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.xaml
@@ -7,7 +7,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					mc:Ignorable="d ios android wasm not_win">

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.Base.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.Base.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:converters="using:Uno.Toolkit.UI.Cupertino.Converters">
+					xmlns:utu="using:Uno.Toolkit.UI">
 
 	<ResourceDictionary.MergedDictionaries>
 		<CupertinoColors xmlns="using:Uno.Cupertino" />
@@ -90,7 +90,7 @@
 		</ResourceDictionary>
 	</ResourceDictionary.MergedDictionaries>
 
-	<converters:InflateDimensionConverter x:Key="DeflateWidthConverter"
-										  Inflation="-4" />
+	<utu:InflateDimensionConverter x:Key="DeflateWidthConverter"
+								   Inflation="-4" />
 
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.Mobile.xaml
@@ -7,11 +7,10 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:converters="using:Uno.Toolkit.UI.Cupertino.Converters"
 					mc:Ignorable="d ios android wasm not_win">
 
 	<ResourceDictionary.MergedDictionaries>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
@@ -7,11 +7,10 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:wasm="http://uno.ui/wasm"
+					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:converters="using:Uno.Toolkit.UI.Cupertino.Converters"
 					mc:Ignorable="d ios android wasm not_win">
 	<ResourceDictionary.MergedDictionaries>
 		<CupertinoColors xmlns="using:Uno.Cupertino" />

--- a/src/library/Uno.Toolkit.Material/Extensions/LayoutExtensions.cs
+++ b/src/library/Uno.Toolkit.Material/Extensions/LayoutExtensions.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.Foundation;
 
-namespace Uno.Toolkit.UI.Material.Extensions
+namespace Uno.Toolkit.UI
 {
 	internal static class LayoutExtensions
 	{

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.Mobile.xaml
@@ -6,7 +6,7 @@
 					xmlns:toolkitControls="using:Uno.Toolkit.Material.Controls"
 					xmlns:materialToolkit="using:Uno.Toolkit.Material"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.xaml
@@ -4,7 +4,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:controls="using:Uno.Material.Controls"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/Card.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/Card.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:controls="using:Uno.Material.Controls"
 					xmlns:toolkit="using:Uno.UI.Toolkit">
 

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/CardContentControl.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/CardContentControl.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:controls="using:Uno.Material.Controls"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:toolkit="using:Uno.UI.Toolkit">
 
 	<ResourceDictionary.MergedDictionaries>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/Chip.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/Chip.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:controls="using:Uno.Material.Controls"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:not_win="http://uno.ui/not_win"

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/ChipGroup.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/ChipGroup.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:android="http://uno.ui/android"
 					xmlns:ios="http://uno.ui/ios"

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/Divider.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/Divider.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls">
+					xmlns:utu="using:Uno.Toolkit.UI">
 
 	<x:Double x:Key="MaterialDividerHeight">1</x:Double>
 

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Base.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Base.xaml
@@ -6,7 +6,7 @@
 					xmlns:ios="http://nventive.com/ios"
 					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:controls="using:Uno.Material.Controls"
 					xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
 					xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Mobile.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:android="http://nventive.com/android"
 					xmlns:ios="http://nventive.com/ios"

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls">
+					xmlns:utu="using:Uno.Toolkit.UI">
 
 	<ResourceDictionary.MergedDictionaries>
 		<MaterialColors xmlns="using:Uno.Material" />

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.Mobile.xaml
@@ -4,7 +4,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:controls="using:Uno.Material.Controls"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.xaml
@@ -4,7 +4,7 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:controls="using:Uno.Material.Controls"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="d">
 
 	<ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
BREAKING CHANGE: Toolkit controls now under Uno.Toolkit.UI


## PR Type

What kind of change does this PR introduce?

- Refactoring


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
