### PR TITLE
fix: sample app background not toggling with theme

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Styles/Application/Colors.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Styles/Application/Colors.xaml
@@ -16,15 +16,15 @@
 
 
 	<SolidColorBrush x:Key="DividerBrush"
-					 Color="{StaticResource MaterialOnSurfaceColor}"
+					 Color="{ThemeResource MaterialOnSurfaceColor}"
 					 Opacity="0.13" />
 
 	<SolidColorBrush x:Key="SampleSecondBackgroundBrush"
-					 Color="{StaticResource MaterialOnSurfaceColor}"
+					 Color="{ThemeResource MaterialOnSurfaceColor}"
 					 Opacity="0.05" />
 
 	<SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush"
-					 Color="{StaticResource MaterialBackgroundColor}" />
+					 Color="{ThemeResource MaterialBackgroundColor}" />
 
 	<Color x:Key="UnoBlueColor">#FF229DFC</Color>
 	<Color x:Key="UnoPurpleColor">#FF7A69F5</Color>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #267

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Samples app main content background doesnt toggle with theme

## What is the new behavior?
Samples app main content background will toggle with theme

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information
n/a