### PR TITLE
fix: Remove use of SymbolIcon in NavBar styles

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v1/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v1/NavigationBar.xaml
@@ -20,14 +20,6 @@
 					xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
                     mc:Ignorable="android ios not_win mobile">
 
-    <mobile:Style x:Key="MaterialMainCommandStyle"
-           BasedOn="{StaticResource BaseMaterialMainCommandStyle}"
-           TargetType="AppBarButton" />
-
-    <mobile:Style x:Key="MaterialModalMainCommandStyle"
-           BasedOn="{StaticResource BaseMaterialModalMainCommandStyle}"
-           TargetType="AppBarButton" />
-
     <mobile:Style x:Key="MaterialNavigationBarStyle"
            BasedOn="{StaticResource BaseMaterialNavigationBarStyle}"
            TargetType="utu:NavigationBar">
@@ -39,45 +31,25 @@
 
     </mobile:Style>
 
-    <mobile:Style x:Key="MaterialModalNavigationBarStyle"
+	<mobile:Style x:Key="MaterialModalNavigationBarStyle"
            BasedOn="{StaticResource BaseMaterialModalNavigationBarStyle}"
            TargetType="utu:NavigationBar">
-        <ios:Setter Property="Height"
+		<ios:Setter Property="Height"
                     Value="NaN" />
-        <Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
-        <Setter Property="MainCommandStyle" Value="{StaticResource MaterialModalMainCommandStyle}" />
-        <Setter Property="Template" Value="{StaticResource NativeNavigationBarTemplate}" />
+		<Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
+		<Setter Property="MainCommandStyle" Value="{StaticResource MaterialModalMainCommandStyle}" />
+		<Setter Property="Template" Value="{StaticResource NativeNavigationBarTemplate}" />
 
-    </mobile:Style>
-    
-    <not_mobile:Style x:Key="MaterialMainCommandStyle"
-		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource BaseMaterialMainCommandStyle}">
-		<Setter Property="Icon">
-			<Setter.Value>
-				<SymbolIcon Symbol="Back" />
-			</Setter.Value>
-		</Setter>
-	</not_mobile:Style>
+	</mobile:Style>
 
-    <not_mobile:Style x:Key="MaterialNavigationBarStyle"
+	<not_mobile:Style x:Key="MaterialNavigationBarStyle"
 		   TargetType="utu:NavigationBar"
 		   BasedOn="{StaticResource BaseMaterialNavigationBarStyle}">
 		<Setter Property="MainCommandStyle"
 				Value="{StaticResource MaterialMainCommandStyle}" />
 	</not_mobile:Style>
-
-    <not_mobile:Style x:Key="MaterialModalMainCommandStyle"
-		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource BaseMaterialModalMainCommandStyle}">
-        <Setter Property="Icon">
-            <Setter.Value>
-                <SymbolIcon Symbol="Back" />
-            </Setter.Value>
-        </Setter>
-    </not_mobile:Style>
-
-    <not_mobile:Style x:Key="MaterialModalNavigationBarStyle"
+	
+	<not_mobile:Style x:Key="MaterialModalNavigationBarStyle"
 		   TargetType="utu:NavigationBar"
 		   BasedOn="{StaticResource BaseMaterialModalNavigationBarStyle}">
 		<Setter Property="MainCommandStyle"
@@ -650,7 +622,7 @@
 				Value="{StaticResource XamlMaterialNavigationBarTemplate}" />
     </Style>
 
-    <Style x:Key="BaseMaterialMainCommandStyle"
+    <Style x:Key="MaterialMainCommandStyle"
 		   TargetType="AppBarButton"
 		   BasedOn="{StaticResource MaterialAppBarButton}">
         <Setter Property="Foreground"
@@ -661,16 +633,16 @@
 		   TargetType="utu:NavigationBar"
 		   BasedOn="{StaticResource BaseMaterialNavigationBarStyle}">
         <Setter Property="MainCommandStyle"
-				Value="{StaticResource BaseMaterialModalMainCommandStyle}" />
+				Value="{StaticResource MaterialModalMainCommandStyle}" />
         <Setter Property="Background"
 				Value="{ThemeResource MaterialSurfaceBrush}" />
         <Setter Property="Foreground"
 				Value="{ThemeResource MaterialOnSurfaceBrush}" />
     </Style>
 
-    <Style x:Key="BaseMaterialModalMainCommandStyle"
+    <Style x:Key="MaterialModalMainCommandStyle"
 		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource BaseMaterialMainCommandStyle}">
+		   BasedOn="{StaticResource MaterialMainCommandStyle}">
         <Setter Property="Foreground"
 				Value="{ThemeResource MaterialOnSurfaceBrush}" />
     </Style>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
@@ -20,14 +20,6 @@
 					xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
                     mc:Ignorable="android ios not_win mobile">
 
-    <mobile:Style x:Key="M3MaterialMainCommandStyle"
-           BasedOn="{StaticResource BaseM3MaterialMainCommandStyle}"
-           TargetType="AppBarButton" />
-
-    <mobile:Style x:Key="M3MaterialModalMainCommandStyle"
-           BasedOn="{StaticResource BaseM3MaterialModalMainCommandStyle}"
-           TargetType="AppBarButton" />
-
     <mobile:Style x:Key="M3MaterialNavigationBarStyle"
            BasedOn="{StaticResource BaseM3MaterialNavigationBarStyle}"
            TargetType="utu:NavigationBar">
@@ -39,45 +31,25 @@
 
     </mobile:Style>
 
-    <mobile:Style x:Key="M3MaterialModalNavigationBarStyle"
+	<mobile:Style x:Key="M3MaterialModalNavigationBarStyle"
            BasedOn="{StaticResource BaseM3MaterialModalNavigationBarStyle}"
            TargetType="utu:NavigationBar">
-        <ios:Setter Property="Height"
+		<ios:Setter Property="Height"
                     Value="NaN" />
-        <Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
-        <Setter Property="MainCommandStyle" Value="{StaticResource M3MaterialModalMainCommandStyle}" />
-        <Setter Property="Template" Value="{StaticResource M3MaterialNativeNavigationBarTemplate}" />
+		<Setter Property="toolkit:VisibleBoundsPadding.PaddingMask" Value="Top" />
+		<Setter Property="MainCommandStyle" Value="{StaticResource M3MaterialModalMainCommandStyle}" />
+		<Setter Property="Template" Value="{StaticResource M3MaterialNativeNavigationBarTemplate}" />
 
-    </mobile:Style>
-    
-    <not_mobile:Style x:Key="M3MaterialMainCommandStyle"
-		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource BaseM3MaterialMainCommandStyle}">
-		<Setter Property="Icon">
-			<Setter.Value>
-				<SymbolIcon Symbol="Back" />
-			</Setter.Value>
-		</Setter>
-    </not_mobile:Style>
+	</mobile:Style>
 
-    <not_mobile:Style x:Key="M3MaterialNavigationBarStyle"
+	<not_mobile:Style x:Key="M3MaterialNavigationBarStyle"
 		   TargetType="utu:NavigationBar"
 		   BasedOn="{StaticResource BaseM3MaterialNavigationBarStyle}">
-        <Setter Property="MainCommandStyle"
+		<Setter Property="MainCommandStyle"
 				Value="{StaticResource M3MaterialMainCommandStyle}" />
-    </not_mobile:Style>
+	</not_mobile:Style>
 
-    <not_mobile:Style x:Key="M3MaterialModalMainCommandStyle"
-		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource BaseM3MaterialModalMainCommandStyle}">
-        <Setter Property="Icon">
-            <Setter.Value>
-                <SymbolIcon Symbol="Back" />
-            </Setter.Value>
-        </Setter>
-    </not_mobile:Style>
-
-    <not_mobile:Style x:Key="M3MaterialModalNavigationBarStyle"
+	<not_mobile:Style x:Key="M3MaterialModalNavigationBarStyle"
 		   TargetType="utu:NavigationBar"
 		   BasedOn="{StaticResource BaseM3MaterialModalNavigationBarStyle}">
 		<Setter Property="MainCommandStyle"
@@ -659,7 +631,7 @@
 				Value="{StaticResource XamlM3MaterialNavigationBarTemplate}" />
     </Style>
 
-    <Style x:Key="BaseM3MaterialMainCommandStyle"
+    <Style x:Key="M3MaterialMainCommandStyle"
 		   TargetType="AppBarButton"
 		   BasedOn="{StaticResource M3MaterialAppBarButtonStyle}">
         <Setter Property="Foreground"
@@ -670,16 +642,16 @@
 		   TargetType="utu:NavigationBar"
 		   BasedOn="{StaticResource BaseM3MaterialNavigationBarStyle}">
         <Setter Property="MainCommandStyle"
-				Value="{StaticResource BaseM3MaterialModalMainCommandStyle}" />
+				Value="{StaticResource M3MaterialModalMainCommandStyle}" />
         <Setter Property="Background"
 				Value="{ThemeResource SurfaceBrush}" />
         <Setter Property="Foreground"
 				Value="{ThemeResource OnSurfaceBrush}" />
     </Style>
 
-    <Style x:Key="BaseM3MaterialModalMainCommandStyle"
+    <Style x:Key="M3MaterialModalMainCommandStyle"
 		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource BaseM3MaterialMainCommandStyle}">
+		   BasedOn="{StaticResource M3MaterialMainCommandStyle}">
         <Setter Property="Foreground"
 				Value="{ThemeResource OnSurfaceBrush}" />
     </Style>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

On Windows, having more than one NavigationBar within the visual tree will cause a crash
This is because of the SymbolIcon: On Windows, no IconElement derived classes (besides BitmapIcon) can be used as a StaticResource and placed multiple times in the visual tree.

https://github.com/microsoft/microsoft-ui-xaml/issues/1494

## What is the new behavior?

Don't crash