### PR TITLE
fix(SystemThemeHelper): darkmode detection logic

### DIFF
--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -55,13 +55,13 @@ namespace Uno.Toolkit.UI
 		/// Get if the application is currently in dark mode.
 		/// </summary>
 		public static bool IsAppInDarkMode()
-			=> GetRootTheme(null) == ApplicationTheme.Dark;
+			=> GetRootTheme(GetWindowRoot().XamlRoot) == ApplicationTheme.Dark;
 
 		public static bool IsRootInDarkMode(XamlRoot root)
 			=> GetRootTheme(root) == ApplicationTheme.Dark;
 
 		public static void SetApplicationTheme(bool darkMode)
-			=> SetRootTheme(GetWindowRoot()?.XamlRoot, darkMode);
+			=> SetRootTheme(GetWindowRoot().XamlRoot, darkMode);
 
 		/// <summary>
 		/// Sets the theme for the provided XamlRoot
@@ -74,7 +74,7 @@ namespace Uno.Toolkit.UI
 		public static void SetApplicationTheme(XamlRoot? root, ElementTheme theme)
 		{
 			if (root?.Content is FrameworkElement fe)
-			{ 
+			{
 				fe.RequestedTheme = theme;
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

IsAppInDarkMode is always based on os theme, ignoring the app theme.
ToggleApplicationTheme fails to work after the first time, due its reliance on the above method.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
