### PR TITLE
fix: Make sure WinUI version of Toolkit Themes include/exclude the mobile and not_mobile XAML namespaces

### DIFF
--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
@@ -20,7 +20,22 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="2.0.0-dev.154" />
 		<PackageReference Include="Uno.WinUI" Version="4.2.0-dev.622" />
 	</ItemGroup>
-	
+
+	<Choose>
+		<When Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid11.0'">
+			<ItemGroup>
+				<IncludeXamlNamespaces Include="mobile" />
+				<ExcludeXamlNamespaces Include="not_mobile" />
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<IncludeXamlNamespaces Include="not_mobile" />
+				<ExcludeXamlNamespaces Include="mobile" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
+
 	<PropertyGroup>
 		<XamlMergeOutputFile>Generated\mergedpages.winui.xaml</XamlMergeOutputFile>
 	</PropertyGroup>

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
@@ -23,6 +23,21 @@
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.24" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
 	</ItemGroup>
 
+	<Choose>
+		<When Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid11.0'">
+			<ItemGroup>
+				<IncludeXamlNamespaces Include="mobile" />
+				<ExcludeXamlNamespaces Include="not_mobile" />
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<IncludeXamlNamespaces Include="not_mobile" />
+				<ExcludeXamlNamespaces Include="mobile" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
+
 	<ItemGroup>
 		<XamlMergeOutputFiles Include="Generated\mergedpages.winui.v1.xaml" />
 		<XamlMergeOutputFiles Include="Generated\mergedpages.winui.v2.xaml" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix