### PR TITLE
Dev/xygu/20220512/latest resdict alias

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
@@ -66,10 +66,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.Cupertino">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml
@@ -1,47 +1,34 @@
 ﻿<Application x:Class="Uno.Toolkit.Samples.App"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:local="using:Uno.Toolkit.Samples">
-
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<Application.Resources>
 		<ResourceDictionary>
+			
 			<ResourceDictionary.MergedDictionaries>
+
 				<!-- Load WinUI resources -->
 				<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
 
-				<!-- Load Uno.UI.Toolkit resources -->
-				<ToolkitResources xmlns="using:Uno.Toolkit.UI" />
-
-				<!-- Load Uno.Material resources (Material Design 2) -->
-				<MaterialColors xmlns="using:Uno.Material"
-								OverrideSource="ms-appx:///ColorPaletteOverride.xaml" />
-				<MaterialFonts xmlns="using:Uno.Material"
-							   OverrideSource="ms-appx:///MaterialFontsOverride.xaml" />
-				<MaterialResources xmlns="using:Uno.Material" />
-
-				<!-- Load Uno.Material v2 resources (Material Design 3) -->
+				<!-- Load Uno.Material resources -->
+				<MaterialFonts xmlns="using:Uno.Material" OverrideSource="ms-appx:///MaterialFontsOverride.xaml" />
+				<MaterialColorsV1 xmlns="using:Uno.Material" OverrideSource="ms-appx:///ColorPaletteOverride.xaml" />
+				<MaterialResourcesV1 xmlns="using:Uno.Material" />
 				<MaterialColorsV2 xmlns="using:Uno.Material" />
-                <MaterialResourcesV2 xmlns="using:Uno.Material" />
+				<MaterialResourcesV2 xmlns="using:Uno.Material" />
 
-				<!-- Load Material Toolkit resources (Material Design 2) -->
-                <MaterialToolkitResources xmlns="using:Uno.Toolkit.UI.Material" />
-
-				<!-- Load Material Toolkit v2 resources (Material Design 3) -->
-				<MaterialToolkitResourcesV2 xmlns="using:Uno.Toolkit.UI.Material" />
-
-                <!-- Load Cupertino resources -->
+				<!-- Load Uno.Cupertino resources -->
 				<CupertinoColors xmlns="using:Uno.Cupertino" />
-				<CupertinoFonts xmlns="using:Uno.Cupertino"
-								OverrideSource="ms-appx:///CupertinoFontsOverride.xaml" />
+				<CupertinoFonts xmlns="using:Uno.Cupertino" OverrideSource="ms-appx:///CupertinoFontsOverride.xaml" />
 				<CupertinoResources xmlns="using:Uno.Cupertino" />
 
-				<!-- Load Cupertino Toolkit resources -->
+				<!-- Load Uno.Toolkit.UI resources -->
+				<ToolkitResources xmlns="using:Uno.Toolkit.UI" />
+				<MaterialToolkitResourcesV1 xmlns="using:Uno.Toolkit.UI.Material" />
+				<MaterialToolkitResourcesV2 xmlns="using:Uno.Toolkit.UI.Material" />
 				<CupertinoToolkitResources xmlns="using:Uno.Toolkit.UI.Cupertino" />
 
-				<!-- Converters -->
+				<!-- Load application resources -->
 				<ResourceDictionary Source="Converters.xaml" />
-
-				<!-- Application's custom styles -->
 				<ResourceDictionary Source="ms-appx:///Styles/Application/Colors.xaml" />
 				<ResourceDictionary Source="ms-appx:///Styles/Application/Fonts.xaml" />
 				<ResourceDictionary Source="ms-appx:///Styles/Button.xaml" />
@@ -51,10 +38,11 @@
 				<ResourceDictionary Source="ms-appx:///Styles/SamplePageLayout.xaml" />
 				<ResourceDictionary Source="ms-appx:///Styles/TextBlock.xaml" />
 				<ResourceDictionary Source="ms-appx:///Styles/OverviewSampleView.xaml" />
+				
 			</ResourceDictionary.MergedDictionaries>
-			
+
 			<x:Double x:Key="DesktopAdaptiveThresholdWidth">720</x:Double>
+			
 		</ResourceDictionary>
 	</Application.Resources>
-
 </Application>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Gtk/Uno.Toolkit.Samples.Skia.Gtk.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Gtk/Uno.Toolkit.Samples.Skia.Gtk.csproj
@@ -29,8 +29,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.Cupertino" Version="2.0.0-dev.181" />
-    <PackageReference Include="Uno.Material" Version="2.0.0-dev.181" />
+    <PackageReference Include="Uno.Cupertino" Version="2.0.0-dev.195" />
+    <PackageReference Include="Uno.Material" Version="2.0.0-dev.195" />
     <PackageReference Include="Uno.UI.Skia.Gtk" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.622" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Tizen/Uno.Toolkit.Samples.Skia.Tizen.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Tizen/Uno.Toolkit.Samples.Skia.Tizen.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="SkiaSharp.Views" Version="2.80.2" />
-    <PackageReference Include="Uno.UI.Skia.Tizen" Version="3.10.0-dev.390" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.0-dev.390" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Skia.Tizen" Version="4.2.0-dev.622" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <Import Project="..\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems" Label="Shared" />
 </Project>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Wpf.Host/Uno.Toolkit.Samples.Skia.Wpf.Host.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Wpf.Host/Uno.Toolkit.Samples.Skia.Wpf.Host.csproj
@@ -7,8 +7,8 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI.Skia.Wpf" Version="3.10.0-dev.390" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.0-dev.390" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.2.0-dev.622" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Wpf/Uno.Toolkit.Samples.Skia.Wpf.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Wpf/Uno.Toolkit.Samples.Skia.Wpf.csproj
@@ -6,8 +6,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.UI.Skia.Wpf" Version="3.10.0-dev.390" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="3.10.0-dev.390" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.2.0-dev.622" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <ItemGroup>
     <UpToDateCheckInput Include="..\Uno.Toolkit.Samples.Shared\**\*.xaml" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.UWP/Uno.Toolkit.Samples.UWP.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.UWP/Uno.Toolkit.Samples.UWP.csproj
@@ -12,10 +12,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.0-prerelease.210623001" />
     <PackageReference Include="Uno.Cupertino">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.2.0-dev.622" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Wasm/Uno.Toolkit.Samples.Wasm.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Wasm/Uno.Toolkit.Samples.Wasm.csproj
@@ -42,9 +42,9 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-		<PackageReference Include="Uno.Cupertino" Version="2.0.0-dev.181" />
+		<PackageReference Include="Uno.Cupertino" Version="2.0.0-dev.195" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0-dev.1" />
-		<PackageReference Include="Uno.Material" Version="2.0.0-dev.181" />
+		<PackageReference Include="Uno.Material" Version="2.0.0-dev.195" />
 		<PackageReference Include="Uno.UI.WebAssembly" Version="4.2.0-dev.622" />
 		<PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="3.2.0" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.iOS/Uno.Toolkit.Samples.iOS.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.iOS/Uno.Toolkit.Samples.iOS.csproj
@@ -187,10 +187,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Uno.Cupertino">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.macOS/Uno.Toolkit.Samples.macOS.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.macOS/Uno.Toolkit.Samples.macOS.csproj
@@ -71,10 +71,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.Cupertino">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.Material">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/Uno.Toolkit.WinUI.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/Uno.Toolkit.WinUI.Samples.Droid.csproj
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.WinUI" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Skia.Gtk/Uno.Toolkit.WinUI.Samples.Skia.Gtk.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Skia.Gtk/Uno.Toolkit.WinUI.Samples.Skia.Gtk.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.Material.WinUI" Version="2.0.0-dev.181" />
+    <PackageReference Include="Uno.Material.WinUI" Version="2.0.0-dev.195" />
     <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.0-dev.622" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.UWP/Uno.Toolkit.WinUI.Samples.UWP.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.UWP/Uno.Toolkit.WinUI.Samples.UWP.csproj
@@ -11,11 +11,11 @@
       <Version>6.2.11</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.5.0" />
-    <PackageReference Include="Uno.Core" Version="2.4.0" />
+    <PackageReference Include="Uno.Core" Version="4.0.0-dev.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Uno.WinUI">
-      <Version>3.10.0-dev.390</Version>
+      <Version>4.2.0-dev.622</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Wasm/Uno.Toolkit.WinUI.Samples.Wasm.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Wasm/Uno.Toolkit.WinUI.Samples.Wasm.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0-dev.1" />
-    <PackageReference Include="Uno.Material.WinUI" Version="2.0.0-dev.181" />
+    <PackageReference Include="Uno.Material.WinUI" Version="2.0.0-dev.195" />
     <PackageReference Include="Uno.WinUI.WebAssembly" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />
 	  <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.2.0" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
@@ -18,7 +18,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="2.0.0-dev.181" />
+		<PackageReference Include="Uno.Material.WinUI" Version="2.0.0-dev.195" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.iOS/Uno.Toolkit.WinUI.Samples.iOS.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.iOS/Uno.Toolkit.WinUI.Samples.iOS.csproj
@@ -124,7 +124,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.WinUI" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.macOS/Uno.Toolkit.WinUI.Samples.macOS.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.macOS/Uno.Toolkit.WinUI.Samples.macOS.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>2.0.0-dev.181</Version>
+      <Version>2.0.0-dev.195</Version>
     </PackageReference>
     <PackageReference Include="Uno.WinUI" Version="4.2.0-dev.622" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.0-dev.622" Condition="'$(Configuration)'=='Debug'" />

--- a/src/Uno.Toolkit.UI/ToolkitResources.cs
+++ b/src/Uno.Toolkit.UI/ToolkitResources.cs
@@ -12,6 +12,9 @@ using Windows.UI.Xaml;
 
 namespace Uno.Toolkit.UI
 {
+	/// <summary>
+	/// Default styles for the controls in the Uno.Toolkit.UI library.
+	/// </summary>
 	public sealed class ToolkitResources : ResourceDictionary
 	{
 		private const string PackageName =

--- a/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.38">
+<Project Sdk="MSBuild.Sdk.Extras/3.0.38">
   <!--
 	Adding project references to this project requires some manual adjustments.
 	Please see https://github.com/unoplatform/uno/issues/3909 for more details.
@@ -23,24 +23,24 @@
 
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
-			
+
 			<ItemGroup>
 				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
 			</ItemGroup>
-			
+
 		</When>
 		<Otherwise>
-			
+
 			<ItemGroup>
 				<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 				<Compile Update="**\*.xaml.cs">
 					<DependentUpon>%(Filename)</DependentUpon>
 				</Compile>
 			</ItemGroup>
-			
+
 		</Otherwise>
 	</Choose>
-	
+
   <ItemGroup>
     <UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
   </ItemGroup>

--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.UI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.UI.Cupertino.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/3.0.38">
 	<!--
 	Adding project references to this project requires some manual adjustments.
@@ -15,10 +15,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Cupertino" Version="2.0.0-dev.181" />
+		<PackageReference Include="Uno.Cupertino" Version="2.0.0-dev.195" />
 		<PackageReference Include="Uno.UI" Version="4.2.0-dev.622" />
 	</ItemGroup>
-	
+
 	<PropertyGroup>
 		<XamlMergeOutputFile>Generated\mergedpages.uwp.xaml</XamlMergeOutputFile>
 	</PropertyGroup>
@@ -52,7 +52,7 @@
 	<ItemGroup>
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<EmbeddedResource Include="LinkerConfig.xml">
 			<LogicalName>$(AssemblyName).xml</LogicalName>
@@ -78,6 +78,6 @@
 			<ProjectReferenceWithConfiguration Remove="@(_UnoToolkitUIFiles)" />
 		</ItemGroup>
 	</Target>
-	
+
 	<Import Project="xamlmerge.props" />
 </Project>

--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/3.0.38">
 	<!--
 	Adding project references to this project requires some manual adjustments.
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Cupertino.WinUI" Version="2.0.0-dev.181" />
+		<PackageReference Include="Uno.Cupertino.WinUI" Version="2.0.0-dev.195" />
 		<PackageReference Include="Uno.WinUI" Version="4.2.0-dev.622" />
 	</ItemGroup>
 
@@ -42,26 +42,26 @@
 
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
-			
+
 			<ItemGroup>
 				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
 				<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.24" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
 				<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.24" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
 			</ItemGroup>
-			
+
 			<ItemGroup>
 				<Page Remove="Generated\*.xaml" />
 			</ItemGroup>
 		</When>
 		<Otherwise>
-			
+
 			<ItemGroup>
 				<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 				<Compile Update="**\*.xaml.cs">
 					<DependentUpon>%(Filename)</DependentUpon>
 				</Compile>
 			</ItemGroup>
-			
+
 		</Otherwise>
 	</Choose>
   <ItemGroup>

--- a/src/library/Uno.Toolkit.Material/MaterialToolkitResources.cs
+++ b/src/library/Uno.Toolkit.Material/MaterialToolkitResources.cs
@@ -1,37 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-#if IS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using Windows.UI.Xaml;
-#endif
-
-/// <summary>
-/// Material Toolkit resources
-/// </summary>
+﻿
 namespace Uno.Toolkit.UI.Material
 {
-	public sealed class MaterialToolkitResources : ResourceDictionary
+	/// <summary>
+	/// Material Design styles for the controls in the Uno.Toolkit.UI library.
+	/// </summary>
+	/// <remarks>
+	/// This class is like an alias for the latest version of MaterialToolkitResources,
+	/// which is currently pointing to <see cref="MaterialToolkitResourcesV2"/>.
+	/// </remarks>
+	public sealed class MaterialToolkitResources : MaterialToolkitResourcesV2
 	{
-#if IS_WINUI
-		private const string PackageName =
-			"Uno.Toolkit.WinUI.Material";
-		private const string PackageNameSuffix =
-			"winui";
-#else
-		private const string PackageName =
-			"Uno.Toolkit.UI.Material";
-		private const string PackageNameSuffix =
-			"uwp";
-#endif
-
-		public MaterialToolkitResources()
-		{
-			Source = new Uri($"ms-appx:///{PackageName}/Generated/mergedpages.{PackageNameSuffix}.v1.xaml");
-		}
 	}
 }

--- a/src/library/Uno.Toolkit.Material/MaterialToolkitResourcesV1.cs
+++ b/src/library/Uno.Toolkit.Material/MaterialToolkitResourcesV1.cs
@@ -10,28 +10,28 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Uno.Toolkit.UI.Cupertino
+namespace Uno.Toolkit.UI.Material
 {
 	/// <summary>
-	/// Cupertino styles for the controls in the Uno.Toolkit.UI library.
+	/// Material (Material Design 2) styles for the controls in the Uno.Toolkit.UI library.
 	/// </summary>
-	public sealed class CupertinoToolkitResources : ResourceDictionary
+	public class MaterialToolkitResourcesV1 : ResourceDictionary
 	{
 #if IS_WINUI
 		private const string PackageName =
-			"Uno.Toolkit.WinUI.Cupertino";
+			"Uno.Toolkit.WinUI.Material";
 		private const string PackageNameSuffix =
 			"winui";
 #else
 		private const string PackageName =
-			"Uno.Toolkit.UI.Cupertino";
+			"Uno.Toolkit.UI.Material";
 		private const string PackageNameSuffix =
 			"uwp";
 #endif
 
-		public CupertinoToolkitResources()
+		public MaterialToolkitResourcesV1()
 		{
-			Source = new Uri($"ms-appx:///{PackageName}/Generated/mergedpages.{PackageNameSuffix}.xaml");
+			Source = new Uri($"ms-appx:///{PackageName}/Generated/mergedpages.{PackageNameSuffix}.v1.xaml");
 		}
 	}
 }

--- a/src/library/Uno.Toolkit.Material/MaterialToolkitResourcesV2.cs
+++ b/src/library/Uno.Toolkit.Material/MaterialToolkitResourcesV2.cs
@@ -10,12 +10,12 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-/// <summary>
-/// Material Toolkit resources
-/// </summary>
 namespace Uno.Toolkit.UI.Material
 {
-	public sealed class MaterialToolkitResourcesV2 : ResourceDictionary
+	/// <summary>
+	/// Material (Material Design 3) styles for the controls in the Uno.Toolkit.UI library.
+	/// </summary>
+	public class MaterialToolkitResourcesV2 : ResourceDictionary
 	{
 #if IS_WINUI
 		private const string PackageName =

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.UI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.UI.Material.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/3.0.38">
 	<!--
 	Adding project references to this project requires some manual adjustments.
@@ -14,7 +14,7 @@
 		<PackageId>Uno.Toolkit.UI.Material</PackageId>
 		<IncludeLayoutFilesInPackage>true</IncludeLayoutFilesInPackage>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
 		<XamlMergeOutputFiles Include="Generated\mergedpages.uwp.v1.xaml" />
 		<XamlMergeOutputFiles Include="Generated\mergedpages.uwp.v2.xaml" />
@@ -39,10 +39,10 @@
 	</Choose>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Material" Version="2.0.0-dev.181" />
+		<PackageReference Include="Uno.Material" Version="2.0.0-dev.195" />
 		<PackageReference Include="Uno.UI" Version="4.2.0-dev.622" />
 	</ItemGroup>
-	
+
 	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 		<PackageReference Include="Microsoft.UI.Xaml" Version="2.6.0-prerelease.210623001" />
 	</ItemGroup>
@@ -69,7 +69,7 @@
 			<Name>Uno.Toolkit.UI</Name>
 		</ProjectReference>
 	</ItemGroup>
-	
+
 	<!-- Workaround to avoid including Uno.Toolkit.UI XBFs in the PRI file -->
 	<Target Name="AdjustGetPackagingOutputs" BeforeTargets="GetPackagingOutputs">
 		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/3.0.38">
 	<!--
 	Adding project references to this project requires some manual adjustments.
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Material.WinUI" Version="2.0.0-dev.181" />
+		<PackageReference Include="Uno.Material.WinUI" Version="2.0.0-dev.195" />
 		<PackageReference Include="Uno.WinUI" Version="4.2.0-dev.622" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.24" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.24" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
@@ -48,24 +48,24 @@
 
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
-			
+
 			<ItemGroup>
 				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
 			</ItemGroup>
-			
+
 			<ItemGroup>
 				<Page Remove="Generated\*.xaml" />
 			</ItemGroup>
 		</When>
 		<Otherwise>
-			
+
 			<ItemGroup>
 				<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 				<Compile Update="**\*.xaml.cs">
 					<DependentUpon>%(Filename)</DependentUpon>
 				</Compile>
 			</ItemGroup>
-			
+
 		</Otherwise>
 	</Choose>
   <ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the new behavior?
MaterialToolkitResources is now an "alias" (via subclassing) pointing to their latest version.
Updated xml doc for the res-dicts in this libraries to better reflect their functions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
This is a continuation of unoplatform/Uno.Themes#764.
The specific version can always be referenced by appending Vn after the class name.
Projects that still rely on V1 of this library, need to change the resource-dictionaries to include V1 explicitly now:
```xml
<MaterialToolkitResourcesV1 xmlns="using:Uno.Toolkit.UI.Material" />
```