### PR TITLE
fix(drawer): manipulation canceled in uno4 & eatten by scrollable/swipable elements

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DrawerControlSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DrawerControlSamplePage.xaml
@@ -27,13 +27,22 @@
 							<sample:ControlExample>
 								<sample:ControlExample.Content>
 									<utu:DrawerControl x:Name="SampleDrawerControl"
-													   Content="Content"
-													   DrawerContent="DrawerContent"
 													   IsOpen="{Binding ElementName=OptionIsOpen, Path=IsChecked, Mode=TwoWay}"
 													   OpenDirection="{Binding ElementName=OptionOpenDirection, Path=SelectedItem}"
 													   IsGestureEnabled="{Binding ElementName=OptionIsGestureEnabled, Path=IsChecked}"
 													   FitToDrawerContent="{Binding ElementName=OptionFitToDrawerContent, Path=IsChecked}"
-													   MinHeight="300" />
+													   MinHeight="300">
+
+										<TextBlock Text="Main Content" />
+
+										<utu:DrawerControl.DrawerContent>
+											<StackPanel>
+												<ToggleButton Content="IsOpen" IsChecked="{Binding ElementName=SampleDrawerControl, Path=IsOpen}" />
+												<TextBlock Text="Drawer Content" />
+											</StackPanel>
+										</utu:DrawerControl.DrawerContent>
+
+									</utu:DrawerControl>
 								</sample:ControlExample.Content>
 
 								<sample:ControlExample.Options>

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
@@ -35,7 +35,9 @@
 								Background="{TemplateBinding LightDismissOverlayBackground}" />
 						<ContentControl x:Name="DrawerContentControl"
 										Content="{TemplateBinding DrawerContent}"
-										Background="{TemplateBinding DrawerBackground}">
+										Background="{TemplateBinding DrawerBackground}"
+										HorizontalContentAlignment="{TemplateBinding HorizontalAlignment}"
+										VerticalContentAlignment="{TemplateBinding VerticalAlignment}">
 							<ContentControl.Template>
 								<ControlTemplate TargetType="ContentControl">
 									<Border Background="{TemplateBinding Background}">
@@ -47,6 +49,13 @@
 								<TranslateTransform />
 							</ContentControl.RenderTransform>
 						</ContentControl>
+
+						<!-- workaround for edge swipe to work on top of other control (eg: SwipeControl) -->
+						<!-- see: https://github.com/unoplatform/nventive-private/issues/271 -->
+						<Border x:Name="GestureInterceptor"
+								Background="Transparent"
+								Visibility="{Binding IsGestureEnabled, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TrueToVisible}}"
+								Margin="{TemplateBinding GestureInterceptorMargin}" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/nventive-private#363

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
uno4 manipulation event-source breaking change: https://github.com/unoplatform/nventive-private/issues/349
manipulation eatten by scrollable/swipable elements (gesture interceptor): https://github.com/unoplatform/nventive-private/issues/271