### PR TITLE
fix: UWP and WinUI sample apps build error

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.Properties.cs
@@ -61,14 +61,14 @@ namespace Uno.Toolkit.UI
 		#endregion
 
 		#region SafeAreaOverride (Attached DP)
-		internal static DependencyProperty SafeAreaOverrideProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty SafeAreaOverrideProperty { get; } = DependencyProperty.RegisterAttached(
 			"SafeAreaOverride",
 			typeof(Thickness?),
 			typeof(SafeArea),
 			new PropertyMetadata(default, OnSafeAreaOverrideChanged));
 
-		internal static Thickness? GetSafeAreaOverride(DependencyObject obj) => (Thickness?)obj.GetValue(SafeAreaOverrideProperty);
-		internal static void SetSafeAreaOverride(DependencyObject obj, Thickness? value) => obj.SetValue(SafeAreaOverrideProperty, value);
+		public static Thickness? GetSafeAreaOverride(DependencyObject obj) => (Thickness?)obj.GetValue(SafeAreaOverrideProperty);
+		public static void SetSafeAreaOverride(DependencyObject obj, Thickness? value) => obj.SetValue(SafeAreaOverrideProperty, value);
 		#endregion
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): N/A


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

WinUI and UWP sample apps won't build because SafeAreaOverride could be resolved

## What is the new behavior?

No build errors for WinUI and UWP sample apps

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
