### PR TITLE
fix(ChipGroup): SelectionMemberPath overwritten by SelectionItem(s)

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.cs
@@ -60,21 +60,20 @@ namespace Uno.Toolkit.UI
 
 		private void ApplyIconTemplate()
 		{
-			if (IconTemplate != null)
+			var itemTemplate = IconTemplate;
+			foreach (var container in GetItemContainers())
 			{
-				foreach (var container in GetItemContainers())
-				{
-					container.Icon = container.Content;
-					container.IconTemplate = IconTemplate;
-				}
+				container.Icon = itemTemplate != null ? container.Content : null;
+				container.IconTemplate = itemTemplate;
 			}
 		}
 
 		private void ApplyCanRemoveProperty()
 		{
+			var canRemove = CanRemove;
 			foreach (var container in GetItemContainers())
 			{
-				container.CanRemove = CanRemove;
+				container.CanRemove = canRemove;
 			}
 		}
 

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.cs
@@ -50,12 +50,11 @@ namespace Uno.Toolkit.UI
 				: null;
 			foreach (var container in GetItemContainers())
 			{
+				container.ClearValue(Chip.IsCheckedProperty);
 				if (binding != null)
 				{
 					container.SetBinding(Chip.IsCheckedProperty, binding);
 				}
-
-				container.ClearValue(Chip.IsCheckedProperty);
 			}
 		}
 
@@ -172,6 +171,10 @@ namespace Uno.Toolkit.UI
 				{
 					container.SetBinding(Chip.IsCheckedProperty, new Binding { Path = new PropertyPath(SelectionMemberPath), Mode = BindingMode.TwoWay });
 				}
+				else
+				{
+					container.IsChecked = IsItemSelected(item);
+				}
 
 				if (IconTemplate != null)
 				{
@@ -179,7 +182,6 @@ namespace Uno.Toolkit.UI
 					container.IconTemplate = IconTemplate;
 				}
 
-				container.IsChecked = IsItemSelected(item);
 				container.CanRemove = CanRemove;
 
 				container.IsCheckedChanged += OnItemIsCheckedChanged;
@@ -204,6 +206,7 @@ namespace Uno.Toolkit.UI
 			if (element is Chip container)
 			{
 				container.ClearValue(Chip.IsCheckedProperty);
+				container.IsChecked = false;
 
 				container.Icon = null;
 				container.IconTemplate = null;


### PR DESCRIPTION
GitHub Issue (If applicable): #348

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Given:
```xml
<ChipGroup ItemsSource="{Binding Items}" SelectionMode="Multiple" SelectionMemberPath="IsSelected" />
```
```cs
public IEnumerable Items { get; } = Enumerable.Range(0, 9).Select(x => new { IsSelected = x % 2 == 0 }).ToArray();
```
None of the resulting chips are selected.

## What is the new behavior?
^ will work.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
