### PR TITLE
fix(NavigationBar):  Move to UINavigationAppearance APIs, fix unapplied background color

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml.cs
@@ -69,6 +69,9 @@ namespace Uno.Toolkit.Samples
 		/// <param name="e">Details about the launch request and process.</param>
 		protected override void OnLaunched(XamlLaunchActivatedEventArgs e)
 		{
+#if __IOS__ && !NET6_0
+			Xamarin.Calabash.Start();
+#endif
 #if DEBUG
 			if (System.Diagnostics.Debugger.IsAttached)
 			{

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NavigationBarSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NavigationBarSamplePage.xaml
@@ -12,6 +12,7 @@
         <StackPanel Spacing="8" Margin="50">
             <Button Click="LaunchFullScreenSample"
                     Content="Show Sample"
+                    AutomationProperties.AutomationId="NavigationBar_Launch_Sample_Button"
                     Style="{StaticResource MaterialContainedButtonStyle}" />
 
             <Button x:Name="ModalButton"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_ModalPage2.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_ModalPage2.xaml
@@ -16,9 +16,11 @@
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Style="{StaticResource MaterialModalNavigationBarStyle}"
 						   Content="Second Page"
+                           AutomationProperties.AutomationId="Page2NavBar"
 						   MainCommandMode="Back">
 			<utu:NavigationBar.MainCommand>
-				<AppBarButton Click="NavigateBack">
+				<AppBarButton Click="NavigateBack"
+                              Label="Back">
 				</AppBarButton>
 			</utu:NavigationBar.MainCommand>
 			<utu:NavigationBar.PrimaryCommands>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_NestedPage1.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_NestedPage1.xaml
@@ -14,11 +14,13 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Content="First Page"
+                           AutomationProperties.AutomationId="Page1NavBar"
 						   MainCommandMode="Action"
 						   Style="{StaticResource MaterialNavigationBarStyle}">
 			<utu:NavigationBar.MainCommand>
 				<AppBarButton Label="Close"
                               Click="NavigateBack"
+                              AutomationProperties.AutomationId="NavBar_Close_Button"
 							  Style="{StaticResource MaterialAppBarButton}">
 					<AppBarButton.Icon>
 						<BitmapIcon UriSource="ms-appx:///Assets/CloseIcon.png"
@@ -31,7 +33,7 @@
 							  Style="{StaticResource MaterialAppBarButton}"
 							  Command="{Binding Primary1CountCommand}">
 					<AppBarButton.Icon>
-						<BitmapIcon UriSource="ms-appx:///Assets/CloseIcon.png"
+						<BitmapIcon UriSource="ms-appx:///Assets/MaterialIcon_Small.png"
 									ShowAsMonochrome="False" />
 					</AppBarButton.Icon>
 				</AppBarButton>
@@ -39,7 +41,7 @@
 							  Style="{StaticResource MaterialAppBarButton}"
 							  Command="{Binding Primary2CountCommand}">
 					<AppBarButton.Icon>
-						<BitmapIcon UriSource="ms-appx:///Assets/CloseIcon.png"
+						<BitmapIcon UriSource="ms-appx:///Assets/AppleIcon_Small.png"
 									ShowAsMonochrome="False" />
 					</AppBarButton.Icon>
 				</AppBarButton>
@@ -60,6 +62,7 @@
 			<Button Content="Exit sample"
 					Click="NavigateBack" />
 			<Button Click="NavigateToNextPage"
+                    AutomationProperties.AutomationId="Page1_Navigate_To_Page2"
 					Content="Navigate To Second Page" />
 			<TextBlock HorizontalAlignment="Center"
 					   Style="{StaticResource MaterialCaption}">

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_NestedPage2.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_NestedPage2.xaml
@@ -15,6 +15,7 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Style="{StaticResource MaterialNavigationBarStyle}"
+                           AutomationProperties.AutomationId="Page2NavBar"
 						   Content="Second Page">
 			<utu:NavigationBar.PrimaryCommands>
 				<AppBarButton Style="{StaticResource MaterialAppBarButton}"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.iOS/Uno.Toolkit.Samples.iOS.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.iOS/Uno.Toolkit.Samples.iOS.csproj
@@ -54,6 +54,10 @@
     <MtouchDebug>true</MtouchDebug>
     <MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
   </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">
+		<IsUiAutomationMappingEnabled>True</IsUiAutomationMappingEnabled>
+		<DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>
+	</PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
@@ -195,6 +199,9 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
+    <PackageReference Include="Xamarin.TestCloud.Agent">
+      <Version>0.23.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\library\Uno.Toolkit.Cupertino\Uno.Toolkit.UI.Cupertino.csproj">

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
@@ -842,6 +842,24 @@ namespace Uno.Toolkit.UI
 
 				return base.PopViewController(animated);
 			}
+
+			public override void PushViewController(UIViewController viewController, bool animated)
+			{
+				base.PushViewController(viewController, animated);
+
+				// If navigating from ViewController A to ViewController B, B's back button text is determined by A's NavigationBar.MainCommand.Label.
+				if (viewController is PageViewController pvc)
+				{
+					var pushedNavBar = pvc.GetNavigationBar();
+					if (pushedNavBar?.MainCommandMode == MainCommandMode.Back
+						&& pushedNavBar?.MainCommand?.Label is string backButtonTitle
+						&& LowerController?.NavigationItem is { } previousNavItem)
+					{
+						previousNavItem.BackButtonTitle = backButtonTitle;
+					}
+				}
+				
+			}
 		}
 
 		private class ControllerDelegate : UINavigationControllerDelegate

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.Native.xaml
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.Native.xaml
@@ -17,14 +17,14 @@
 				Value="Stretch" />
 		<Setter Property="VerticalAlignment"
 				Value="Top" />
+        <Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBar">
-					<!-- We use BorderBrush instead of Background to ensure that semi-transparent background of Grid and NativeNavigationBarPresenter don't add up -->
-					<Border BorderBrush="{TemplateBinding Background}"
-							BorderThickness="{TemplateBinding Padding}">
-						<!-- TODO: 1px line -->
-						<utu:NativeNavigationBarPresenter x:Name="NavigationBarPresenter" />
+                    <Border BorderThickness="{TemplateBinding Padding}">
+                        <utu:NativeNavigationBarPresenter x:Name="NavigationBarPresenter"
+                                                          Height="44" />
+                        <!-- TODO: 1px line -->
 					</Border>
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
@@ -117,35 +117,18 @@ namespace Uno.Toolkit.UI
 				.Reverse()
 				.ToArray();
 
-			// CommandBarExtensions.NavigationCommand
+			// MainCommand
 			var navigationCommand = element.GetValue(NavigationBar.MainCommandProperty) as AppBarButton;
 			if (navigationCommand?.Visibility == Visibility.Visible)
 			{
 				var mode = (MainCommandMode)element.GetValue(NavigationBar.MainCommandModeProperty);
-				if (mode == MainCommandMode.Back)
-				{
-					if (navigationCommand.Icon == null && (navigationCommand.Content == null || navigationCommand.Content is string))
-					{
-						native.BackBarButtonItem = new UIBarButtonItem(navigationCommand?.Content as string ?? " ", UIBarButtonItemStyle.Plain, null);
-						//native.BackBarButtonItem = navigationCommand?.GetRenderer(() => new AppBarButtonRenderer(navigationCommand)).Native;
-						native.LeftBarButtonItem = null;
-					}
-					else
-					{
-						native.LeftBarButtonItem = navigationCommand?.GetRenderer(() => new AppBarButtonRenderer(navigationCommand)).Native;
-						native.BackBarButtonItem = null;
-					}
-				}
-				else
+				if (mode == MainCommandMode.Action)
 				{
 					native.LeftBarButtonItem = navigationCommand.GetRenderer(() => new AppBarButtonRenderer(navigationCommand)).Native;
-					native.BackBarButtonItem = null;
 				}
-
 			}
 			else
 			{
-				native.BackBarButtonItem = null;
 				native.LeftBarButtonItem = null;
 			}
 		}

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
@@ -1,5 +1,6 @@
 ﻿#if __IOS__
 using CoreGraphics;
+using Foundation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -77,58 +78,163 @@ namespace Uno.Toolkit.UI
 			}
 
 			ApplyVisibility();
-
-			// Foreground
-			if (ColorHelper.TryGetColorWithOpacity(Element.Foreground, out var foregroundColor))
-			{
-				Native.TitleTextAttributes = new UIStringAttributes
-				{
-					ForegroundColor = foregroundColor,
-				};
-			}
-			else
-			{
-				Native.TitleTextAttributes = null!;
-			}
+			var appearance = new UINavigationBarAppearance();
 
 			// Background
 			ColorHelper.TryGetColorWithOpacity(Element.Background, out var backgroundColor);
 			switch (backgroundColor)
 			{
 				case { } opaqueColor when opaqueColor.A == byte.MaxValue:
-					// Prefer BarTintColor because it supports smooth transitions
-					Native.BarTintColor = opaqueColor;
-					Native.Translucent = false; //Make fully opaque for consistency with SetBackgroundImage
-					Native.SetBackgroundImage(null, UIBarMetrics.Default);
-					Native.ShadowImage = null;
+					if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+					{
+						appearance.ConfigureWithOpaqueBackground();
+						appearance.BackgroundColor = opaqueColor;
+					}
+					else
+					{
+						// Prefer BarTintColor because it supports smooth transitions
+						Native.BarTintColor = opaqueColor;
+						Native.Translucent = false; //Make fully opaque for consistency with SetBackgroundImage
+						Native.SetBackgroundImage(null, UIBarMetrics.Default);
+						Native.ShadowImage = null;
+					}
 					break;
 				case { } semiTransparentColor when semiTransparentColor.A > 0:
-					Native.BarTintColor = null;
-					// Use SetBackgroundImage as hack to support semi-transparent background
-					Native.SetBackgroundImage(((UIColor)semiTransparentColor).ToUIImage(), UIBarMetrics.Default);
-					Native.Translucent = true;
-					Native.ShadowImage = null;
+					if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+					{
+						appearance.ConfigureWithDefaultBackground();
+						appearance.BackgroundColor = semiTransparentColor;
+					}
+					else
+					{
+						Native.BarTintColor = null;
+						// Use SetBackgroundImage as hack to support semi-transparent background
+						Native.SetBackgroundImage(((UIColor)semiTransparentColor).ToUIImage(), UIBarMetrics.Default);
+						Native.Translucent = true;
+						Native.ShadowImage = null;
+					}
 					break;
 				case { } transparent when transparent.A == 0:
-					Native.BarTintColor = null;
-					Native.SetBackgroundImage(new UIImage(), UIBarMetrics.Default);
-					// We make sure a transparent bar doesn't cast a shadow.
-					Native.ShadowImage = new UIImage(); // Removes the default 1px line
-					Native.Translucent = true;
+					if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+					{
+						appearance.ConfigureWithTransparentBackground();
+						appearance.BackgroundColor = transparent;
+					}
+					else
+					{
+						Native.BarTintColor = null;
+						Native.SetBackgroundImage(new UIImage(), UIBarMetrics.Default);
+						// We make sure a transparent bar doesn't cast a shadow.
+						Native.ShadowImage = new UIImage(); // Removes the default 1px line
+						Native.Translucent = true;
+					}
 					break;
 				default: //Background is null
-					Native.BarTintColor = null;
-					Native.SetBackgroundImage(null, UIBarMetrics.Default); // Restores the default blurry background
-					Native.ShadowImage = null; // Restores the default 1px line
-					Native.Translucent = true;
+					if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+					{
+						appearance.ConfigureWithDefaultBackground();
+						appearance.BackgroundColor = null;
+					}
+					else
+					{
+						Native.BarTintColor = null;
+						Native.SetBackgroundImage(null, UIBarMetrics.Default); // Restores the default blurry background
+						Native.ShadowImage = null; // Restores the default 1px line
+						Native.Translucent = true;
+					}
 					break;
+			}
+
+			// Foreground
+			if (ColorHelper.TryGetColorWithOpacity(Element.Foreground, out var foregroundColor))
+			{
+				if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+				{
+					appearance.TitleTextAttributes = new UIStringAttributes
+					{
+						ForegroundColor = foregroundColor,
+					};
+
+					appearance.LargeTitleTextAttributes = new UIStringAttributes
+					{
+						ForegroundColor = foregroundColor,
+					};
+				}
+				else
+				{
+					Native.TitleTextAttributes = new UIStringAttributes
+					{
+						ForegroundColor = foregroundColor,
+					};
+				}
+			}
+			else
+			{
+				if(UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+				{
+					appearance.TitleTextAttributes = new UIStringAttributes();
+					appearance.LargeTitleTextAttributes = new UIStringAttributes();
+				}
+				else
+				{
+					Native.TitleTextAttributes = null;
+				}
 			}
 
 			var mainCommand = Element.GetValue(NavigationBar.MainCommandProperty) as AppBarButton;
 
-			// CommandBarExtensions.BackButtonForeground
-			ColorHelper.TryGetColorWithOpacity(mainCommand?.Foreground, out var backButtonForeground);
-			Native.TintColor = backButtonForeground;
+			// MainCommand.Foreground
+			ColorHelper.TryGetColorWithOpacity(mainCommand?.Foreground, out var mainCommandForeground);
+			Native.TintColor = mainCommandForeground;
+
+			// MainCommand.Icon
+			var mainCommandIcon = mainCommand?.Icon is BitmapIcon bitmapIcon
+				? ImageHelper.FromUri(bitmapIcon.UriSource)?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal)
+				: null;
+
+			if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+			{
+				var backButtonAppearance = new UIBarButtonItemAppearance(UIBarButtonItemStyle.Plain);
+
+				if (mainCommandForeground is { } foreground)
+				{
+					var titleTextAttributes = new UIStringAttributes
+					{
+						ForegroundColor = foreground
+					};
+
+					var attributes = new NSDictionary<NSString, NSObject>(
+						new NSString[] { titleTextAttributes.Dictionary.Keys[0] as NSString }, titleTextAttributes.Dictionary.Values
+					);
+
+					backButtonAppearance.Normal.TitleTextAttributes = attributes;
+					backButtonAppearance.Highlighted.TitleTextAttributes = attributes;
+
+					if (mainCommandIcon is { } image)
+					{
+						var tintedImage = image.ApplyTintColor(foreground);
+						appearance.SetBackIndicatorImage(tintedImage, tintedImage);
+					}
+				}
+				else
+				{
+					if (mainCommandIcon is { } image)
+					{
+						appearance.SetBackIndicatorImage(image, image);
+					}
+				}
+
+				appearance.BackButtonAppearance = backButtonAppearance;
+			}
+			else
+			{
+				Native.BackIndicatorImage = mainCommandIcon;
+				Native.BackIndicatorTransitionMaskImage = mainCommandIcon;
+			}
+
+			Native.CompactAppearance = appearance;
+			Native.StandardAppearance = appearance;
+			Native.ScrollEdgeAppearance = appearance;
 		}
 
 		private void ApplyVisibility()

--- a/src/Uno.Toolkit.UITest/Constants.cs
+++ b/src/Uno.Toolkit.UITest/Constants.cs
@@ -14,6 +14,6 @@ namespace Uno.Toolkit.UITest
         public readonly static string AndroidAppName = "Uno.Toolkit.Samples";
         public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";
 
-        public readonly static Platform CurrentPlatform = Platform.Browser;
+        public readonly static Platform CurrentPlatform = Platform.Android;
     }
 }

--- a/src/Uno.Toolkit.UITest/NavigationBar/Given_NavigationBar.cs
+++ b/src/Uno.Toolkit.UITest/NavigationBar/Given_NavigationBar.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Uno.UITest;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
+
+namespace Uno.Toolkit.UITest.NavigationBar
+{
+
+	public class Given_NavigationBar : TestBase
+	{
+		[SetUp]
+		public override void SetUpTest()
+		{
+			if (AppInitializer.GetLocalPlatform() != Platform.Android
+				&& AppInitializer.GetLocalPlatform() != Platform.iOS)
+			{
+				Assert.Ignore("Test is only valid for iOS and Android");
+			}
+
+			base.SetUpTest();
+			NavigateToSample("NavigationBar");
+		}
+
+		[Test]
+		public void NavBar_Has_Size()
+		{
+			App.WaitThenTap("NavigationBar_Launch_Sample_Button");
+
+			var nativeBar = PlatformHelpers.On<IAppResult>(
+				iOS: () => App.CreateQuery(x => x.WithClass("navigationBar")).FirstResult(),
+				Android: () => App.Marked("Page1NavBar").Descendant("Toolbar").FirstResult()
+			);
+
+			Assert.NotZero(nativeBar.Rect.Height);
+			Assert.NotZero(nativeBar.Rect.Width);
+		}
+
+		[Test]
+		public void NavBar_Has_Title()
+		{
+			App.WaitThenTap("NavigationBar_Launch_Sample_Button");
+
+			var title = PlatformHelpers.On<IAppResult>(
+				iOS: () => App.CreateQuery(x => x.WithClass("navigationBar").Descendant("label")).FirstResult(),
+				Android: () => App.Marked("Page1NavBar").Descendant("AppCompatTextView").FirstResult()
+			);
+
+			Assert.AreEqual("First Page", title.Text);
+		}
+
+		[Test]
+		public void NavBar_Can_Close_From_First_Page()
+		{
+			App.WaitThenTap("NavigationBar_Launch_Sample_Button");
+
+			App.WaitForElement("Page1NavBar", "Timed out waiting for Page 1 Nav Bar");
+
+			PlatformHelpers.On(
+				iOS: () => App.Tap("CloseIcon"),
+				Android: () => App.Tap(q => q.Marked("Page1NavBar").Descendant("AppCompatImageButton"))
+			);
+			;
+
+			PlatformHelpers.On(
+				iOS: () => App.WaitForNoElement(q => q.Class("navigationBar"), "Timed out waiting for Nav Bar"),
+				Android: () => App.WaitForNoElement("Page1NavBar", "Timed out waiting for Nav Bar")
+			);
+		}
+
+		[Test]
+		public void NavBar_Page2_NavBar_Exists()
+		{
+			App.WaitThenTap("NavigationBar_Launch_Sample_Button");
+
+			App.WaitForNoElement("Page2NavBar", "Timed out waiting for no Page 2 Nav Bar");
+
+			App.Tap("Page1_Navigate_To_Page2");
+
+			App.WaitForElement("Page2NavBar", "Timed out waiting for Page 2 Nav Bar");
+
+			var nativeBar = PlatformHelpers.On<IAppResult>(
+				iOS: () => App.CreateQuery(x => x.WithClass("navigationBar")).FirstResult(),
+				Android: () => App.Marked("Page1NavBar").Descendant("Toolbar").FirstResult()
+			);
+
+			Assert.NotZero(nativeBar.Rect.Height);
+			Assert.NotZero(nativeBar.Rect.Width);
+		}
+
+		[Test]
+		public void NavBar_Page_Can_Go_Back()
+		{
+			App.WaitThenTap("NavigationBar_Launch_Sample_Button");
+
+			App.WaitForNoElement("Page2NavBar", "Timed out waiting for no Page 2 Nav Bar");
+
+			App.Tap("Page1_Navigate_To_Page2");
+
+			App.WaitForElement("Page2NavBar", "Timed out waiting for Page 2 Nav Bar");
+
+			PlatformHelpers.On(
+				iOS: () => App.Tap("BackButton"),
+				Android: () => App.Tap(q => q.Marked("Page2NavBar").Descendant("AppCompatImageButton"))
+			);
+
+			App.WaitForNoElement("Page2NavBar", "Timed out waiting for no Page 2 Nav Bar");
+		}
+
+		private IAppResult GetNativeBar()
+		{
+			return PlatformHelpers.On<IAppResult>(
+				iOS: () => App.CreateQuery(x => x.WithClass("navigationBar")).FirstResult(),
+				Android: () => App.Marked("Page1NavBar").Descendant("Toolbar").FirstResult()
+			);
+		}
+			
+	}
+}

--- a/src/library/Uno.Toolkit.Cupertino/Generated/mergedpages.uwp.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Generated/mergedpages.uwp.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d ios android wasm not_win" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:utu="using:Uno.Toolkit.UI" xmlns:android="http://uno.ui/android" xmlns:ios="http://uno.ui/ios" xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:not_win="http://uno.ui/not_win" xmlns:wasm="http://uno.ui/wasm" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:toolkit="using:Uno.UI.Toolkit" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d mobile ios android wasm not_win" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mobile="http://uno.ui/mobile" xmlns:utu="using:Uno.Toolkit.UI" xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:android="http://uno.ui/android" xmlns:ios="http://uno.ui/ios" xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:not_win="http://uno.ui/not_win" xmlns:wasm="http://uno.ui/wasm" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:toolkit="using:Uno.UI.Toolkit" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Default">
       <Color x:Key="CupertinoInactiveColor">#757575</Color>
@@ -55,7 +55,7 @@
   <Thickness x:Key="TabBarItemContentMargin">0,0,0,12</Thickness>
   <Thickness x:Key="TabBarItemContentOnlyMargin">12,0</Thickness>
   <!--origin: Styles\Controls\BottomTabBar.Mobile.xaml-->
-  <Style x:Key="CupertinoBottomTabBarStyle" TargetType="utu:TabBar">
+  <mobile:Style x:Key="CupertinoBottomTabBarStyle" TargetType="utu:TabBar">
     <Setter Property="Background" Value="{ThemeResource CupertinoTabBarBackground}" />
     <Setter Property="IsTabStop" Value="False" />
     <Setter Property="BorderBrush" Value="{ThemeResource CupertinoTabBarBorderBrush}" />
@@ -76,8 +76,8 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-  </Style>
-  <Style x:Key="CupertinoSegmentedStyle" TargetType="utu:TabBar">
+  </mobile:Style>
+  <mobile:Style x:Key="CupertinoSegmentedStyle" TargetType="utu:TabBar">
     <Setter Property="Background" Value="{ThemeResource CupertinoSystemBackgroundBrush}" />
     <Setter Property="IsTabStop" Value="False" />
     <Setter Property="BorderBrush" Value="{ThemeResource CupertinoBlueBrush}" />
@@ -100,8 +100,99 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-  </Style>
-  <Style x:Key="CupertinoBottomTabBarItemStyle" TargetType="utu:TabBarItem">
+  </mobile:Style>
+  <mobile:Style x:Key="CupertinoBottomTabBarItemStyle" TargetType="utu:TabBarItem">
+    <Setter Property="Background" Value="{ThemeResource TabBarItemBackground}" />
+    <Setter Property="Foreground" Value="{ThemeResource TabBarItemForeground}" />
+    <Setter Property="BorderBrush" Value="{ThemeResource TabBarItemBorderBrush}" />
+    <Setter Property="FontFamily" Value="{StaticResource CupertinoTabBarFontFamily}" />
+    <Setter Property="FontSize" Value="{StaticResource CupertinoTabBarFontSize}" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="UseSystemFocusVisuals" Value="True" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="utu:TabBarItem">
+          <Grid x:Name="LayoutRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Control.IsTemplateFocusTarget="True">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="PointerStates">
+                <VisualState x:Name="Normal" />
+                <VisualState x:Name="Selected">
+                  <VisualState.Setters>
+                    <Setter Target="LayoutRoot.Background" Value="{ThemeResource TabBarItemBackgroundSelected}" />
+                    <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TabBarItemBackgroundSelected}" />
+                    <Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundSelected}" />
+                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundSelected}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="DisabledStates">
+                <VisualState x:Name="Enabled" />
+                <VisualState x:Name="Disabled">
+                  <VisualState.Setters>
+                    <Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundDisabled}" />
+                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundDisabled}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="TabBarIconPositionStates">
+                <VisualState x:Name="IconOnTop" />
+                <VisualState x:Name="IconOnly">
+                  <VisualState.Setters>
+                    <Setter Target="PointerRectangle.Visibility" Value="Visible" />
+                    <Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="ContentOnly">
+                  <VisualState.Setters>
+                    <Setter Target="IconBox.Visibility" Value="Collapsed" />
+                    <Setter Target="ContentPresenter.Margin" Value="{StaticResource TabBarItemContentOnlyMargin}" />
+                    <Setter Target="IconRow.Height" Value="0" />
+                    <Setter Target="ContentRow.Height" Value="*" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Rectangle x:Name="PointerRectangle" Fill="Transparent" Visibility="Collapsed" />
+            <Grid x:Name="ContentGrid">
+              <Grid.RowDefinitions>
+                <RowDefinition x:Name="IconRow" Height="*" />
+                <RowDefinition x:Name="ContentRow" Height="Auto" />
+              </Grid.RowDefinitions>
+              <Viewbox x:Name="IconBox" Height="{StaticResource TabBarItemIconHeight}" Width="{StaticResource TabBarItemIconWidth}">
+                <ContentPresenter x:Name="Icon" Content="{TemplateBinding Icon}" Foreground="{TemplateBinding Foreground}" />
+              </Viewbox>
+              <ContentPresenter x:Name="ContentPresenter" Grid.Row="1" TextWrapping="NoWrap" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" Margin="{StaticResource TabBarItemContentMargin}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
+            </Grid>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </mobile:Style>
+  <!--origin: Styles\Controls\BottomTabBar.xaml-->
+  <not_mobile:Style x:Key="CupertinoBottomTabBarStyle" TargetType="utu:TabBar">
+    <Setter Property="Background" Value="{ThemeResource CupertinoTabBarBackground}" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="BorderBrush" Value="{ThemeResource CupertinoTabBarBorderBrush}" />
+    <Setter Property="ItemsPanel">
+      <Setter.Value>
+        <ItemsPanelTemplate>
+          <utu:TabBarListPanel />
+        </ItemsPanelTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="ItemContainerStyle" Value="{StaticResource CupertinoBottomTabBarItemStyle}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="utu:TabBar">
+          <Grid x:Name="TabBarGrid" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}">
+            <ItemsPresenter Height="{StaticResource TabBarHeight}" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </not_mobile:Style>
+  <not_mobile:Style x:Key="CupertinoBottomTabBarItemStyle" TargetType="utu:TabBarItem">
     <Setter Property="Background" Value="{ThemeResource TabBarItemBackground}" />
     <Setter Property="Foreground" Value="{ThemeResource TabBarItemForeground}" />
     <Setter Property="BorderBrush" Value="{ThemeResource TabBarItemBorderBrush}" />
@@ -200,12 +291,105 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-  </Style>
-  <!--origin: Styles\Controls\BottomTabBar.xaml-->
+  </not_mobile:Style>
   <!--origin: Styles\Controls\SegmentedControl.Base.xaml-->
   <SolidColorBrush x:Key="CupertinoTabBarItemBackgroundPressed" Color="{ThemeResource CupertinoBlueColor}" Opacity="0.2" />
   <!--origin: Styles\Controls\SegmentedControl.Mobile.xaml-->
-  <Style x:Key="CupertinoSegmentedItemStyle" TargetType="utu:TabBarItem">
+  <mobile:Style x:Key="CupertinoSegmentedItemStyle" TargetType="utu:TabBarItem">
+    <Setter Property="Background" Value="{ThemeResource TabBarItemBackground}" />
+    <Setter Property="BorderBrush" Value="{ThemeResource TabBarItemBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="FontFamily" Value="{StaticResource CupertinoTabBarFontFamily}" />
+    <Setter Property="FontSize" Value="{StaticResource CupertinoTabBarFontSize}" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="Foreground" Value="{ThemeResource TabBarItemForeground}" />
+    <Setter Property="UseSystemFocusVisuals" Value="True" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="utu:TabBarItem">
+          <Grid x:Name="LayoutRoot" Background="Transparent" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Control.IsTemplateFocusTarget="True">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="PointerStates">
+                <VisualState x:Name="Normal" />
+                <VisualState x:Name="Selected">
+                  <VisualState.Setters>
+                    <Setter Target="LayoutRoot.Background" Value="{ThemeResource TabBarItemBackgroundSelected}" />
+                    <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TabBarItemBackgroundSelected}" />
+                    <Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundSelected}" />
+                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundSelected}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="DisabledStates">
+                <VisualState x:Name="Enabled" />
+                <VisualState x:Name="Disabled">
+                  <VisualState.Setters>
+                    <Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundDisabled}" />
+                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundDisabled}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="TabBarIconPositionStates">
+                <VisualState x:Name="IconOnTop" />
+                <VisualState x:Name="IconOnly">
+                  <VisualState.Setters>
+                    <Setter Target="PointerRectangle.Visibility" Value="Visible" />
+                    <Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="ContentOnly">
+                  <VisualState.Setters>
+                    <Setter Target="IconBox.Visibility" Value="Collapsed" />
+                    <Setter Target="ContentPresenter.Margin" Value="{StaticResource TabBarItemContentOnlyMargin}" />
+                    <Setter Target="IconRow.Width" Value="0" />
+                    <Setter Target="ContentRow.Width" Value="*" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Rectangle x:Name="PointerRectangle" Fill="Transparent" Visibility="Collapsed" />
+            <Grid x:Name="ContentGrid">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="IconRow" Width="*" />
+                <ColumnDefinition x:Name="ContentRow" Width="Auto" />
+              </Grid.ColumnDefinitions>
+              <Viewbox x:Name="IconBox" Height="{StaticResource TabBarItemIconHeight}" Width="{StaticResource TabBarItemIconWidth}">
+                <ContentPresenter x:Name="Icon" Content="{TemplateBinding Icon}" />
+              </Viewbox>
+              <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" TextWrapping="NoWrap" FontSize="{TemplateBinding FontSize}" Margin="{StaticResource TabBarItemContentMargin}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
+            </Grid>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </mobile:Style>
+  <!--origin: Styles\Controls\SegmentedControl.xaml-->
+  <not_mobile:Style x:Key="CupertinoSegmentedStyle" TargetType="utu:TabBar">
+    <Setter Property="Background" Value="{ThemeResource CupertinoSystemBackgroundBrush}" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="BorderBrush" Value="{ThemeResource CupertinoBlueBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Height" Value="{StaticResource TabBarHeight}" />
+    <Setter Property="ItemsPanel">
+      <Setter.Value>
+        <ItemsPanelTemplate>
+          <utu:TabBarListPanel />
+        </ItemsPanelTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="ItemContainerStyle" Value="{StaticResource CupertinoSegmentedItemStyle}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="utu:TabBar">
+          <Grid x:Name="TabBarGrid" CornerRadius="3" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Height="{TemplateBinding Height}">
+            <ItemsPresenter Padding="0" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </not_mobile:Style>
+  <not_mobile:Style x:Key="CupertinoSegmentedItemStyle" TargetType="utu:TabBarItem">
     <Setter Property="Background" Value="{ThemeResource TabBarItemBackground}" />
     <Setter Property="BorderBrush" Value="{ThemeResource TabBarItemBorderBrush}" />
     <Setter Property="BorderThickness" Value="1" />
@@ -305,13 +489,12 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-  </Style>
-  <!--origin: Styles\Controls\SegmentedControl.xaml-->
+  </not_mobile:Style>
   <!--origin: Styles\Controls\SlidingSegmentedControl.Base.xaml-->
   <SolidColorBrush x:Key="CupertinoTabBarItemForegroundPressed" Color="{ThemeResource LabelColor}" Opacity="0.2" />
   <utu:InflateDimensionConverter x:Key="DeflateWidthConverter" Inflation="-4" />
   <!--origin: Styles\Controls\SlidingSegmentedControl.Mobile.xaml-->
-  <Style x:Key="CupertinoSlidingSegmentedStyle" TargetType="utu:TabBar">
+  <mobile:Style x:Key="CupertinoSlidingSegmentedStyle" TargetType="utu:TabBar">
     <Setter Property="Background" Value="{ThemeResource CupertinoTertiarySystemFillBrush}" />
     <Setter Property="IsTabStop" Value="False" />
     <Setter Property="Height" Value="{StaticResource TabBarHeight}" />
@@ -337,8 +520,77 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-  </Style>
-  <Style x:Key="CupertinoSlidingSegmentedItemStyle" TargetType="utu:TabBarItem">
+  </mobile:Style>
+  <mobile:Style x:Key="CupertinoSlidingSegmentedItemStyle" TargetType="utu:TabBarItem">
+    <Setter Property="Background" Value="{ThemeResource TabBarItemBackground}" />
+    <Setter Property="BorderBrush" Value="{ThemeResource TabBarItemBorderBrush}" />
+    <Setter Property="FontFamily" Value="{StaticResource CupertinoTabBarFontFamily}" />
+    <Setter Property="FontSize" Value="{StaticResource CupertinoTabBarFontSize}" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="UseSystemFocusVisuals" Value="True" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="CornerRadius" Value="6" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="utu:TabBarItem">
+          <Grid x:Name="LayoutRoot" Background="Transparent" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}" Control.IsTemplateFocusTarget="True">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="PointerStates">
+                <VisualState x:Name="Normal" />
+                <VisualState x:Name="Selected">
+                  <VisualState.Setters>
+                    <Setter Target="LayoutRoot.Background" Value="{ThemeResource TabBarItemBackgroundSelected}" />
+                    <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TabBarItemBackgroundSelected}" />
+                    <Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundSelected}" />
+                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundSelected}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="DisabledStates">
+                <VisualState x:Name="Enabled" />
+                <VisualState x:Name="Disabled">
+                  <VisualState.Setters>
+                    <Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundDisabled}" />
+                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundDisabled}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="TabBarIconPositionStates">
+                <VisualState x:Name="IconOnTop" />
+                <VisualState x:Name="IconOnly">
+                  <VisualState.Setters>
+                    <Setter Target="PointerRectangle.Visibility" Value="Visible" />
+                    <Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="ContentOnly">
+                  <VisualState.Setters>
+                    <Setter Target="IconBox.Visibility" Value="Collapsed" />
+                    <Setter Target="ContentPresenter.Margin" Value="{StaticResource TabBarItemContentOnlyMargin}" />
+                    <Setter Target="IconRow.Width" Value="0" />
+                    <Setter Target="ContentRow.Width" Value="*" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Rectangle x:Name="PointerRectangle" Fill="Transparent" Visibility="Collapsed" />
+            <Grid x:Name="ContentGrid">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="IconRow" Width="*" />
+                <ColumnDefinition x:Name="ContentRow" Width="Auto" />
+              </Grid.ColumnDefinitions>
+              <Viewbox x:Name="IconBox" Height="{StaticResource TabBarItemIconHeight}" Width="{StaticResource TabBarItemIconWidth}">
+                <ContentPresenter x:Name="Icon" Content="{TemplateBinding Icon}" />
+              </Viewbox>
+              <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" TextWrapping="NoWrap" FontSize="{TemplateBinding FontSize}" Margin="{StaticResource TabBarItemContentMargin}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
+            </Grid>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </mobile:Style>
+  <!--origin: Styles\Controls\SlidingSegmentedControl.xaml-->
+  <not_mobile:Style x:Key="CupertinoSlidingSegmentedItemStyle" TargetType="utu:TabBarItem">
     <Setter Property="Background" Value="{ThemeResource TabBarItemBackground}" />
     <Setter Property="BorderBrush" Value="{ThemeResource TabBarItemBorderBrush}" />
     <Setter Property="FontFamily" Value="{StaticResource CupertinoTabBarFontFamily}" />
@@ -437,6 +689,32 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-  </Style>
-  <!--origin: Styles\Controls\SlidingSegmentedControl.xaml-->
+  </not_mobile:Style>
+  <not_mobile:Style x:Key="CupertinoSlidingSegmentedStyle" TargetType="utu:TabBar">
+    <Setter Property="Background" Value="{ThemeResource CupertinoTertiarySystemFillBrush}" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="Height" Value="{StaticResource TabBarHeight}" />
+    <Setter Property="ItemsPanel">
+      <Setter.Value>
+        <ItemsPanelTemplate>
+          <utu:TabBarListPanel />
+        </ItemsPanelTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="ItemContainerStyle" Value="{StaticResource CupertinoSlidingSegmentedItemStyle}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="utu:TabBar">
+          <Grid x:Name="TabBarGrid" CornerRadius="8" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Height="{TemplateBinding Height}">
+            <utu:TabBarSelectionIndicatorPresenter Owner="{Binding RelativeSource={RelativeSource TemplatedParent}}" x:Name="SelectionIndicatorPresenter" AutomationProperties.AutomationId="SelectionIndicatorPresenter" IndicatorTransitionMode="Slide" Opacity="0">
+              <toolkit:ElevatedView Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}" Height="28" Background="Transparent" CornerRadius="8" Elevation="5" ShadowColor="#CC94949A">
+                <Rectangle Fill="{ThemeResource SystemBackgroundColor}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" RadiusX="8" RadiusY="8" Height="24" Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth, Converter={StaticResource DeflateWidthConverter}}" />
+              </toolkit:ElevatedView>
+            </utu:TabBarSelectionIndicatorPresenter>
+            <ItemsPresenter Padding="{TemplateBinding Padding}" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </not_mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/BottomTabBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/BottomTabBar.Mobile.xaml
@@ -1,12 +1,13 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:mobile="http://uno.ui/mobile" 
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:utu="using:Uno.Toolkit.UI"
-					mc:Ignorable="d">
+					mc:Ignorable="d mobile">
 
 	<!-- Cupertino Bottom TabBar -->
-	<Style x:Key="CupertinoBottomTabBarStyle"
+	<mobile:Style x:Key="CupertinoBottomTabBarStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoTabBarBackground}" />
@@ -36,9 +37,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 
-	<Style x:Key="CupertinoSegmentedStyle"
+    <mobile:Style x:Key="CupertinoSegmentedStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoSystemBackgroundBrush}" />
@@ -73,9 +74,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 
-	<Style x:Key="CupertinoBottomTabBarItemStyle"
+    <mobile:Style x:Key="CupertinoBottomTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource TabBarItemBackground}" />
@@ -189,5 +190,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/BottomTabBar.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/BottomTabBar.xaml
@@ -2,11 +2,12 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="d">
 
 	<!-- Cupertino Bottom TabBar -->
-	<Style x:Key="CupertinoBottomTabBarStyle"
+    <not_mobile:Style x:Key="CupertinoBottomTabBarStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoTabBarBackground}" />
@@ -36,9 +37,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 
-	<Style x:Key="CupertinoBottomTabBarItemStyle"
+    <not_mobile:Style x:Key="CupertinoBottomTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource TabBarItemBackground}" />
@@ -200,5 +201,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.Mobile.xaml
@@ -8,10 +8,11 @@
 					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:wasm="http://uno.ui/wasm"
+                    xmlns:mobile="http://uno.ui/mobile"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					mc:Ignorable="d ios android wasm not_win">
+					mc:Ignorable="d ios android wasm not_win mobile">
 
-	<Style x:Key="CupertinoSegmentedStyle"
+	<mobile:Style x:Key="CupertinoSegmentedStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoSystemBackgroundBrush}" />
@@ -46,9 +47,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 
-	<Style x:Key="CupertinoSegmentedItemStyle"
+	<mobile:Style x:Key="CupertinoSegmentedItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource TabBarItemBackground}" />
@@ -162,5 +163,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SegmentedControl.xaml
@@ -8,10 +8,11 @@
 					xmlns:not_win="http://uno.ui/not_win"
 					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:wasm="http://uno.ui/wasm"
+                    xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					mc:Ignorable="d ios android wasm not_win">
 
-	<Style x:Key="CupertinoSegmentedStyle"
+    <not_mobile:Style x:Key="CupertinoSegmentedStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoSystemBackgroundBrush}" />
@@ -46,9 +47,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 
-	<Style x:Key="CupertinoSegmentedItemStyle"
+    <not_mobile:Style x:Key="CupertinoSegmentedItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource TabBarItemBackground}" />
@@ -210,5 +211,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.Mobile.xaml
@@ -9,11 +9,12 @@
 					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:wasm="http://uno.ui/wasm"
+                    xmlns:mobile="http://uno.ui/mobile"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					mc:Ignorable="d ios android wasm not_win">
+					mc:Ignorable="d ios android wasm not_win mobile">
 
 	<!-- Styles -->
-	<Style x:Key="CupertinoSlidingSegmentedStyle"
+    <mobile:Style x:Key="CupertinoSlidingSegmentedStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoTertiarySystemFillBrush}" />
@@ -65,9 +66,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 
-	<Style x:Key="CupertinoSlidingSegmentedItemStyle"
+    <mobile:Style x:Key="CupertinoSlidingSegmentedItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource TabBarItemBackground}" />
@@ -180,5 +181,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
@@ -9,10 +9,11 @@
 					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
+                    xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					mc:Ignorable="d ios android wasm not_win">
 
-	<Style x:Key="CupertinoSlidingSegmentedItemStyle"
+    <not_mobile:Style x:Key="CupertinoSlidingSegmentedItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource TabBarItemBackground}" />
@@ -173,10 +174,10 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 
 	<!-- Styles -->
-	<Style x:Key="CupertinoSlidingSegmentedStyle"
+    <not_mobile:Style x:Key="CupertinoSlidingSegmentedStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoTertiarySystemFillBrush}" />
@@ -228,5 +229,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.UI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.UI.Cupertino.csproj
@@ -22,6 +22,21 @@
 		<XamlMergeOutputFile>Generated\mergedpages.uwp.xaml</XamlMergeOutputFile>
 	</PropertyGroup>
 
+	<Choose>
+		<When Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='monoandroid11.0'">
+			<ItemGroup>
+				<IncludeXamlNamespaces Include="mobile" />
+				<ExcludeXamlNamespaces Include="not_mobile" />
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<IncludeXamlNamespaces Include="not_mobile" />
+				<ExcludeXamlNamespaces Include="mobile" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
+
 	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 		<PackageReference Include="Microsoft.UI.Xaml" Version="2.6.0-prerelease.210623001" />
 	</ItemGroup>

--- a/src/library/Uno.Toolkit.Cupertino/xamlmerge.props
+++ b/src/library/Uno.Toolkit.Cupertino/xamlmerge.props
@@ -2,7 +2,7 @@
 <Project>
 
 	<PropertyGroup>
-		<_Uno_XamlMerge_Task_Version>0.1.0-dev.46</_Uno_XamlMerge_Task_Version>
+		<_Uno_XamlMerge_Task_Version>0.1.0-dev.51</_Uno_XamlMerge_Task_Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Uno.XamlMerge.Task" Version="$(_Uno_XamlMerge_Task_Version)" />

--- a/src/library/Uno.Toolkit.Material/Generated/mergedpages.uwp.xaml
+++ b/src/library/Uno.Toolkit.Material/Generated/mergedpages.uwp.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d not_win android ios wasm macos" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:um="using:Uno.Material" xmlns:toolkit="using:Uno.UI.Toolkit" xmlns:utu="using:Uno.Toolkit.UI" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:not_win="http://uno.ui/not_win" xmlns:android="http://uno.ui/android" xmlns:ios="http://uno.ui/ios" xmlns:wasm="http://uno.ui/wasm" xmlns:macos="http://uno.ui/macos" xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)" xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)" xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)" xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)" xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)" xmlns:contract12Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,12)" xmlns:contract12NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,12)" xmlns:contract6NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,6)" xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d not_win android ios wasm macos mobile" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:um="using:Uno.Material" xmlns:toolkit="using:Uno.UI.Toolkit" xmlns:utu="using:Uno.Toolkit.UI" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:not_win="http://uno.ui/not_win" xmlns:android="http://uno.ui/android" xmlns:ios="http://uno.ui/ios" xmlns:wasm="http://uno.ui/wasm" xmlns:macos="http://uno.ui/macos" xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)" xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)" xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)" xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)" xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)" xmlns:contract12Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,12)" xmlns:contract12NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,12)" xmlns:contract6NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,6)" xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)" xmlns:mobile="http://uno.ui/mobile" xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="ms-appx:///Uno.Toolkit.UI.Material/Styles/Application/Colors.xaml" />
   </ResourceDictionary.MergedDictionaries>
@@ -1756,8 +1756,7 @@
   <Thickness x:Key="MaterialNavigationBarContentMargin">16,0,0,0</Thickness>
   <Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
   <ios:ControlTemplate x:Key="NativeNavigationBarTemplate" TargetType="utu:NavigationBar">
-    <!-- We use BorderBrush instead of Background to ensure that semi-transparent background of Grid and NativeCommandBarPresenter don't add up -->
-    <Border BorderBrush="{TemplateBinding Background}" BorderThickness="{TemplateBinding Padding}" Background="{TemplateBinding Background}">
+    <Border BorderThickness="{TemplateBinding Padding}">
       <utu:NativeNavigationBarPresenter Height="44" x:Name="NavigationBarPresenter" />
     </Border>
   </ios:ControlTemplate>
@@ -1965,7 +1964,7 @@
                   <ColumnDefinition x:Name="ContentControlColumnDefinition" Width="*" />
                   <ColumnDefinition x:Name="PrimaryItemsControlColumnDefinition" Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <ContentPresenter x:Name="MainCommandPresenter" Content="{Binding Path=(utu:CommandBarExtensions.MainCommand), RelativeSource={RelativeSource TemplatedParent}}">
+                <ContentPresenter x:Name="MainCommandPresenter" Margin="{TemplateBinding Padding}" Content="{Binding Path=(utu:CommandBarExtensions.MainCommand), RelativeSource={RelativeSource TemplatedParent}}">
                   <ContentPresenter.Resources>
                     <x:Double x:Key="AppBarButtonContentHeight">16</x:Double>
                   </ContentPresenter.Resources>
@@ -2082,7 +2081,6 @@
     <Setter Property="Foreground" Value="{StaticResource MaterialOnPrimaryBrush}" />
     <android:Setter Property="(toolkit:UIElementExtensions.Elevation)" Value="{StaticResource MaterialNavigationBarElevation}" />
     <Setter Property="Height" Value="{StaticResource MaterialNavigationBarHeight}" />
-    <Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
     <Setter Property="Padding" Value="16,0,0,0" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Top" />
@@ -2104,27 +2102,41 @@
     <Setter Property="Foreground" Value="{ThemeResource MaterialOnSurfaceBrush}" />
   </Style>
   <!--origin: Styles\Controls\NavigationBar.Mobile.xaml-->
-  <Style x:Key="MaterialMainCommandStyle" TargetType="AppBarButton" BasedOn="{StaticResource BaseMaterialMainCommandStyle}">
-    <Setter Property="Icon">
-      <Setter.Value>
-        <SymbolIcon Symbol="Back" />
-      </Setter.Value>
-    </Setter>
-  </Style>
-  <Style x:Key="MaterialModalMainCommandStyle" TargetType="AppBarButton" BasedOn="{StaticResource BaseMaterialModalMainCommandStyle}">
-    <Setter Property="Icon">
-      <Setter.Value>
-        <SymbolIcon Symbol="Back" />
-      </Setter.Value>
-    </Setter>
-  </Style>
-  <Style x:Key="MaterialNavigationBarStyle" TargetType="utu:NavigationBar" BasedOn="{StaticResource BaseMaterialNavigationBarStyle}">
+  <mobile:Style x:Key="MaterialMainCommandStyle" BasedOn="{StaticResource BaseMaterialMainCommandStyle}" TargetType="AppBarButton" />
+  <mobile:Style x:Key="MaterialModalMainCommandStyle" BasedOn="{StaticResource BaseMaterialModalMainCommandStyle}" TargetType="AppBarButton" />
+  <mobile:Style x:Key="MaterialNavigationBarStyle" BasedOn="{StaticResource BaseMaterialNavigationBarStyle}" TargetType="utu:NavigationBar">
+    <ios:Setter Property="Height" Value="NaN" />
     <Setter Property="MainCommandStyle" Value="{StaticResource MaterialMainCommandStyle}" />
-  </Style>
-  <Style x:Key="MaterialModalNavigationBarStyle" TargetType="utu:NavigationBar" BasedOn="{StaticResource BaseMaterialModalNavigationBarStyle}">
+    <Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
+    <Setter Property="Template" Value="{StaticResource NativeNavigationBarTemplate}" />
+  </mobile:Style>
+  <mobile:Style x:Key="MaterialModalNavigationBarStyle" BasedOn="{StaticResource BaseMaterialModalNavigationBarStyle}" TargetType="utu:NavigationBar">
+    <ios:Setter Property="Height" Value="NaN" />
+    <Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
     <Setter Property="MainCommandStyle" Value="{StaticResource MaterialModalMainCommandStyle}" />
-  </Style>
+    <Setter Property="Template" Value="{StaticResource NativeNavigationBarTemplate}" />
+  </mobile:Style>
   <!--origin: Styles\Controls\NavigationBar.xaml-->
+  <not_mobile:Style x:Key="MaterialMainCommandStyle" TargetType="AppBarButton" BasedOn="{StaticResource BaseMaterialMainCommandStyle}">
+    <Setter Property="Icon">
+      <Setter.Value>
+        <SymbolIcon Symbol="Back" />
+      </Setter.Value>
+    </Setter>
+  </not_mobile:Style>
+  <not_mobile:Style x:Key="MaterialNavigationBarStyle" TargetType="utu:NavigationBar" BasedOn="{StaticResource BaseMaterialNavigationBarStyle}">
+    <Setter Property="MainCommandStyle" Value="{StaticResource MaterialMainCommandStyle}" />
+  </not_mobile:Style>
+  <not_mobile:Style x:Key="MaterialModalMainCommandStyle" TargetType="AppBarButton" BasedOn="{StaticResource BaseMaterialModalMainCommandStyle}">
+    <Setter Property="Icon">
+      <Setter.Value>
+        <SymbolIcon Symbol="Back" />
+      </Setter.Value>
+    </Setter>
+  </not_mobile:Style>
+  <not_mobile:Style x:Key="MaterialModalNavigationBarStyle" TargetType="utu:NavigationBar" BasedOn="{StaticResource BaseMaterialModalNavigationBarStyle}">
+    <Setter Property="MainCommandStyle" Value="{StaticResource MaterialModalMainCommandStyle}" />
+  </not_mobile:Style>
   <!--origin: Styles\Controls\TopTabBar.Base.xaml-->
   <x:Double x:Key="MaterialTabBarSelectionMinWidthIndicator">120</x:Double>
   <!--origin: Styles\Controls\TopTabBar.Mobile.xaml-->

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Base.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Base.xaml
@@ -26,10 +26,7 @@
 
 	<ios:ControlTemplate x:Key="NativeNavigationBarTemplate"
 						 TargetType="utu:NavigationBar">
-		<!-- We use BorderBrush instead of Background to ensure that semi-transparent background of Grid and NativeCommandBarPresenter don't add up -->
-		<Border BorderBrush="{TemplateBinding Background}"
-				BorderThickness="{TemplateBinding Padding}"
-				Background="{TemplateBinding Background}">
+		<Border BorderThickness="{TemplateBinding Padding}">
 			<utu:NativeNavigationBarPresenter Height="44"
 											  x:Name="NavigationBarPresenter" />
 		</Border>
@@ -568,11 +565,9 @@
 				Value="{StaticResource MaterialOnPrimaryBrush}" />
 		<android:Setter Property="(toolkit:UIElementExtensions.Elevation)"
 						Value="{StaticResource MaterialNavigationBarElevation}" />
-		<Setter Property="Height"
+        <Setter Property="Height"
 				Value="{StaticResource MaterialNavigationBarHeight}" />
-		<Setter Property="toolkit:VisibleBoundsPadding.PaddingMask"
-				Value="Top" />
-		<Setter Property="Padding"
+        <Setter Property="Padding"
 				Value="16,0,0,0" />
 		<Setter Property="HorizontalAlignment"
 				Value="Stretch" />

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.Mobile.xaml
@@ -1,43 +1,40 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:utu="using:Uno.Toolkit.UI"
-					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:android="http://uno.ui/android"
-					xmlns:ios="http://uno.ui/ios"
-					mc:Ignorable="android ios">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:android="http://uno.ui/android"
+                    xmlns:ios="http://uno.ui/ios"
+                    xmlns:mobile="http://uno.ui/mobile" 
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:toolkit="using:Uno.UI.Toolkit"
+                    xmlns:utu="using:Uno.Toolkit.UI"
+                    mc:Ignorable="android ios mobile">
 
-	<Style x:Key="MaterialMainCommandStyle"
-		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource BaseMaterialMainCommandStyle}" />
+    <mobile:Style x:Key="MaterialMainCommandStyle"
+           BasedOn="{StaticResource BaseMaterialMainCommandStyle}"
+           TargetType="AppBarButton" />
 
-    <Style x:Key="MaterialModalMainCommandStyle"
-		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource BaseMaterialModalMainCommandStyle}" />
+    <mobile:Style x:Key="MaterialModalMainCommandStyle"
+           BasedOn="{StaticResource BaseMaterialModalMainCommandStyle}"
+           TargetType="AppBarButton" />
 
-    <Style x:Key="MaterialNavigationBarStyle"
-		   TargetType="utu:NavigationBar"
-		   BasedOn="{StaticResource BaseMaterialNavigationBarStyle}">
+    <mobile:Style x:Key="MaterialNavigationBarStyle"
+           BasedOn="{StaticResource BaseMaterialNavigationBarStyle}"
+           TargetType="utu:NavigationBar">
         <ios:Setter Property="Height"
-					Value="NaN" />
-        <ios:Setter Property="Template"
-					Value="{StaticResource NativeNavigationBarTemplate}" />
-        <android:Setter Property="Template"
-						Value="{StaticResource NativeNavigationBarTemplate}" />
-        <Setter Property="MainCommandStyle"
-				Value="{StaticResource MaterialMainCommandStyle}" />
-    </Style>
+                    Value="NaN" />
+        <Setter Property="MainCommandStyle" Value="{StaticResource MaterialMainCommandStyle}" />
+        <Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
+        <Setter Property="Template" Value="{StaticResource NativeNavigationBarTemplate}" />
 
-    <Style x:Key="MaterialModalNavigationBarStyle"
-		   TargetType="utu:NavigationBar"
-		   BasedOn="{StaticResource BaseMaterialModalNavigationBarStyle}">
+    </mobile:Style>
+
+    <mobile:Style x:Key="MaterialModalNavigationBarStyle"
+           BasedOn="{StaticResource BaseMaterialModalNavigationBarStyle}"
+           TargetType="utu:NavigationBar">
         <ios:Setter Property="Height"
-					Value="NaN" />
-        <ios:Setter Property="Template"
-					Value="{StaticResource NativeNavigationBarTemplate}" />
-        <android:Setter Property="Template"
-						Value="{StaticResource NativeNavigationBarTemplate}" />
-        <Setter Property="MainCommandStyle"
-				Value="{StaticResource MaterialModalMainCommandStyle}" />
-	</Style>
+                    Value="NaN" />
+        <Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
+        <Setter Property="MainCommandStyle" Value="{StaticResource MaterialModalMainCommandStyle}" />
+        <Setter Property="Template" Value="{StaticResource NativeNavigationBarTemplate}" />
+
+    </mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/NavigationBar.xaml
@@ -1,8 +1,9 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:utu="using:Uno.Toolkit.UI">
 
-	<Style x:Key="MaterialMainCommandStyle"
+    <not_mobile:Style x:Key="MaterialMainCommandStyle"
 		   TargetType="AppBarButton"
 		   BasedOn="{StaticResource BaseMaterialMainCommandStyle}">
 		<Setter Property="Icon">
@@ -10,16 +11,16 @@
 				<SymbolIcon Symbol="Back" />
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 
-	<Style x:Key="MaterialNavigationBarStyle"
+    <not_mobile:Style x:Key="MaterialNavigationBarStyle"
 		   TargetType="utu:NavigationBar"
 		   BasedOn="{StaticResource BaseMaterialNavigationBarStyle}">
 		<Setter Property="MainCommandStyle"
 				Value="{StaticResource MaterialMainCommandStyle}" />
-	</Style>
+	</not_mobile:Style>
 
-    <Style x:Key="MaterialModalMainCommandStyle"
+    <not_mobile:Style x:Key="MaterialModalMainCommandStyle"
 		   TargetType="AppBarButton"
 		   BasedOn="{StaticResource BaseMaterialModalMainCommandStyle}">
         <Setter Property="Icon">
@@ -27,12 +28,12 @@
                 <SymbolIcon Symbol="Back" />
             </Setter.Value>
         </Setter>
-    </Style>
+    </not_mobile:Style>
 
-    <Style x:Key="MaterialModalNavigationBarStyle"
+    <not_mobile:Style x:Key="MaterialModalNavigationBarStyle"
 		   TargetType="utu:NavigationBar"
 		   BasedOn="{StaticResource BaseMaterialModalNavigationBarStyle}">
 		<Setter Property="MainCommandStyle"
 				Value="{StaticResource MaterialModalMainCommandStyle}" />
-	</Style>
+	</not_mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.UI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.UI.Material.csproj
@@ -18,6 +18,21 @@
 		<XamlMergeOutputFile>Generated\mergedpages.uwp.xaml</XamlMergeOutputFile>
 	</PropertyGroup>
 
+	<Choose>
+		<When Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='monoandroid11.0'">
+			<ItemGroup>
+				<IncludeXamlNamespaces Include="mobile" />
+				<ExcludeXamlNamespaces Include="not_mobile" />
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<IncludeXamlNamespaces Include="not_mobile" />
+				<ExcludeXamlNamespaces Include="mobile" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
+
 	<ItemGroup>
 		<PackageReference Include="Uno.Material" Version="1.2.0" />
 		<PackageReference Include="Uno.UI" Version="4.0.9" />

--- a/src/library/Uno.Toolkit.Material/xamlmerge.props
+++ b/src/library/Uno.Toolkit.Material/xamlmerge.props
@@ -2,7 +2,7 @@
 <Project>
 
 	<PropertyGroup>
-		<_Uno_XamlMerge_Task_Version>0.1.0-dev.46</_Uno_XamlMerge_Task_Version>
+		<_Uno_XamlMerge_Task_Version>0.1.0-dev.51</_Uno_XamlMerge_Task_Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Uno.XamlMerge.Task" Version="$(_Uno_XamlMerge_Task_Version)" />


### PR DESCRIPTION
relates to: https://github.com/unoplatform/uno/issues/3892
relates to: https://github.com/unoplatform/uno/issues/6717
relates to: https://github.com/unoplatform/uno/issues/7803

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

**As of iOS 13, the preferred method for styling the UINavigationBar and its components is by using the [UINavigationBarAppearance](https://developer.apple.com/documentation/uikit/uinavigationbarappearance) and [UIBarButtonItemAppearance](https://developer.apple.com/documentation/uikit/uibarbuttonitemappearance) APIs.**
## What is the current behavior?


The Native UINavigationBar wasn't truly having its background set. Instead, the Border that wraps the NativeNavigationBarPresenter is what determined was displaying the background color. This caused issues such as the animation of the bar's background color transition not working:
![navbarbad](https://user-images.githubusercontent.com/4793020/150562639-68e85224-d379-417e-b5e0-728a3e45e2f7.gif)


## What is the new behavior?

The UINavigationBar now properly displays the Background color to allow for smooth color transitions between pages as seen below:
![navbarblend](https://user-images.githubusercontent.com/4793020/150562010-4fddf109-0c60-4e9f-8ce9-279ed59ddfe3.gif)
