### PR TITLE
fix: DrawerFlyoutPresenter namespace

### DIFF
--- a/doc/controls/DrawerFlyoutPresenter.md
+++ b/doc/controls/DrawerFlyoutPresenter.md
@@ -6,7 +6,7 @@
 ### Remarks
 All of the properties below can be used both as a dependency property or as an attached property, much like the `ScrollViewer` properties:
 ```xml
-xmlns:utu="using:Uno.Toolkit.UI.Controls"
+xmlns:utu="using:Uno.Toolkit.UI"
 
 <Style x:Key="CustomDrawerFlyoutPresenterStyle"
        BasedOn="{StaticResource DrawerFlyoutPresenterStyle}"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DrawerFlyoutSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/DrawerFlyoutSamplePage.xaml.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.Toolkit.Samples.Entities;
-using Uno.Toolkit.UI.Controls;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 

--- a/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.Properties.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class DrawerFlyoutPresenter
 	{

--- a/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.cs
@@ -32,7 +32,7 @@ using Windows.UI.Xaml.Media.Animation;
 using XamlWindow = Windows.UI.Xaml.Window;
 #endif
 
-namespace Uno.Toolkit.UI.Controls
+namespace Uno.Toolkit.UI
 {
 	public partial class DrawerFlyoutPresenter
 	{

--- a/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.xaml
@@ -1,8 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:utu="using:Uno.Toolkit.UI.Controls"
-					xmlns:win="using:Uno.Toolkit.UI.Controls"
+					xmlns:utu="using:Uno.Toolkit.UI"
+					xmlns:win="using:Uno.Toolkit.UI"
 					xmlns:not_win="http://uno.ui/not_win"
 					mc:Ignorable="not_win">
 


### PR DESCRIPTION
GitHub Issue (If applicable): resolved #311

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
DrawerFlyoutPresenter was in the wrong namespace.

## What is the new behavior?
is in the right place.