### PR TITLE
fix(SafeArea): Ensure the root of the XAML tree is used to compute relative bounds of SafeArea control/owner

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SafeAreaSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SafeAreaSamplePage.xaml
@@ -32,6 +32,12 @@
 							Click="LaunchSoftInputSample"
 							Content="Show SoftInput Sample" />
 
+					<Button HorizontalAlignment="Center"
+							VerticalAlignment="Center"
+							AutomationProperties.AutomationId="SafeArea_Launch_Modal_Button"
+							Click="LaunchModalSample"
+							Content="Show Modal Sample" />
+
 				</StackPanel>
 			</DataTemplate>
 		</sample:SamplePageLayout.DesignAgnosticTemplate>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SafeAreaSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SafeAreaSamplePage.xaml.cs
@@ -9,6 +9,11 @@ using Windows.Foundation.Collections;
 using Uno.Toolkit.Samples.Content.NestedSamples;
 using Uno.Toolkit.UI;
 using Uno.Toolkit.Samples.Helpers;
+
+#if __IOS__
+using UIKit;
+#endif
+
 #if IS_WINUI
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -17,6 +22,8 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using XamlWindow = Microsoft.UI.Xaml.Window;
+
 #else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -25,6 +32,8 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using XamlWindow = Windows.UI.Xaml.Window;
+
 #endif
 
 namespace Uno.Toolkit.Samples.Content.Controls
@@ -50,6 +59,20 @@ namespace Uno.Toolkit.Samples.Content.Controls
 		private void LaunchSoftInputSample(object sender, RoutedEventArgs e)
 		{
 			Shell.GetForCurrentView().ShowNestedSample<SafeArea_SoftInput_NestedPage>(clearStack: true);
+		}
+
+		private void LaunchModalSample(object sender, RoutedEventArgs e)
+		{
+#if __IOS__
+			var vc = new UIViewController { View = new SafeArea_ModalPage() };
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+			{
+				// Esnure the behavior of the iPad modal presentation mimics that of the iPhone
+				vc.PreferredContentSize = XamlWindow.Current.Bounds.ToCGRect().Size;
+				vc.ModalPresentationStyle = UIModalPresentationStyle.FormSheet;
+			}
+			UIApplication.SharedApplication.KeyWindow.RootViewController.PresentModalViewController(vc, true);
+#endif
 		}
 	}
 }

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_ModalPage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_ModalPage.xaml
@@ -1,0 +1,45 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.SafeArea_ModalPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid utu:SafeArea.Insets="VisibleBounds"
+		  utu:SafeArea.SafeAreaOverride="0,0,0,30"
+		  Background="Blue"
+		  AutomationProperties.AutomationId="ContainerGrid">
+		<Rectangle Fill="Red"
+				   AutomationProperties.AutomationId="TestRectangle" />
+
+		<StackPanel>
+			<Grid>
+				<Button Content="Change Layout"
+						AutomationProperties.AutomationId="ChangeLayoutButton"
+						x:Name="ChangeLayoutButton"
+						HorizontalAlignment="Left"
+						Click="Button_Click" />
+
+				<Button Content="Close Modal"
+						AutomationProperties.AutomationId="CloseModalButton"
+						x:Name="CloseModalButton"
+						HorizontalAlignment="Right"
+						Click="CloseModalClick" />
+			</Grid>
+
+			<Rectangle Fill="Blue"
+					   Height="100"
+					   Width="100" />
+			<Rectangle x:Name="LayoutRectangle"
+					   Fill="Blue"
+					   Height="100"
+					   Width="100" />
+			<Rectangle Fill="Blue"
+					   Height="100"
+					   Width="100" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_ModalPage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_ModalPage.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+
+using Uno.Toolkit.UI;
+using Uno.UI.Toolkit;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.ViewManagement;
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using XamlWindow = Microsoft.UI.Xaml.Window;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using XamlWindow = Windows.UI.Xaml.Window;
+#endif
+#if __IOS__
+using UIKit;
+#endif
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class SafeArea_ModalPage : Page
+	{
+		public SafeArea_ModalPage()
+		{
+			this.InitializeComponent();
+		}
+
+		private void Button_Click(object sender, RoutedEventArgs e)
+		{
+			LayoutRectangle.Visibility = LayoutRectangle.Visibility == Visibility.Collapsed ? Visibility.Visible : Visibility.Collapsed;
+		}
+
+		private void CloseModalClick(object sender, RoutedEventArgs e)
+		{
+#if __IOS__
+			UIApplication.SharedApplication.KeyWindow.RootViewController.DismissModalViewController(animated: false);
+#endif
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
@@ -86,6 +86,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_Control_NestedPage.xaml.cs">
       <DependentUpon>SafeArea_Control_NestedPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_ModalPage.xaml.cs">
+      <DependentUpon>SafeArea_ModalPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_SoftInput_NestedPage.xaml.cs">
       <DependentUpon>SafeArea_SoftInput_NestedPage.xaml</DependentUpon>
     </Compile>
@@ -272,6 +275,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_Control_NestedPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_ModalPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -354,7 +354,9 @@ namespace Uno.Toolkit.UI
 					// If the owner view is scrollable, the visibility of interest is that of the scroll viewport.
 					var fixedControl = scrollAncestor ?? Owner;
 
-					var controlBounds = GetRelativeBounds(fixedControl, XamlWindow.Current.Content);
+					// Using relativeTo: null instead of Window.Current.Content since there are cases when the current UIElement
+					// may be outside the bounds of the current Window content, for example, when the element is hosted in a modal window.
+					var controlBounds = GetRelativeBounds(fixedControl, relativeTo: null);
 
 					visibilityPadding = CalculateVisibilityInsets(OffsetVisibleBounds, controlBounds);
 
@@ -528,7 +530,7 @@ namespace Uno.Toolkit.UI
 				return Owner?.FindFirstParent<ScrollViewer>();
 			}
 
-			private static Rect GetRelativeBounds(FrameworkElement boundsOf, UIElement relativeTo)
+			private static Rect GetRelativeBounds(FrameworkElement boundsOf, UIElement? relativeTo)
 			{
 				return boundsOf
 					.TransformToVisual(relativeTo)

--- a/src/Uno.Toolkit.UITest/Controls/SafeArea/Given_SafeArea.cs
+++ b/src/Uno.Toolkit.UITest/Controls/SafeArea/Given_SafeArea.cs
@@ -192,6 +192,39 @@ namespace Uno.Toolkit.UITest.Controls.SafeArea
 			}
 		}
 
+		[Test]
+		[ActivePlatforms(Platform.iOS)]
+		public void When_Inside_Modal()
+		{
+			const string Blue = "#0000FF";
+
+			App.FastTap("SafeArea_Launch_Modal_Button");
+
+			App.WaitForElement("ContainerGrid");
+			App.FastTap("ChangeLayoutButton");
+
+			var containerGrid = App.GetPhysicalRect("ContainerGrid");
+			var testRectangle = App.GetPhysicalRect("TestRectangle");
+
+			using var screenshot = TakeScreenshot("SafeArea_Modal_After_Relayout");
+
+			var safeAreaBottomInset = containerGrid.Bottom - testRectangle.Bottom;
+
+			Assert.AreEqual(30.LogicalToPhysicalPixels(App), safeAreaBottomInset);
+
+			for (int i = 1; i < safeAreaBottomInset; i++)
+			{
+				ImageAssert.HasPixels(
+					screenshot,
+					ExpectedPixels
+						.At(containerGrid.CenterX / 2, containerGrid.Bottom - i)
+						.Named($"SafeArea_Modal_Bottom_{i}")
+						.Pixel(Blue));
+			}
+
+			App.FastTap("CloseModalButton");
+		}
+
 		private void ClearMasks()
 		{
 			App.FastTap("ClearMasks");

--- a/src/Uno.Toolkit.UITest/TestBase.cs
+++ b/src/Uno.Toolkit.UITest/TestBase.cs
@@ -103,10 +103,6 @@ namespace Uno.Toolkit.UITest
 		{
 			TakeScreenshot("teardown");
 
-			//var isNestedFrameVisible = App.Marked("NestedSampleFrame")
-			//	.GetDependencyPropertyValue<string>("Visibility")
-			//	?.Equals("Visible", StringComparison.OrdinalIgnoreCase) ?? false;
-
 			if (App.Marked("NestedSampleFrame").HasResults())
 			{
 				ExitNestedSample();


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/412

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

SafeArea calculates improper offsets when the control is within a native iOS Modal window. We were using `TransformToVisual` relative to `Windows.Current.Content` which results in an offset of X=16, Y=47 since the Window.Content (white background) is no longer at position 0,0 while a modal (red background) is being displayed

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/4793020/190813416-c8601bf9-a0c8-4609-8927-e820e60598cd.png)

## What is the new behavior?

Use `TransformToVisual(null)` to ensure that the root of the XAML tree is used for the transformation