### PR TITLE
fix(TabBar): use mobile/not_mobile prefixes for Top/Bottom TabBars

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.Mobile.xaml
@@ -5,7 +5,8 @@
 					xmlns:um="using:Uno.Material"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:utu="using:Uno.Toolkit.UI"
-					mc:Ignorable="d">
+                    xmlns:mobile="http://uno.ui/mobile" 
+					mc:Ignorable="d mobile">
 
 
 	<!-- Code can be removed when this issue is fixed in Uno: -->
@@ -14,7 +15,7 @@
 	<x:Double x:Key="AjustedTabBarHeight">92</x:Double>
 
 	<!-- Material Bottom TabBar -->
-	<Style x:Key="MaterialBottomTabBarStyle"
+    <mobile:Style x:Key="MaterialBottomTabBarStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource MaterialTabBarBackground}" />
@@ -73,9 +74,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 
-	<Style x:Key="MaterialBottomTabBarItemFabStyle"
+    <mobile:Style x:Key="MaterialBottomTabBarItemFabStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource MaterialSecondaryBrush}" />
@@ -211,9 +212,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 
-	<Style x:Key="MaterialBottomTabBarItemStyle"
+    <mobile:Style x:Key="MaterialBottomTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource TabBarItemBackground}" />
@@ -346,5 +347,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.xaml
@@ -4,11 +4,12 @@
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:um="using:Uno.Material"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
+                    xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:utu="using:Uno.Toolkit.UI"
 					mc:Ignorable="d">
 
 	<!-- Material Bottom TabBar -->
-	<Style x:Key="MaterialBottomTabBarStyle"
+	<not_mobile:Style x:Key="MaterialBottomTabBarStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource MaterialTabBarBackground}" />
@@ -25,22 +26,47 @@
 		</Setter>
 		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource MaterialBottomTabBarItemStyle}" />
-		<Setter Property="Template">
+        <!-- Workaround until this issue is fixed, can be removed after -->
+        <!-- https://github.com/unoplatform/uno/issues/7393 -->
+        <Setter Property="VerticalContentAlignment"	
+				Value="Bottom" />
+        <Setter Property="Template">
 			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBar">
-					<Grid x:Name="TabBarGrid"
-						  Background="{TemplateBinding Background}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}"
-						  Padding="{TemplateBinding Padding}">
-						<ItemsPresenter Height="{StaticResource TabBarHeight}" />
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
+                <ControlTemplate TargetType="utu:TabBar">
+                    <!-- Code can be uncommented when this issue is fixed in Uno: -->
+                    <!-- https://github.com/unoplatform/uno/issues/7393 -->
+                    <!--<Grid x:Name="TabBarGrid"	
+						  Background="{TemplateBinding Background}"	
+						  BorderBrush="{TemplateBinding BorderBrush}"	
+						  BorderThickness="{TemplateBinding BorderThickness}"	
+						  Padding="{TemplateBinding Padding}">	
+						<ItemsPresenter Height="{StaticResource TabBarHeight}" />	
+					</Grid>-->
+                    <!-- Workaround until the above issue is fixed, can be removed after -->
+                    <Grid x:Name="TabBarGrid">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="{StaticResource TabBarHeight}" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Border Grid.Row="1"	
+								x:Name="BackgroundBorder"	
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}"	
+								Background="{TemplateBinding Background}"	
+								Height="{StaticResource TabBarHeight}" />
+                        <ItemsPresenter Grid.RowSpan="2"	
+										Height="{StaticResource AjustedTabBarHeight}" />
+                        <Border Grid.Row="2"	
+								x:Name="VisibleBoundsBorder"	
+								Background="{TemplateBinding Background}"	
+								Padding="{TemplateBinding Padding}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 
-	<Style x:Key="MaterialBottomTabBarItemFabStyle"
+    <not_mobile:Style x:Key="MaterialBottomTabBarItemFabStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource MaterialSecondaryBrush}" />
@@ -66,15 +92,20 @@
 				Value="{StaticResource MaterialFabLargeCorderRadius}" />
 		<Setter Property="Padding"
 				Value="{StaticResource MaterialFabLargePadding}" />
-		<Setter Property="RenderTransform">
-			<Setter.Value>
-				<TranslateTransform Y="{StaticResource FabItemVerticalOffset}" />
-			</Setter.Value>
-		</Setter>
-		<Setter Property="Template">
+        <!-- Code can be uncommented when this issue is fixed in Uno: -->
+        <!-- https://github.com/unoplatform/uno/issues/7393 -->
+        <!--<Setter Property="RenderTransform">	
+			<Setter.Value>	
+				<TranslateTransform Y="{StaticResource FabItemVerticalOffset}" />	
+			</Setter.Value>	
+		</Setter>-->
+        <!-- Workaround until the above issue is fixed, can be removed after -->
+        <Setter Property="VerticalAlignment"	
+				Value="Top" />
+        <Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBarItem">
-					<Grid>
+                    <Grid VerticalAlignment="{TemplateBinding VerticalAlignment}">
 						<toolkit:ElevatedView x:Name="ElevatedView"
 											  Margin="0,0,6,6"
 											  Elevation="6"
@@ -171,9 +202,9 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 
-	<Style x:Key="MaterialBottomTabBarItemStyle"
+    <not_mobile:Style x:Key="MaterialBottomTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource TabBarItemBackground}" />
@@ -191,7 +222,13 @@
 				Value="True" />
 		<Setter Property="HorizontalContentAlignment"
 				Value="Center" />
-		<Setter Property="Template">
+        <!-- Workaround with these two properties until this issue is fixed, can be removed after -->
+        <!-- https://github.com/unoplatform/uno/issues/7393 -->
+        <Setter Property="Height"	
+				Value="{StaticResource TabBarHeight}" />
+        <Setter Property="VerticalAlignment"	
+				Value="Bottom" />
+        <Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBarItem">
 					<Grid x:Name="LayoutRoot"
@@ -348,5 +385,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.Mobile.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.Mobile.xaml
@@ -5,10 +5,11 @@
 					xmlns:um="using:Uno.Material"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:utu="using:Uno.Toolkit.UI"
-					mc:Ignorable="d">
+                    xmlns:mobile="http://uno.ui/mobile" 
+					mc:Ignorable="d mobile">
 
 	<!--Material TabBar-->
-	<Style x:Key="MaterialTopTabBarStyle"
+    <mobile:Style x:Key="MaterialTopTabBarStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{StaticResource MaterialTabBarBackground}" />
@@ -56,10 +57,10 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 
 	<!--Material TabBar Item -->
-	<Style x:Key="MaterialTopTabBarItemStyle"
+    <mobile:Style x:Key="MaterialTopTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource MaterialTabBarBackground}" />
@@ -187,5 +188,5 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</mobile:Style>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/TopTabBar.xaml
@@ -5,10 +5,11 @@
 					xmlns:um="using:Uno.Material"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:utu="using:Uno.Toolkit.UI"
+                    xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					mc:Ignorable="d">
 
 	<!--Material TabBar-->
-	<Style x:Key="MaterialTopTabBarStyle"
+    <not_mobile:Style x:Key="MaterialTopTabBarStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{StaticResource MaterialTabBarBackground}" />
@@ -56,10 +57,10 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 
 	<!--Material TabBar Item -->
-	<Style x:Key="MaterialTopTabBarItemStyle"
+    <not_mobile:Style x:Key="MaterialTopTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource MaterialTabBarBackground}" />
@@ -235,6 +236,6 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</Style>
+	</not_mobile:Style>
 
 </ResourceDictionary>


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Some Material styles for [Bottom/Top]TabBar were not prefixed with `mobile:` or `not_mobile:`. Causing issues with the xaml merge

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
