### PR TITLE
fix(BottomTabBar): Adjust padding of BottomTabBarItems

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/BottomTabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/BottomTabBar.xaml
@@ -74,12 +74,13 @@
 	<x:Double x:Key="MaterialBottomTabBarHeight">80</x:Double>
 	<GridLength x:Key="MaterialBottomTabBarGridLengthHeight">80</GridLength>
 	<x:Double x:Key="FabItemVerticalOffset">-32</x:Double>
-	<x:Double x:Key="MaterialBottomTabBarItemIconHeight">20</x:Double>
-	<x:Double x:Key="MaterialBottomTabBarItemIconWidth">20</x:Double>
+	<x:Double x:Key="MaterialBottomTabBarItemIconHeight">18</x:Double>
+	<x:Double x:Key="MaterialBottomTabBarItemIconWidth">18</x:Double>
 	<Thickness x:Key="MaterialBottomTabBarItemContentMargin">0,0,0,6</Thickness>
+	<Thickness x:Key="MaterialBottomTabBarItemPadding">0,12,0,16</Thickness>
 	<Thickness x:Key="MaterialBottomTabBarItemContentOnlyMargin">12,0</Thickness>
-	<CornerRadius x:Key="MaterialBottomTabBarItemActiveIndicatorCornerRadius">12</CornerRadius>
-	<Thickness x:Key="MaterialBottomTabBarItemActiveIndicatorPadding">18,2</Thickness>
+	<CornerRadius x:Key="MaterialBottomTabBarItemActiveIndicatorCornerRadius">16</CornerRadius>
+	<Thickness x:Key="MaterialBottomTabBarItemActiveIndicatorPadding">22,7</Thickness>
 	<!--  Code can be removed when this issue is fixed in Uno:  -->
 	<!--  https://github.com/unoplatform/uno/issues/7393  -->
 	<!--  AjustedMaterialBottomTabBarHeight = MaterialBottomTabBarHeight + Half size of the Fab TabBarItem (including ElevatedView margin)  -->
@@ -309,6 +310,8 @@
 		        Value="True" />
 		<Setter Property="HorizontalContentAlignment"
 		        Value="Center" />
+		<Setter Property="Padding"
+		        Value="{StaticResource MaterialBottomTabBarItemPadding}" />
 		<!--  Workaround with these two properties until this issue is fixed, can be removed after  -->
 		<!--  https://github.com/unoplatform/uno/issues/7393  -->
 		<Setter Property="Height"
@@ -395,6 +398,8 @@
 									<VisualState.Setters>
 										<Setter Target="ContentPresenter.Visibility"
 										        Value="Collapsed" />
+										<Setter Target="ContentGrid.RowSpacing"
+										        Value="0" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="ContentOnly">
@@ -411,60 +416,60 @@
 								</VisualState>
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
-						<um:Ripple x:Name="RippleControl"
-						           Padding="{TemplateBinding Padding}"
-						           AutomationProperties.AccessibilityView="Raw"
-						           BorderBrush="{TemplateBinding BorderBrush}"
-						           BorderThickness="{TemplateBinding BorderThickness}"
-						           CornerRadius="{TemplateBinding CornerRadius}"
-						           Feedback="{ThemeResource OnSurfaceBrush}"
-						           FeedbackOpacity="{StaticResource PressedOpacity}">
-							<um:Ripple.Content>
-								<Grid>
-									<Rectangle x:Name="PointerRectangle"
-									           Fill="Transparent"
-									           Visibility="Collapsed" />
+					<um:Ripple x:Name="RippleControl"
+						        Padding="{TemplateBinding Padding}"
+						        AutomationProperties.AccessibilityView="Raw"
+						        BorderBrush="{TemplateBinding BorderBrush}"
+						        BorderThickness="{TemplateBinding BorderThickness}"
+						        CornerRadius="{TemplateBinding CornerRadius}"
+						        Feedback="{ThemeResource OnSurfaceBrush}"
+						        FeedbackOpacity="{StaticResource PressedOpacity}">
+						<um:Ripple.Content>
+							<Grid>
+								<Rectangle x:Name="PointerRectangle"
+									        Fill="Transparent"
+									        Visibility="Collapsed" />
 
-									<Grid x:Name="ContentGrid">
-										<Grid.RowDefinitions>
-											<RowDefinition x:Name="IconRow"
-											               Height="*" />
-											<RowDefinition x:Name="ContentRow"
-											               Height="Auto" />
-										</Grid.RowDefinitions>
+								<Grid x:Name="ContentGrid"
+									  RowSpacing="4">
+									<Grid.RowDefinitions>
+										<RowDefinition x:Name="IconRow"
+											            Height="*" />
+										<RowDefinition x:Name="ContentRow"
+											            Height="Auto" />
+									</Grid.RowDefinitions>
 
-										<Grid x:Name="ActiveIndicator"
-											  Background="{StaticResource MaterialBottomTabBarItemActiveIndicatorBackground}"
-											  VerticalAlignment="Center"
-											  HorizontalAlignment="Center"
-											  Padding="{StaticResource MaterialBottomTabBarItemActiveIndicatorPadding}"
-										      CornerRadius="{StaticResource MaterialBottomTabBarItemActiveIndicatorCornerRadius}">
-											<Viewbox x:Name="IconBox"
-											         Width="{StaticResource MaterialBottomTabBarItemIconWidth}"
-											         Height="{StaticResource MaterialBottomTabBarItemIconHeight}">
-												<ContentPresenter x:Name="Icon"
-												                  Content="{TemplateBinding Icon}"
-												                  Foreground="{StaticResource MaterialBottomTabBarItemIconForeground}" />
-											</Viewbox>
-										</Grid>
-										<ContentPresenter x:Name="ContentPresenter"
-										                  Grid.Row="1"
-										                  Margin="{StaticResource MaterialBottomTabBarItemContentMargin}"
-										                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-										                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-										                  AutomationProperties.AccessibilityView="Raw"
-										                  Content="{TemplateBinding Content}"
-										                  ContentTemplate="{TemplateBinding ContentTemplate}"
-										                  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-										                  ContentTransitions="{TemplateBinding ContentTransitions}"
-										                  FontSize="{TemplateBinding FontSize}"
-										                  FontFamily="{TemplateBinding FontFamily}"
-										                  FontWeight="{TemplateBinding FontWeight}"
-										                  Foreground="{TemplateBinding Foreground}"
-										                  TextWrapping="NoWrap" />
+									<Grid x:Name="ActiveIndicator"
+											Background="{StaticResource MaterialBottomTabBarItemActiveIndicatorBackground}"
+											VerticalAlignment="Center"
+											HorizontalAlignment="Center"
+											Padding="{StaticResource MaterialBottomTabBarItemActiveIndicatorPadding}"
+										    CornerRadius="{StaticResource MaterialBottomTabBarItemActiveIndicatorCornerRadius}">
+										<Viewbox x:Name="IconBox"
+											        Width="{StaticResource MaterialBottomTabBarItemIconWidth}"
+											        Height="{StaticResource MaterialBottomTabBarItemIconHeight}">
+											<ContentPresenter x:Name="Icon"
+												                Content="{TemplateBinding Icon}"
+												                Foreground="{StaticResource MaterialBottomTabBarItemIconForeground}" />
+										</Viewbox>
 									</Grid>
+									<ContentPresenter x:Name="ContentPresenter"
+										                Grid.Row="1"
+										                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+										                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+										                AutomationProperties.AccessibilityView="Raw"
+										                Content="{TemplateBinding Content}"
+										                ContentTemplate="{TemplateBinding ContentTemplate}"
+										                ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+										                ContentTransitions="{TemplateBinding ContentTransitions}"
+										                FontSize="{TemplateBinding FontSize}"
+										                FontFamily="{TemplateBinding FontFamily}"
+										                FontWeight="{TemplateBinding FontWeight}"
+										                Foreground="{TemplateBinding Foreground}"
+										                TextWrapping="NoWrap" />
 								</Grid>
-							</um:Ripple.Content>
+							</Grid>
+						</um:Ripple.Content>
 						</um:Ripple>
 					</Grid>
 				</ControlTemplate>


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.Figma/issues/689

Adjust padding values and icon size to match Figma file

![image](https://user-images.githubusercontent.com/4793020/172732007-da47721c-1ea6-45da-a496-d21c4fcdc099.png)![image](https://user-images.githubusercontent.com/4793020/172731787-3c191706-761d-4853-8f63-849094aff304.png)