### PR TITLE
fix: Uwp sample app crashes on launch

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_DataContext_NestedPage1.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NavigationBarSample_DataContext_NestedPage1.xaml
@@ -15,15 +15,18 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <utu:NavigationBar AutomationProperties.AutomationId="Page1DataContextNavBar"
-                           MainCommandMode="Action">
-            <utu:NavigationBar.Content>
-                <Grid VerticalAlignment="Center"
-                      ios:HorizontalAlignment="Center">
-                    <TextBlock ios:TextAlignment="Center"
-                               Foreground="Black"
-                               Text="{Binding ViewModelName}" />
-                </Grid>
-            </utu:NavigationBar.Content>
+                           MainCommandMode="Action"
+                           Content="{Binding ViewModelName}">
+            <utu:NavigationBar.ContentTemplate>
+                <DataTemplate>
+                    <Grid VerticalAlignment="Center"
+                          ios:HorizontalAlignment="Center">
+                        <TextBlock ios:TextAlignment="Center"
+                                   Foreground="Black"
+                                   Text="{Binding}" />
+                    </Grid>
+                </DataTemplate>
+            </utu:NavigationBar.ContentTemplate>
             <utu:NavigationBar.MainCommand>
                 <AppBarButton AutomationProperties.AutomationId="NavBar_DataContext_Close_Button"
                               Click="NavigateBack"

--- a/src/library/Uno.Toolkit.Material/Generated/mergedpages.uwp.xaml
+++ b/src/library/Uno.Toolkit.Material/Generated/mergedpages.uwp.xaml
@@ -22,6 +22,7 @@
   <x:Double x:Key="MaterialBottomTabBarFontSize">14</x:Double>
   <FontFamily x:Key="MaterialBottomTabBarFontFamily">Roboto</FontFamily>
   <x:Double x:Key="MaterialBottomTabBarHeight">64</x:Double>
+  <GridLength x:Key="MaterialBottomTabBarGridLengthHeight">64</GridLength>
   <x:Double x:Key="FabItemVerticalOffset">-32</x:Double>
   <x:Double x:Key="MaterialBottomTabBarItemIconHeight">22</x:Double>
   <x:Double x:Key="MaterialBottomTabBarItemIconWidth">22</x:Double>
@@ -59,7 +60,7 @@
           <Grid x:Name="TabBarGrid">
             <Grid.RowDefinitions>
               <RowDefinition Height="Auto" />
-              <RowDefinition Height="{StaticResource MaterialBottomTabBarHeight}" />
+              <RowDefinition Height="{StaticResource MaterialBottomTabBarGridLengthHeight}" />
               <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Border Grid.Row="1" x:Name="BackgroundBorder" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Background="{TemplateBinding Background}" Height="{StaticResource MaterialBottomTabBarHeight}" />
@@ -257,7 +258,7 @@
           <Grid x:Name="TabBarGrid">
             <Grid.RowDefinitions>
               <RowDefinition Height="Auto" />
-              <RowDefinition Height="{StaticResource MaterialBottomTabBarHeight}" />
+              <RowDefinition Height="{StaticResource MaterialBottomTabBarGridLengthHeight}" />
               <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Border Grid.Row="1" x:Name="BackgroundBorder" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Background="{TemplateBinding Background}" Height="{StaticResource MaterialBottomTabBarHeight}" />

--- a/src/library/Uno.Toolkit.Material/Generated/mergedpages.winui.xaml
+++ b/src/library/Uno.Toolkit.Material/Generated/mergedpages.winui.xaml
@@ -22,6 +22,7 @@
   <x:Double x:Key="MaterialBottomTabBarFontSize">14</x:Double>
   <FontFamily x:Key="MaterialBottomTabBarFontFamily">Roboto</FontFamily>
   <x:Double x:Key="MaterialBottomTabBarHeight">64</x:Double>
+  <GridLength x:Key="MaterialBottomTabBarGridLengthHeight">64</GridLength>
   <x:Double x:Key="FabItemVerticalOffset">-32</x:Double>
   <x:Double x:Key="MaterialBottomTabBarItemIconHeight">22</x:Double>
   <x:Double x:Key="MaterialBottomTabBarItemIconWidth">22</x:Double>
@@ -59,7 +60,7 @@
           <Grid x:Name="TabBarGrid">
             <Grid.RowDefinitions>
               <RowDefinition Height="Auto" />
-              <RowDefinition Height="{StaticResource MaterialBottomTabBarHeight}" />
+              <RowDefinition Height="{StaticResource MaterialBottomTabBarGridLengthHeight}" />
               <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Border Grid.Row="1" x:Name="BackgroundBorder" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Background="{TemplateBinding Background}" Height="{StaticResource MaterialBottomTabBarHeight}" />
@@ -257,7 +258,7 @@
           <Grid x:Name="TabBarGrid">
             <Grid.RowDefinitions>
               <RowDefinition Height="Auto" />
-              <RowDefinition Height="{StaticResource MaterialBottomTabBarHeight}" />
+              <RowDefinition Height="{StaticResource MaterialBottomTabBarGridLengthHeight}" />
               <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Border Grid.Row="1" x:Name="BackgroundBorder" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Background="{TemplateBinding Background}" Height="{StaticResource MaterialBottomTabBarHeight}" />

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/BottomTabBar.xaml
@@ -44,6 +44,7 @@
     <x:Double x:Key="MaterialBottomTabBarFontSize">14</x:Double>
     <FontFamily x:Key="MaterialBottomTabBarFontFamily">Roboto</FontFamily>
     <x:Double x:Key="MaterialBottomTabBarHeight">64</x:Double>
+    <GridLength x:Key="MaterialBottomTabBarGridLengthHeight">64</GridLength>
     <x:Double x:Key="FabItemVerticalOffset">-32</x:Double>
     <x:Double x:Key="MaterialBottomTabBarItemIconHeight">22</x:Double>
     <x:Double x:Key="MaterialBottomTabBarItemIconWidth">22</x:Double>
@@ -94,7 +95,7 @@
                     <Grid x:Name="TabBarGrid">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="{StaticResource MaterialBottomTabBarHeight}" />
+                            <RowDefinition Height="{StaticResource MaterialBottomTabBarGridLengthHeight}" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
@@ -427,7 +428,7 @@
                     <Grid x:Name="TabBarGrid">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="{StaticResource MaterialBottomTabBarHeight}" />
+                            <RowDefinition Height="{StaticResource MaterialBottomTabBarGridLengthHeight}" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Border Grid.Row="1"	


### PR DESCRIPTION
GitHub Issue (If applicable): #205 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Uwp sample app crashes on launch

- For the MaterialBottomTabBarStyle : `Error HRESULT E_FAIL has been returned from a call to a COM component.`
- For the NavigationBarSample_DataContext_NestedPage1
![image](https://user-images.githubusercontent.com/16295702/162484736-06fe3140-1371-44b3-93b0-ece1ca7804ca.png)

## What is the new behavior?

Uwp sample app doesn't crash on launch

- Fixed by using a proper GridLength resource for MaterialBottomTabBarHeight for the MaterialBottomTabBarStyle.
- Fixed NavigationBar content for NavigationBarSample_DataContext_NestedPage1


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
