### PR TITLE
fix: horizontal center align icons in tabbar

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/BottomTabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/BottomTabBar.xaml
@@ -444,15 +444,17 @@
 											VerticalAlignment="Center"
 											HorizontalAlignment="Center"
 											Padding="{StaticResource MaterialBottomTabBarItemActiveIndicatorPadding}"
-										    CornerRadius="{StaticResource MaterialBottomTabBarItemActiveIndicatorCornerRadius}">
-										<Viewbox x:Name="IconBox"
-											        Width="{StaticResource MaterialBottomTabBarItemIconWidth}"
+											CornerRadius="{StaticResource MaterialBottomTabBarItemActiveIndicatorCornerRadius}">
+											<Border  Width="{StaticResource MaterialBottomTabBarItemIconWidth}"
 											        Height="{StaticResource MaterialBottomTabBarItemIconHeight}">
-											<ContentPresenter x:Name="Icon"
-												                Content="{TemplateBinding Icon}"
-												                Foreground="{StaticResource MaterialBottomTabBarItemIconForeground}" />
-										</Viewbox>
-									</Grid>
+												<Viewbox x:Name="IconBox"
+														 HorizontalAlignment="Center">
+													<ContentPresenter x:Name="Icon"
+																	  Content="{TemplateBinding Icon}"
+																	  Foreground="{StaticResource MaterialBottomTabBarItemIconForeground}" />
+												</Viewbox>
+											</Border>
+										</Grid>
 									<ContentPresenter x:Name="ContentPresenter"
 										                Grid.Row="1"
 										                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"


### PR DESCRIPTION

old:
![image](https://user-images.githubusercontent.com/4793020/172888773-c7e6a3f3-0654-4c83-8e23-0abd729691fc.png)

new:
![image](https://user-images.githubusercontent.com/4793020/172888004-13e2b479-b6c5-447c-b3a5-ccacebec1480.png)
