### PR TITLE
fix(NavigationBar): Add NavigationBarContent property

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_ModalPage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_ModalPage.xaml
@@ -9,8 +9,8 @@
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Grid utu:SafeArea.Insets="VisibleBounds"
-		  utu:SafeArea.SafeAreaOverride="0,0,0,30"
 		  Background="Blue"
+		  x:Name="ContainerGrid"
 		  AutomationProperties.AutomationId="ContainerGrid">
 		<Rectangle Fill="Red"
 				   AutomationProperties.AutomationId="TestRectangle" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_ModalPage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_ModalPage.xaml.cs
@@ -35,6 +35,8 @@ namespace Uno.Toolkit.Samples.Content.NestedSamples
 		public SafeArea_ModalPage()
 		{
 			this.InitializeComponent();
+
+			SafeArea.SetSafeAreaOverride(ContainerGrid, new Thickness(0, 0, 0, 30));
 		}
 
 		private void Button_Click(object sender, RoutedEventArgs e)

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.xaml
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.xaml
@@ -25,7 +25,8 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBar">
-					<utu:NavigationBarPresenter x:Name="NavigationBarPresenter" />
+					<utu:NavigationBarPresenter x:Name="NavigationBarPresenter"
+												NavigationBarContent="{TemplateBinding Content}"/>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
@@ -36,6 +37,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBarPresenter">
 					<CommandBar x:Name="XamlNavigationBarCommandBar"
+								Content="{TemplateBinding NavigationBarContent}"
 								Style="{StaticResource NavigationBarCommandBar}" />
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.xaml
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.xaml
@@ -26,7 +26,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBar">
 					<utu:NavigationBarPresenter x:Name="NavigationBarPresenter"
-												NavigationBarContent="{TemplateBinding Content}"/>
+												Content="{TemplateBinding Content}"/>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
@@ -37,7 +37,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBarPresenter">
 					<CommandBar x:Name="XamlNavigationBarCommandBar"
-								Content="{TemplateBinding NavigationBarContent}"
+								Content="{TemplateBinding Content}"
 								Style="{StaticResource NavigationBarCommandBar}" />
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.Properties.cs
@@ -9,8 +9,8 @@ namespace Uno.Toolkit.UI
 	partial class NavigationBarPresenter
 	{
 		
-		public static DependencyProperty NavigationBarContentProperty { get; } = DependencyProperty.Register(
-			nameof(NavigationBarContent),
+		public static DependencyProperty ContentProperty { get; } = DependencyProperty.Register(
+			nameof(Content),
 			typeof(object),
 			typeof(NavigationBarPresenter),
 			new PropertyMetadata(default));
@@ -18,10 +18,10 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Gets or sets the NavigationBar Content
 		/// </summary>
-		public object NavigationBarContent
+		public object Content
 		{
-			get => GetValue(NavigationBarContentProperty);
-			set => SetValue(NavigationBarContentProperty, value);
+			get => GetValue(ContentProperty);
+			set => SetValue(ContentProperty, value);
 		}
 
 	}

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.Properties.cs
@@ -1,0 +1,28 @@
+﻿#if IS_WINUI
+using Microsoft.UI.Xaml;
+#else
+using Windows.UI.Xaml;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	partial class NavigationBarPresenter
+	{
+		
+		public static DependencyProperty NavigationBarContentProperty { get; } = DependencyProperty.Register(
+			nameof(NavigationBarContent),
+			typeof(object),
+			typeof(NavigationBarPresenter),
+			new PropertyMetadata(default));
+
+		/// <summary>
+		/// Gets or sets the NavigationBar Content
+		/// </summary>
+		public object NavigationBarContent
+		{
+			get => GetValue(NavigationBarContentProperty);
+			set => SetValue(NavigationBarContentProperty, value);
+		}
+
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.cs
@@ -26,7 +26,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Uno.Toolkit.UI
 {
-	public partial class NavigationBarPresenter : Control, INavigationBarPresenter
+	public partial class NavigationBarPresenter : ContentControl, INavigationBarPresenter
 	{
 		private const string XamlNavigationBarCommandBar = "XamlNavigationBarCommandBar";
 
@@ -94,7 +94,6 @@ namespace Uno.Toolkit.UI
 					_commandBar.SecondaryCommands.Add(command);
 				}
 
-				setBinding(_commandBar, navigationBar, CommandBar.ContentProperty, nameof(navigationBar.Content));
 				setBinding(_commandBar, navigationBar, CommandBar.IsStickyProperty, nameof(navigationBar.IsSticky));
 				setBinding(_commandBar, navigationBar, CommandBar.IsOpenProperty, nameof(navigationBar.IsOpen));
 				setBinding(_commandBar, navigationBar, CommandBar.LightDismissOverlayModeProperty, nameof(navigationBar.LightDismissOverlayMode));

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.cs
@@ -26,7 +26,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Uno.Toolkit.UI
 {
-	public partial class NavigationBarPresenter : ContentControl, INavigationBarPresenter
+	public partial class NavigationBarPresenter : Control, INavigationBarPresenter
 	{
 		private const string XamlNavigationBarCommandBar = "XamlNavigationBarCommandBar";
 

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v1/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v1/NavigationBar.xaml
@@ -77,7 +77,7 @@
     <ControlTemplate x:Key="XamlMaterialNavigationBarTemplate"
 					 TargetType="utu:NavigationBar">
         <utu:NavigationBarPresenter Style="{StaticResource MaterialNavigationBarPresenter}"
-									NavigationBarContent="{TemplateBinding Content}"
+									Content="{TemplateBinding Content}"
 									x:Name="NavigationBarPresenter" />
     </ControlTemplate>
 
@@ -87,7 +87,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="utu:NavigationBarPresenter">
                     <CommandBar x:Name="XamlNavigationBarCommandBar"
-								Content="{TemplateBinding NavigationBarContent}"
+								Content="{TemplateBinding Content}"
 								Style="{StaticResource MaterialNavigationBarCommandBar}" />
                 </ControlTemplate>
             </Setter.Value>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v1/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v1/NavigationBar.xaml
@@ -77,6 +77,7 @@
     <ControlTemplate x:Key="XamlMaterialNavigationBarTemplate"
 					 TargetType="utu:NavigationBar">
         <utu:NavigationBarPresenter Style="{StaticResource MaterialNavigationBarPresenter}"
+									NavigationBarContent="{TemplateBinding Content}"
 									x:Name="NavigationBarPresenter" />
     </ControlTemplate>
 
@@ -86,6 +87,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="utu:NavigationBarPresenter">
                     <CommandBar x:Name="XamlNavigationBarCommandBar"
+								Content="{TemplateBinding NavigationBarContent}"
 								Style="{StaticResource MaterialNavigationBarCommandBar}" />
                 </ControlTemplate>
             </Setter.Value>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
@@ -81,6 +81,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBarPresenter">
 					<CommandBar x:Name="XamlNavigationBarCommandBar"
+								Content="{TemplateBinding NavigationBarContent}"
 								Style="{StaticResource MaterialNavigationBarCommandBar}" />
 				</ControlTemplate>
 			</Setter.Value>
@@ -539,6 +540,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBarPresenter">
 					<CommandBar x:Name="XamlNavigationBarCommandBar"
+								Content="{TemplateBinding NavigationBarContent}"
 								Style="{StaticResource MaterialPrimaryNavigationBarCommandBar}" />
 				</ControlTemplate>
 			</Setter.Value>
@@ -1053,12 +1055,14 @@
 	<ControlTemplate x:Key="XamlMaterialNavigationBarTemplate"
 					 TargetType="utu:NavigationBar">
 		<utu:NavigationBarPresenter Style="{StaticResource MaterialNavigationBarPresenter}"
+									NavigationBarContent="{TemplateBinding Content}"
 									x:Name="NavigationBarPresenter" />
 	</ControlTemplate>
 
 	<ControlTemplate x:Key="XamlMaterialPrimaryNavigationBarTemplate"
 					 TargetType="utu:NavigationBar">
 		<utu:NavigationBarPresenter Style="{StaticResource MaterialPrimaryNavigationBarPresenter}"
+									NavigationBarContent="{TemplateBinding Content}"
 									x:Name="NavigationBarPresenter" />
 	</ControlTemplate>
 </ResourceDictionary>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
@@ -81,7 +81,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBarPresenter">
 					<CommandBar x:Name="XamlNavigationBarCommandBar"
-								Content="{TemplateBinding NavigationBarContent}"
+								Content="{TemplateBinding Content}"
 								Style="{StaticResource MaterialNavigationBarCommandBar}" />
 				</ControlTemplate>
 			</Setter.Value>
@@ -540,7 +540,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:NavigationBarPresenter">
 					<CommandBar x:Name="XamlNavigationBarCommandBar"
-								Content="{TemplateBinding NavigationBarContent}"
+								Content="{TemplateBinding Content}"
 								Style="{StaticResource MaterialPrimaryNavigationBarCommandBar}" />
 				</ControlTemplate>
 			</Setter.Value>
@@ -1055,14 +1055,14 @@
 	<ControlTemplate x:Key="XamlMaterialNavigationBarTemplate"
 					 TargetType="utu:NavigationBar">
 		<utu:NavigationBarPresenter Style="{StaticResource MaterialNavigationBarPresenter}"
-									NavigationBarContent="{TemplateBinding Content}"
+									Content="{TemplateBinding Content}"
 									x:Name="NavigationBarPresenter" />
 	</ControlTemplate>
 
 	<ControlTemplate x:Key="XamlMaterialPrimaryNavigationBarTemplate"
 					 TargetType="utu:NavigationBar">
 		<utu:NavigationBarPresenter Style="{StaticResource MaterialPrimaryNavigationBarPresenter}"
-									NavigationBarContent="{TemplateBinding Content}"
+									Content="{TemplateBinding Content}"
 									x:Name="NavigationBarPresenter" />
 	</ControlTemplate>
 </ResourceDictionary>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/9494

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Setting the `NavigationBar`'s Content to a `FrameworkElement` instead of just a string results in a crash on Windows 

## What is the new behavior?

Adding `NavigationBarContent` property on the `NavigationBarPresenter` and TemplateBinding that to the `CommandBar`'s `ContentProperty` works around the issue and avoid the crash.