### PR TITLE
feat: Adding explicit style for LoadingView

### DIFF
--- a/doc/controls/LoadingView.md
+++ b/doc/controls/LoadingView.md
@@ -7,6 +7,7 @@ Property|Type|Description
 Source|ILoadable|Gets and sets the source `ILoadable` associated with this control.
 LoadingContent|object|Gets or sets the content to be displayed during loading/waiting.
 LoadingContentTemplate|DataTemplate|Gets or sets the template to be used to display the LoadingContent during loading/waiting.
+LoadingContentTemplateSelector|DataTemplateSelector|Gets or sets the template selector to be used to display the LoadingContent during loading/waiting.
 
 ## ILoadable
 Describes if this instance is currently in a busy state and notifies subscribers that said state when has changed.

--- a/doc/controls/LoadingView.md
+++ b/doc/controls/LoadingView.md
@@ -6,6 +6,7 @@ Property|Type|Description
 -|-|-
 Source|ILoadable|Gets and sets the source `ILoadable` associated with this control.
 LoadingContent|object|Gets or sets the content to be displayed during loading/waiting.
+LoadingContentTemplate|DataTemplate|Gets or sets the template to be used to display the LoadingContent during loading/waiting.
 
 ## ILoadable
 Describes if this instance is currently in a busy state and notifies subscribers that said state when has changed.

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/LoadingViewSample.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/LoadingViewSample.xaml
@@ -1,49 +1,49 @@
 ﻿<Page x:Class="Uno.Toolkit.Samples.Content.Controls.LoadingViewSample"
-      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:local="using:Uno.Toolkit.Samples.Content.Controls"
-      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:utu="using:Uno.Toolkit.UI"
-      xmlns:sample="using:Uno.Toolkit.Samples"
-      mc:Ignorable="d"
-      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:sample="using:Uno.Toolkit.Samples"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <sample:SamplePageLayout x:Name="SamplePageLayout"
-                             IsDesignAgnostic="True">
-        <sample:SamplePageLayout.DesignAgnosticTemplate>
-            <DataTemplate>
+	<sample:SamplePageLayout x:Name="SamplePageLayout"
+							 IsDesignAgnostic="True">
+		<sample:SamplePageLayout.DesignAgnosticTemplate>
+			<DataTemplate>
                 <utu:LoadingView DataContext="{Binding Data}"
                                  LoadingContent="Loading....">
-                    <utu:LoadingView.Source>
-                        <utu:CompositeLoadableSource>
-                            <utu:LoadableSource Source="{Binding LoadContent0Command}" />
-                            <utu:LoadableSource Source="{Binding LoadContent1Command}" />
-                        </utu:CompositeLoadableSource>
-                    </utu:LoadingView.Source>
+					<utu:LoadingView.Source>
+						<utu:CompositeLoadableSource>
+							<utu:LoadableSource Source="{Binding LoadContent0Command}" />
+							<utu:LoadableSource Source="{Binding LoadContent1Command}" />
+						</utu:CompositeLoadableSource>
+					</utu:LoadingView.Source>
 
-                    <StackPanel x:Name="TestPanel">
-                        <TextBlock Text="{Binding Text}" />
-                        <ListView ItemsSource="{Binding Source}" />
+					<StackPanel x:Name="TestPanel">
+						<TextBlock Text="{Binding Text}" />
+						<ListView ItemsSource="{Binding Source}" />
 
-                        <Button Content="Reload Text"
-                                Command="{Binding LoadContent0Command}" />
-                        <Button Content="Reload List"
-                                Command="{Binding LoadContent1Command}" />
-                    </StackPanel>
+						<Button Content="Reload Text"
+								Command="{Binding LoadContent0Command}" />
+						<Button Content="Reload List"
+								Command="{Binding LoadContent1Command}" />
+					</StackPanel>
 
 
                     <utu:LoadingView.LoadingContentTemplate>
                         <DataTemplate>
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                <ProgressRing IsActive="True" />
+						<ProgressRing IsActive="True" />
                                 <TextBlock Text="{Binding}" />
                             </StackPanel>
                         </DataTemplate>
                     </utu:LoadingView.LoadingContentTemplate>
-                </utu:LoadingView>
-            </DataTemplate>
-        </sample:SamplePageLayout.DesignAgnosticTemplate>
-    </sample:SamplePageLayout>
+				</utu:LoadingView>
+			</DataTemplate>
+		</sample:SamplePageLayout.DesignAgnosticTemplate>
+	</sample:SamplePageLayout>
 
 </Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/LoadingViewSample.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/LoadingViewSample.xaml
@@ -1,42 +1,49 @@
 ﻿<Page x:Class="Uno.Toolkit.Samples.Content.Controls.LoadingViewSample"
-	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:local="using:Uno.Toolkit.Samples.Content.Controls"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  xmlns:utu="using:Uno.Toolkit.UI"
-	  xmlns:sample="using:Uno.Toolkit.Samples"
-	  mc:Ignorable="d"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Uno.Toolkit.Samples.Content.Controls"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      xmlns:sample="using:Uno.Toolkit.Samples"
+      mc:Ignorable="d"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<sample:SamplePageLayout x:Name="SamplePageLayout"
-							 IsDesignAgnostic="True">
-		<sample:SamplePageLayout.DesignAgnosticTemplate>
-			<DataTemplate>
-				<utu:LoadingView DataContext="{Binding Data}">
-					<utu:LoadingView.Source>
-						<utu:CompositeLoadableSource>
-							<utu:LoadableSource Source="{Binding LoadContent0Command}" />
-							<utu:LoadableSource Source="{Binding LoadContent1Command}" />
-						</utu:CompositeLoadableSource>
-					</utu:LoadingView.Source>
+    <sample:SamplePageLayout x:Name="SamplePageLayout"
+                             IsDesignAgnostic="True">
+        <sample:SamplePageLayout.DesignAgnosticTemplate>
+            <DataTemplate>
+                <utu:LoadingView DataContext="{Binding Data}"
+                                 LoadingContent="Loading....">
+                    <utu:LoadingView.Source>
+                        <utu:CompositeLoadableSource>
+                            <utu:LoadableSource Source="{Binding LoadContent0Command}" />
+                            <utu:LoadableSource Source="{Binding LoadContent1Command}" />
+                        </utu:CompositeLoadableSource>
+                    </utu:LoadingView.Source>
 
-					<StackPanel x:Name="TestPanel">
-						<TextBlock Text="{Binding Text}" />
-						<ListView ItemsSource="{Binding Source}" />
+                    <StackPanel x:Name="TestPanel">
+                        <TextBlock Text="{Binding Text}" />
+                        <ListView ItemsSource="{Binding Source}" />
 
-						<Button Content="Reload Text"
-								Command="{Binding LoadContent0Command}" />
-						<Button Content="Reload List"
-								Command="{Binding LoadContent1Command}" />
-					</StackPanel>
+                        <Button Content="Reload Text"
+                                Command="{Binding LoadContent0Command}" />
+                        <Button Content="Reload List"
+                                Command="{Binding LoadContent1Command}" />
+                    </StackPanel>
 
-					<utu:LoadingView.LoadingContent>
-						<ProgressRing IsActive="True" />
-					</utu:LoadingView.LoadingContent>
-				</utu:LoadingView>
-			</DataTemplate>
-		</sample:SamplePageLayout.DesignAgnosticTemplate>
-	</sample:SamplePageLayout>
+
+                    <utu:LoadingView.LoadingContentTemplate>
+                        <DataTemplate>
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <ProgressRing IsActive="True" />
+                                <TextBlock Text="{Binding}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </utu:LoadingView.LoadingContentTemplate>
+                </utu:LoadingView>
+            </DataTemplate>
+        </sample:SamplePageLayout.DesignAgnosticTemplate>
+    </sample:SamplePageLayout>
 
 </Page>

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
@@ -64,6 +64,25 @@ namespace Uno.Toolkit.UI
 
 		#endregion
 
+		#region DependencyProperty: LoadingContentTemplate
+
+		public static DependencyProperty LoadingContentTemplateProperty { get; } = DependencyProperty.Register(
+			nameof(LoadingContentTemplate),
+			typeof(DataTemplate),
+			typeof(LoadingView),
+			new PropertyMetadata(default(object)));
+
+		/// <summary>
+		/// Gets or sets the content template to be used when displayin LoadingContent during loading/waiting.
+		/// </summary>
+		public object LoadingContentTemplate
+		{
+			get => (object)GetValue(LoadingContentTemplateProperty);
+			set => SetValue(LoadingContentTemplateProperty, value);
+		}
+
+		#endregion
+
 		private readonly SerialDisposable _subscription = new();
 		private bool _isReady;
 

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
@@ -78,9 +78,9 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Gets or sets the content template to be used when displayin LoadingContent during loading/waiting.
 		/// </summary>
-		public object LoadingContentTemplate
+		public DataTemplate LoadingContentTemplate
 		{
-			get => (object)GetValue(LoadingContentTemplateProperty);
+			get => (DataTemplate)GetValue(LoadingContentTemplateProperty);
 			set => SetValue(LoadingContentTemplateProperty, value);
 		}
 

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
@@ -18,11 +18,14 @@ namespace Uno.Toolkit.UI
 	/// <summary>
 	/// Represents a control that indicates that the UI is waiting on a task to complete.
 	/// </summary>
+	[TemplateVisualState(GroupName = VisualStateNames.GroupName, Name = VisualStateNames.Loading)]
+	[TemplateVisualState(GroupName = VisualStateNames.GroupName, Name = VisualStateNames.Loaded)]
 	public partial class LoadingView : ContentControl
 	{
 		private class VisualStateNames
 		{
 			// LoadingStates
+			public const string GroupName = "LoadingStates";
 			public const string Loading = nameof(Loading);
 			public const string Loaded = nameof(Loaded);
 		}

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
@@ -66,7 +66,6 @@ namespace Uno.Toolkit.UI
 		}
 
 		#endregion
-
 		#region DependencyProperty: LoadingContentTemplate
 
 		public static DependencyProperty LoadingContentTemplateProperty { get; } = DependencyProperty.Register(
@@ -85,8 +84,7 @@ namespace Uno.Toolkit.UI
 		}
 
 		#endregion
-
-		#region DependencyProperty: LoadingContentTemplate
+		#region DependencyProperty: LoadingContentTemplateSelector
 
 		public static DependencyProperty LoadingContentTemplateSelectorProperty { get; } = DependencyProperty.Register(
 			nameof(LoadingContentTemplateSelector),

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
@@ -86,6 +86,25 @@ namespace Uno.Toolkit.UI
 
 		#endregion
 
+		#region DependencyProperty: LoadingContentTemplate
+
+		public static DependencyProperty LoadingContentTemplateSelectorProperty { get; } = DependencyProperty.Register(
+			nameof(LoadingContentTemplateSelector),
+			typeof(DataTemplateSelector),
+			typeof(LoadingView),
+			new PropertyMetadata(default(object)));
+
+		/// <summary>
+		/// Gets or sets the content template to be used when displayin LoadingContent during loading/waiting.
+		/// </summary>
+		public DataTemplateSelector LoadingContentTemplateSelector
+		{
+			get => (DataTemplateSelector)GetValue(LoadingContentTemplateSelectorProperty);
+			set => SetValue(LoadingContentTemplateSelectorProperty, value);
+		}
+
+		#endregion
+
 		private readonly SerialDisposable _subscription = new();
 		private bool _isReady;
 

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.xaml
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.xaml
@@ -43,7 +43,8 @@
 										  VerticalContentAlignment="Stretch" />
 						<ContentControl x:Name="LoadingContentPresenter"
 										Content="{TemplateBinding LoadingContent}"
-										HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        ContentTemplate="{TemplateBinding LoadingContentTemplate}"
+                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 										HorizontalContentAlignment="Stretch"
 										VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 										VerticalContentAlignment="Stretch" />

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.xaml
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.xaml
@@ -44,6 +44,7 @@
 						<ContentControl x:Name="LoadingContentPresenter"
 										Content="{TemplateBinding LoadingContent}"
                                         ContentTemplate="{TemplateBinding LoadingContentTemplate}"
+										ContentTemplateSelector="{TemplateBinding LoadingContentTemplateSelector}"
                                         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 										HorizontalContentAlignment="Stretch"
 										VerticalAlignment="{TemplateBinding VerticalContentAlignment}"

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.xaml
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.xaml
@@ -7,7 +7,7 @@
 
 	<x:String x:Key="DefaultLoadingViewAnimationDuration">00:00:00.083</x:String>
 
-	<Style TargetType="utu:LoadingView">
+	<Style x:Key="DefaultLoadingView" TargetType="utu:LoadingView">
 
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -52,4 +52,7 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+    
+    <Style TargetType="utu:LoadingView"
+           BasedOn="{StaticResource DefaultLoadingView}" />
 </ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): #336
 
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

No explicit style - applications have to copy entire style instead of just adding LoadingContent (or overriding specific properties)
No LoadingContentTemplate
No TemplateVisualState attributes defining what visual states should exist in the controltemplate

## What is the new behavior?

Adds DefaultLoadingView explicit style
Implicit LoadingView style is BasedOn the added DefaultLoadingView style
Added LoadingContentTemplate property
Added TemplateVisualState attribtues for the Loading and Loaded visual states

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
