### PR TITLE
fix: NavigationBar desync in certain scenario

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
@@ -1,4 +1,4 @@
-﻿#if __IOS__
+#if __IOS__
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -810,9 +810,9 @@ namespace Uno.Toolkit.UI
 			/// </summary>
 			public List<NavigationRequest> AssociatedRequests { get; } = new List<NavigationRequest>();
 
-			internal NavigationBar GetNavigationBar()
+			internal NavigationBar? GetNavigationBar()
 			{
-				return Page.FindFirstChild<NavigationBar>();
+				return Page?.FindTopNavigationBar();
 			}
 
 			public override string ToString()

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarHelper.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarHelper.iOS.cs
@@ -33,7 +33,7 @@ namespace Uno.Toolkit.UI
 		/// <param name="pageController">The controller of the page</param>
 		public static void PageCreated(UIViewController pageController)
 		{
-			var topNavigationBar = pageController.FindTopNavigationBar();
+			var topNavigationBar = pageController.View.FindTopNavigationBar();
 			if (topNavigationBar == null)
 			{
 				// The default NavigationBar style contains information that might be relevant to all pages, including those without a NavigationBar.
@@ -57,7 +57,7 @@ namespace Uno.Toolkit.UI
 		/// <param name="pageController">The controller of the page</param>
 		public static void PageDestroyed(UIViewController pageController)
 		{
-			if (pageController.FindTopNavigationBar() is { } topNavigationBar)
+			if (pageController.View.FindTopNavigationBar() is { } topNavigationBar)
 			{
 				SetNavigationItem(topNavigationBar, null);
 			}
@@ -69,7 +69,7 @@ namespace Uno.Toolkit.UI
 		/// <param name="pageController">The controller of the page</param>
 		public static void PageWillAppear(UIViewController pageController)
 		{
-			var topNavigationBar = pageController.FindTopNavigationBar();
+			var topNavigationBar = pageController.View.FindTopNavigationBar();
 			if (topNavigationBar != null)
 			{
 				if (topNavigationBar.Visibility == Visibility.Visible)
@@ -105,7 +105,7 @@ namespace Uno.Toolkit.UI
 		/// <param name="pageController">The controller of the page</param>
 		public static void PageDidDisappear(UIViewController pageController)
 		{
-			if (pageController.FindTopNavigationBar() is { } topNavigationBar)
+			if (pageController.View.FindTopNavigationBar() is { } topNavigationBar)
 			{
 				// Set the native navigation bar to null so it does not render when the page is not visible
 				SetNavigationBar(topNavigationBar, null);
@@ -114,16 +114,22 @@ namespace Uno.Toolkit.UI
 
 		public static void PageWillDisappear(UIViewController pageController)
 		{
-			if (pageController.FindTopNavigationBar() is { } topNavigationBar)
+			if (pageController.View.FindTopNavigationBar() is { } topNavigationBar)
 			{
 				// Set the native navigation bar to null so it does not render when the page is not visible
 				SetNavigationBar(topNavigationBar, null);
 			}
 		}
 
-		private static NavigationBar? FindTopNavigationBar(this UIViewController controller)
+		internal static NavigationBar? FindTopNavigationBar(this UIView? view)
 		{
-			return controller.View.FindFirstChild<NavigationBar?>();
+			if (view is null) return default;
+
+			return VisualTreeHelperEx.Native.GetFirstDescendant<NavigationBar>(
+				view,
+				x => x is not Frame, // prevent looking into the nested page
+				_ => true
+			);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): resolved: #307

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When navigating to an external view/controller and back, the NavigationBar re-initializes with the UIViewController (native concept) with the wrong instance of NavigationBar (toolkit control). This desync prevents the NavigationBar from updating.

## What is the new behavior?
^ not happening anymore.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->