### PR TITLE
NavigationBar Support for FrameworkElement-based Content for NavBar/AppBarButton

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NavigationBarSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NavigationBarSamplePage.xaml
@@ -15,6 +15,11 @@
                     AutomationProperties.AutomationId="NavigationBar_Launch_Sample_Button"
                     Style="{StaticResource MaterialContainedButtonStyle}" />
 
+            <Button Click="LaunchFullScreenDataContextSample"
+                    Content="Show DataContext Sample"
+                    AutomationProperties.AutomationId="NavigationBar_Launch_DataContext_Sample_Button"
+                    Style="{StaticResource MaterialContainedButtonStyle}" />
+
             <Button x:Name="ModalButton"
                     Content="Show Modal Sample"
                     

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NavigationBarSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NavigationBarSamplePage.xaml.cs
@@ -45,5 +45,10 @@ namespace Uno.Toolkit.Samples.Content.Controls
         {
             Shell.GetForCurrentView().ShowNestedSample<NavigationBarSample_NestedPage1>(clearStack: true);
         }
+
+		private void LaunchFullScreenDataContextSample(object sender, RoutedEventArgs e)
+		{
+			Shell.GetForCurrentView().ShowNestedSample<NavigationBarSample_DataContext_NestedPage1>(clearStack: true);
+		}
 	}
 }

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_DataContext_NestedPage1.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_DataContext_NestedPage1.xaml
@@ -1,0 +1,56 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.NavigationBarSample_DataContext_NestedPage1"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:ios="http://uno.ui/ios"
+      xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:um="using:Uno.Material"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+      mc:Ignorable="d ios">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <utu:NavigationBar AutomationProperties.AutomationId="Page1DataContextNavBar"
+                           MainCommandMode="Action">
+            <utu:NavigationBar.Content>
+                <Grid VerticalAlignment="Center"
+                      ios:HorizontalAlignment="Center">
+                    <TextBlock ios:TextAlignment="Center"
+                               Foreground="Black"
+                               Text="{Binding ViewModelName}" />
+                </Grid>
+            </utu:NavigationBar.Content>
+            <utu:NavigationBar.MainCommand>
+                <AppBarButton AutomationProperties.AutomationId="NavBar_DataContext_Close_Button"
+                              Click="NavigateBack"
+                              Label="Close">
+                    <AppBarButton.Icon>
+                        <BitmapIcon ShowAsMonochrome="False"
+                                    UriSource="ms-appx:///Assets/CloseIcon.png" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+            </utu:NavigationBar.MainCommand>
+            <utu:NavigationBar.PrimaryCommands>
+                <AppBarButton AutomationProperties.AutomationId="DataContext_AppBarButton">
+                    <TextBlock Foreground="Black"
+                               AutomationProperties.AutomationId="DataContext_TextBlock"
+                               Text="{Binding ViewModelName}" />
+                </AppBarButton>
+            </utu:NavigationBar.PrimaryCommands>
+        </utu:NavigationBar>
+        <StackPanel Grid.Row="1"
+                    Padding="16,0"
+                    VerticalAlignment="Center"
+                    Spacing="8">
+            <Button Click="NavigateBack"
+                    Content="Exit sample" />
+            <TextBlock HorizontalAlignment="Center"
+                       Text="Right side button should contain a TextBlock with Text=Page1VM" />
+
+        </StackPanel>
+    </Grid>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_DataContext_NestedPage1.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_DataContext_NestedPage1.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Windows.Input;
+using Uno.Toolkit.Samples.Entities;
+using Uno.Toolkit.Samples.ViewModels;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class NavigationBarSample_DataContext_NestedPage1 : Page
+    {
+        public NavigationBarSample_DataContext_NestedPage1()
+        {
+            this.InitializeComponent();
+			this.DataContext = new Page1VM();
+        }
+
+		private void NavigateBack(object sender, RoutedEventArgs e) => Shell.GetForCurrentView().BackNavigateFromNestedSample();
+	}
+
+	public class Page1VM
+	{
+		public string ViewModelName { get; } = nameof(Page1VM);
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
@@ -25,6 +25,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\ChipSamplePage.xaml.cs">
       <DependentUpon>ChipSamplePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\NavigationBarSample_DataContext_NestedPage1.xaml.cs">
+      <DependentUpon>NavigationBarSample_DataContext_NestedPage1.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ModalDialog.xaml.cs">
       <DependentUpon>ModalDialog.xaml</DependentUpon>
     </Compile>
@@ -116,6 +119,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)ColorPaletteOverride.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\NavigationBarSample_DataContext_NestedPage1.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
@@ -157,5 +157,20 @@ namespace Uno.Toolkit.UI
 		public static T FindFirstParent<T>(this DependencyObject element, bool includeCurrent = true)
 			where T : DependencyObject
 			=> element.GetAllParents(includeCurrent).OfType<T>().FirstOrDefault();
+
+#if HAS_UNO
+		/// <summary>
+		/// Set the parent of the specified dependency object
+		/// </summary>
+		internal static void SetParent(this DependencyObject dependencyObject, object? parent)
+		{
+			if (parent != null
+				&& dependencyObject is IDependencyObjectStoreProvider storeProvider
+				&& (!ReferenceEquals(storeProvider.Store.Parent, parent)))
+			{
+				storeProvider.Store.Parent = parent;
+			}
+		}
+#endif
 	}
 }

--- a/src/Uno.Toolkit.UITest/NavigationBar/Given_NavigationBar.cs
+++ b/src/Uno.Toolkit.UITest/NavigationBar/Given_NavigationBar.cs
@@ -119,6 +119,5 @@ namespace Uno.Toolkit.UITest.NavigationBar
 				Android: () => App.Marked("Page1NavBar").Descendant("Toolbar").FirstResult()
 			);
 		}
-			
 	}
 }


### PR DESCRIPTION
## PR Type
closes https://github.com/unoplatform/uno/issues/3712
### ⚠ Still some outstanding bugs related to these changes ⚠
Android FluentTheme AppBarButton does not render its Content: https://github.com/unoplatform/uno/issues/7970
MaterialAppBarButton style DataContext issue: https://github.com/unoplatform/Uno.Gallery/issues/336

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The following XAML, where NavigationBar's Content and AppBarButton's Content is a TextBlock would not render on the native navigation bars.

```xml
<utu:NavigationBar AutomationProperties.AutomationId="Page1DataContextNavBar"
                    MainCommandMode="Action">
    <utu:NavigationBar.Content>
        <Grid VerticalAlignment="Center"
                ios:HorizontalAlignment="Center">
            <TextBlock ios:TextAlignment="Center"
                        Foreground="Black"
                        Text="{Binding ViewModelName}" />
        </Grid>
    </utu:NavigationBar.Content>
    <utu:NavigationBar.PrimaryCommands>
        <AppBarButton AutomationProperties.AutomationId="DataContext_AppBarButton">
            <TextBlock Foreground="Black"
                        AutomationProperties.AutomationId="DataContext_TextBlock"
                        Text="{Binding ViewModelName}" />
        </AppBarButton>
    </utu:NavigationBar.PrimaryCommands>
</utu:NavigationBar>
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
