### PR TITLE
fix(NavigationBar): Properly subscribe to nested DP changes

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -84,21 +84,7 @@ namespace Uno.Toolkit.UI
 
 			if (Element is { } element)
 			{
-				yield return element.RegisterDisposableNestedPropertyChangedCallback(
-					(s, e) => Invalidate(),
-					new[] { AppBarButton.LabelProperty },
-					new[] { AppBarButton.IconProperty },
-					new[] { AppBarButton.IconProperty, BitmapIcon.UriSourceProperty },
-					new[] { AppBarButton.ContentProperty },
-					new[] { AppBarButton.ContentProperty, FrameworkElement.VisibilityProperty },
-					new[] { AppBarButton.OpacityProperty },
-					new[] { AppBarButton.ForegroundProperty },
-					new[] { AppBarButton.ForegroundProperty, SolidColorBrush.ColorProperty },
-					new[] { AppBarButton.ForegroundProperty, SolidColorBrush.OpacityProperty },
-					new[] { AppBarButton.VisibilityProperty },
-					new[] { AppBarButton.IsEnabledProperty },
-					new[] { AppBarButton.IsInOverflowProperty }
-				);
+				yield return element.SubscribeNestedPropertyChangedCallback((s,e) => Invalidate());
 			}
 		}
 
@@ -228,7 +214,6 @@ namespace Uno.Toolkit.UI
 				}
 			}
 
-			// Background
 			if (ColorHelper.TryGetColorWithOpacity(element?.Background, out var backgroundColor))
 			{
 				_appBarButtonWrapper?.SetBackgroundColor((Android.Graphics.Color)backgroundColor);

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
@@ -77,21 +77,7 @@ namespace Uno.Toolkit.UI
 				_appBarButtonWrapper = null;
 			});
 
-			yield return element.RegisterDisposableNestedPropertyChangedCallback(
-				(s, e) => Invalidate(),
-				new[] { AppBarButton.LabelProperty },
-				new[] { AppBarButton.IconProperty },
-				new[] { AppBarButton.IconProperty, BitmapIcon.UriSourceProperty },
-				new[] { AppBarButton.ContentProperty },
-				new[] { AppBarButton.ContentProperty, FrameworkElement.VisibilityProperty },
-				new[] { AppBarButton.OpacityProperty },
-				new[] { AppBarButton.ForegroundProperty },
-				new[] { AppBarButton.ForegroundProperty, SolidColorBrush.ColorProperty },
-				new[] { AppBarButton.ForegroundProperty, SolidColorBrush.OpacityProperty },
-				new[] { AppBarButton.VisibilityProperty },
-				new[] { AppBarButton.IsEnabledProperty },
-				new[] { AppBarButton.IsInOverflowProperty }
-			);
+			yield return element.SubscribeNestedPropertyChangedCallback((s, e) => Invalidate());
 
 			Native.Clicked += OnNativeClicked;
 			yield return Disposable.Create(() => { Native.Clicked -= OnNativeClicked; });

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
@@ -85,6 +85,7 @@ namespace Uno.Toolkit.UI
 				new[] { NavigationBar.MainCommandProperty, AppBarButton.ContentProperty }
 			);
 
+			yield return (element.MainCommand?.Icon as BitmapIcon).SubscribeNestedPropertyChangedCallback((s, e) => RegisterCommandVisibilityAndInvalidate());
 			RegisterCommandVisibilityAndInvalidate();
 		}
 

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.Android.cs
@@ -141,16 +141,12 @@ namespace Uno.Toolkit.UI
 
 				// Properties
 				yield return element.RegisterDisposableNestedPropertyChangedCallback(
-					(s, e) => Invalidate(),
+					OnPropertyChanged,
 					new[] { NavigationBar.PrimaryCommandsProperty },
 					new[] { NavigationBar.SecondaryCommandsProperty },
 					new[] { NavigationBar.ContentProperty },
 					new[] { NavigationBar.ForegroundProperty },
-					new[] { NavigationBar.ForegroundProperty, SolidColorBrush.ColorProperty },
-					new[] { NavigationBar.ForegroundProperty, SolidColorBrush.OpacityProperty },
 					new[] { NavigationBar.BackgroundProperty },
-					new[] { NavigationBar.BackgroundProperty, SolidColorBrush.ColorProperty },
-					new[] { NavigationBar.BackgroundProperty, SolidColorBrush.OpacityProperty },
 					new[] { NavigationBar.VisibilityProperty },
 					new[] { NavigationBar.PaddingProperty },
 					new[] { NavigationBar.OpacityProperty },
@@ -164,6 +160,12 @@ namespace Uno.Toolkit.UI
 					new[] { NavigationBar.MainCommandProperty, AppBarButton.IconProperty },
 					new[] { NavigationBar.MainCommandModeProperty }
 				);
+
+
+				yield return (element.MainCommand?.Icon as BitmapIcon).SubscribeNestedPropertyChangedCallback(OnPropertyChanged);
+				yield return (element.Background as SolidColorBrush).SubscribeNestedPropertyChangedCallback(OnPropertyChanged);
+				yield return (element.Foreground as SolidColorBrush).SubscribeNestedPropertyChangedCallback(OnPropertyChanged);
+
 			}
 		}
 
@@ -336,6 +338,11 @@ namespace Uno.Toolkit.UI
 				var imm = ContextHelper.Current.GetSystemService(Context.InputMethodService) as InputMethodManager;
 				imm?.HideSoftInputFromWindow(focused.WindowToken, HideSoftInputFlags.None);
 			}
+		}
+
+		private void OnPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			Invalidate();
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
@@ -49,25 +49,23 @@ namespace Uno.Toolkit.UI
 
 		protected override IEnumerable<IDisposable> Initialize()
 		{
-			if (Element == null)
+			if (Element is { } element)
 			{
-				yield break;
-			}
+				yield return element.RegisterDisposableNestedPropertyChangedCallback(
+					OnPropertyChanged,
+					new[] { NavigationBar.VisibilityProperty },
+					new[] { NavigationBar.PrimaryCommandsProperty },
+					new[] { NavigationBar.ContentProperty },
+					new[] { NavigationBar.ForegroundProperty },
+					new[] { NavigationBar.BackgroundProperty },
+					new[] { NavigationBar.MainCommandProperty, AppBarButton.ForegroundProperty },
+					new[] { NavigationBar.MainCommandProperty, AppBarButton.IconProperty }
+				);
 
-			yield return Element.RegisterDisposableNestedPropertyChangedCallback(
-				(s, e) => Invalidate(),
-				new[] { NavigationBar.VisibilityProperty },
-				new[] { NavigationBar.PrimaryCommandsProperty },
-				new[] { NavigationBar.ContentProperty },
-				new[] { NavigationBar.ForegroundProperty },
-				new[] { NavigationBar.ForegroundProperty, SolidColorBrush.ColorProperty },
-				new[] { NavigationBar.ForegroundProperty, SolidColorBrush.OpacityProperty },
-				new[] { NavigationBar.BackgroundProperty },
-				new[] { NavigationBar.BackgroundProperty, SolidColorBrush.ColorProperty },
-				new[] { NavigationBar.BackgroundProperty, SolidColorBrush.OpacityProperty },
-				new[] { NavigationBar.MainCommandProperty, AppBarButton.ForegroundProperty },
-				new[] { NavigationBar.MainCommandProperty, AppBarButton.IconProperty }
-			);
+				yield return (element.MainCommand?.Icon as BitmapIcon).SubscribeNestedPropertyChangedCallback(OnPropertyChanged);
+				yield return (element.Background as SolidColorBrush).SubscribeNestedPropertyChangedCallback(OnPropertyChanged);
+				yield return (element.Foreground as SolidColorBrush).SubscribeNestedPropertyChangedCallback(OnPropertyChanged);
+			}
 		}
 
 		protected override void Render()
@@ -279,6 +277,11 @@ namespace Uno.Toolkit.UI
 				Native.SetNeedsLayout();
 				Native.Superview?.SetNeedsLayout();
 			}
+		}
+
+		private void OnPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			Invalidate();
 		}
 	}
 

--- a/src/Uno.Toolkit.UI/Extensions/PropertyChangedExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/PropertyChangedExtensions.cs
@@ -1,0 +1,100 @@
+﻿#if HAS_UNO
+using System;
+using System.Collections.Generic;
+using Uno.Disposables;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	internal static class PropertyChangedExtensions
+	{
+		public static IDisposable SubscribeNestedPropertyChangedCallback(this AppBarButton? appBarButton, PropertyChangedCallback callback)
+		{
+			if (appBarButton == null)
+			{
+				return Disposable.Empty;
+			}
+
+			var disposable = new CompositeDisposable();
+
+			appBarButton
+				.RegisterDisposableNestedPropertyChangedCallback(
+					callback,
+					new[] { AppBarButton.LabelProperty },
+					new[] { AppBarButton.IconProperty },
+					new[] { AppBarButton.ContentProperty },
+					new[] { AppBarButton.ContentProperty, FrameworkElement.VisibilityProperty },
+					new[] { AppBarButton.OpacityProperty },
+					new[] { AppBarButton.ForegroundProperty },
+					new[] { AppBarButton.VisibilityProperty },
+					new[] { AppBarButton.IsEnabledProperty },
+					new[] { AppBarButton.IsInOverflowProperty }
+			   ).DisposeWith(disposable);
+
+			(appBarButton.Icon as BitmapIcon)
+				.SubscribeNestedPropertyChangedCallback(callback)
+				.DisposeWith(disposable);
+
+			(appBarButton.Foreground as SolidColorBrush)
+				.SubscribeNestedPropertyChangedCallback(callback)
+				.DisposeWith(disposable);
+
+			return disposable;
+		}
+
+		public static IDisposable SubscribeNestedPropertyChangedCallback(this SolidColorBrush? scb, PropertyChangedCallback callback)
+		{
+			if (scb == null)
+			{
+				return Disposable.Empty;
+			}
+
+			var disposable = new CompositeDisposable();
+
+			scb.RegisterDisposableNestedPropertyChangedCallback(
+				callback,
+				new[] { SolidColorBrush.ColorProperty },
+				new[] { SolidColorBrush.OpacityProperty }
+			).DisposeWith(disposable);
+
+			return disposable;
+		}
+
+		public static IDisposable SubscribeNestedPropertyChangedCallback(this BitmapIcon? bmp, PropertyChangedCallback callback)
+		{
+			if (bmp == null)
+			{
+				return Disposable.Empty;
+			}
+
+			var disposable = new CompositeDisposable();
+
+			bmp.RegisterDisposableNestedPropertyChangedCallback(
+				callback,
+				new[] { BitmapIcon.UriSourceProperty },
+				new[] { BitmapIcon.ForegroundProperty },
+				new[] { BitmapIcon.ShowAsMonochromeProperty }
+			).DisposeWith(disposable);
+
+			return disposable;
+		}
+	}
+}
+#endif


### PR DESCRIPTION
closes #298 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Converters for NavigationBar Foreground/Background or any of its AppBarButton properties were not working

## What is the new behavior?

Converters should now work