### PR TITLE
fix(TabBar): Remove MinWidth from TabBarSelectionIndicator

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.Base.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.Base.xaml
@@ -76,9 +76,8 @@
 					  Opacity="0.70" />
 	<x:Double x:Key="MaterialTabBarFontSize">14</x:Double>
 	<FontFamily x:Key="MaterialTabBarFontFamily">Roboto</FontFamily>
-	<x:Double x:Key="TabBarHeight">48</x:Double>
-	<x:Double x:Key="MaterialTabBarSelectionMinWidthIndicator">120</x:Double>
-	<x:Double x:Key="TabBarItemIconHeight">20</x:Double>
+    <x:Double x:Key="TabBarHeight">48</x:Double>
+    <x:Double x:Key="TabBarItemIconHeight">20</x:Double>
 	<x:Double x:Key="TabBarItemIconWidth">20</x:Double>
 	<Thickness x:Key="TabBarItemContentMargin">0,0,0,0</Thickness>
 	<Thickness x:Key="TabBarItemContentOnlyMargin">12,0</Thickness>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.Mobile.xaml
@@ -50,7 +50,6 @@
 									VerticalAlignment="Stretch"
 									Margin="0,0,0,2"
 									Height="2"
-									MinWidth="{StaticResource MaterialTabBarSelectionMinWidthIndicator}"
 									Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}" />
 						</utu:TabBarSelectionIndicatorPresenter>
 					</Grid>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.xaml
@@ -50,7 +50,6 @@
 									VerticalAlignment="Stretch"
 									Margin="0,0,0,2"
 									Height="2"
-									MinWidth="{StaticResource MaterialTabBarSelectionMinWidthIndicator}"
 									Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}" />
 						</utu:TabBarSelectionIndicatorPresenter>
 					</Grid>


### PR DESCRIPTION
closes #109

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
 SelectionIndicator could become larger than the tabs items

## What is the new behavior?

SelectionIndicator maintains same width as TabBarItems


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
