### PR TITLE
fix: WinUI NavBar back button support

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml.cs
@@ -53,6 +53,8 @@ namespace Uno.Toolkit.Samples
 		private XamlWindow _window;
 
 		private Shell _shell;
+		public static App Instance => Current as App;
+		public XamlWindow Window => _window;
 
 		/// <summary>
 		/// Initializes the singleton application object.  This is the first line of authored code

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if !IS_WINUI || HAS_UNO
+#define SYS_NAV_MGR_SUPPORTED
+#endif
+using System;
 using Windows.UI.Core;
 using System.Threading.Tasks;
 using Uno.Toolkit.Samples.Content.NestedSamples;
@@ -47,12 +50,12 @@ namespace Uno.Toolkit.Samples
 
 			NestedSampleFrame.RegisterPropertyChangedCallback(ContentControl.ContentProperty, OnNestedSampleFrameChanged);
 
-#if !IS_WINUI
+#if SYS_NAV_MGR_SUPPORTED
 			SystemNavigationManager.GetForCurrentView().BackRequested += (s, e) => e.Handled = BackNavigateFromNestedSample();
 #endif
 		}
 
-		public static Shell GetForCurrentView() => (Shell)XamlWindow.Current.Content;
+		public static Shell GetForCurrentView() => (Shell)App.Instance.Window.Content;
 
 		public MUXC.NavigationView NavigationView => NavigationViewControl;
 
@@ -121,7 +124,7 @@ namespace Uno.Toolkit.Samples
 				? Visibility.Visible
 				: Visibility.Collapsed;
 
-#if !IS_WINUI
+#if SYS_NAV_MGR_SUPPORTED
 			// toggle built-in back button for wasm (from browser) and uwp (on title bar)
 			SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = isInsideNestedSample
 				? AppViewBackButtonVisibility.Visible

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
@@ -1,6 +1,9 @@
 ﻿#if __IOS__ || __ANDROID__
 #define HAS_NATIVE_NAVBAR
 #endif
+#if !IS_WINUI || HAS_UNO
+#define SYS_NAV_MGR_SUPPORTED
+#endif
 #if __IOS__
 using UIKit;
 #endif
@@ -154,7 +157,8 @@ namespace Uno.Toolkit.UI
 			_pageRef = new WeakReference<Page?>(this.GetFirstParent<Page>());
 
 			_popupHost = Uno.Toolkit.UI.DependencyObjectExtensions.FindFirstParent<Popup>(this);
-#if !IS_WINUI
+
+#if SYS_NAV_MGR_SUPPORTED
 			SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
 			_backRequestedHandler.Disposable = Disposable.Create(() => SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested);
 #endif
@@ -204,10 +208,13 @@ namespace Uno.Toolkit.UI
 			}
 		}
 
-#if !IS_WINUI
+#if SYS_NAV_MGR_SUPPORTED
 		private void OnBackRequested(object? sender, BackRequestedEventArgs e)
 		{
-			e.Handled = TryPerformMainCommand();
+			if (!e.Handled)
+			{
+				e.Handled = TryPerformMainCommand();
+			}
 		}
 #endif
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

NavigationBar was not hooking onto SystemNavigationManager.BackRequested for Uno platforms that are targeting the WinUI APIs

## What is the new behavior?

NavigationBar now hooks onto SystemNavigationManager.BackRequested for Uno platforms that are targeting the WinUI APIs