### PR TITLE
fix: invalid crosstargeting_override

### DIFF
--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -1,38 +1,37 @@
 <Project ToolsVersion="15.0">
-	<Project ToolsVersion="15.0">
-		<PropertyGroup>
-			<!--
-				This property allows the override of the nuget local cache.
-				Set it to the version you want to override, used in another app.
-				You will see the override path in the build output.
-				The packages are located under this directory: "%USERPROFILE%\.nuget\packages".
-			-->
-			<!-- <NugetOverrideVersion>1.0.0-dev.1</NugetOverrideVersion> -->
+	<PropertyGroup>
+		<!--
+			This property allows the override of the nuget local cache.
+			Set it to the version you want to override, used in another app.
+			You will see the override path in the build output.
+			The packages are located under this directory: "%USERPROFILE%\.nuget\packages".
+		-->
+		<!-- <NugetOverrideVersion>1.0.0-dev.1</NugetOverrideVersion> -->
 
-			<!--
-				This property is used to control the platforms compiled by Visual Studio, and 
-				allows for a faster build when testing for a single platform.
-				
-					Instructions:
-					1) Copy this file and remove the ".sample" name
-					2) Adjust the NugetOverrideVersion property below
-					3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
-				
-				Available build targets
+		<!--
+			This property is used to control the platforms compiled by Visual Studio, and
+			allows for a faster build when testing for a single platform.
 
-					uap10.0.18362 (Windows)
-					net5.0-windows10.0.18362 (WinAppSDK Windows)
-					xamarinios10 (iOS)
-					MonoAndroid11.0 (Android 11.0)
-					netstandard2.0 (WebAssembly, Skia)
-					net6.0-ios (.NET 6 iOS)
-					net6.0-android (.NET 6 Android)
-					net6.0-maccatalyst (.NET 6 macOS Catalyst)
-					net6.0-macos (.NET 6 macOS AppKit)
-					xamarinmac20 (macOS)
+				Instructions:
+				1) Copy this file and remove the ".sample" name
+				2) Adjust the NugetOverrideVersion property below
+				3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
 
-				Include netstandard2.0 to make sure all projects build
-			-->
-			<!-- <UnoTargetFrameworkOverride>netstandard2.0;uap10.0.18362</UnoTargetFrameworkOverride> -->
-		</PropertyGroup>
-	</Project>
+			Available build targets
+
+				uap10.0.18362 (Windows)
+				net5.0-windows10.0.18362 (WinAppSDK Windows)
+				xamarinios10 (iOS)
+				MonoAndroid11.0 (Android 11.0)
+				netstandard2.0 (WebAssembly, Skia)
+				net6.0-ios (.NET 6 iOS)
+				net6.0-android (.NET 6 Android)
+				net6.0-maccatalyst (.NET 6 macOS Catalyst)
+				net6.0-macos (.NET 6 macOS AppKit)
+				xamarinmac20 (macOS)
+
+			Include netstandard2.0 to make sure all projects build
+		-->
+		<!-- <UnoTargetFrameworkOverride>netstandard2.0;uap10.0.18362</UnoTargetFrameworkOverride> -->
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
invalid crosstargeting_override.props syntax, and the project wont build

## What is the new behavior?
project can now build

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->