### PR TITLE
fix(NavigationBar): Avoid null BitmapIcon.UriSource

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -130,8 +130,11 @@ namespace Uno.Toolkit.UI
 				switch (element.Icon)
 				{
 					case BitmapIcon bitmap:
-						var drawable = DrawableHelper.FromUri(bitmap.UriSource);
-						native?.SetIcon(drawable);
+						if (bitmap.UriSource is { } uriSource)
+						{
+							var drawable = DrawableHelper.FromUri(uriSource);
+							native?.SetIcon(drawable);
+						}
 						break;
 
 					case FontIcon font: // not supported


### PR DESCRIPTION
closes #298

PR Type
What kind of change does this PR introduce?

Bugfix
What is the current behavior?
Converters for NavigationBar Foreground/Background or any of its AppBarButton properties were not working

What is the new behavior?
Converters should now work