### PR TITLE
chore: fix renamed VSMngrExtensions property getter

### DIFF
--- a/doc/helpers/VisualStateManager-extensions.md
+++ b/doc/helpers/VisualStateManager-extensions.md
@@ -4,7 +4,7 @@ Provides a way of manipulating the visual states of `Control` with attached prop
 ## Remarks
 `VisualStateManager.GoToState` is typically used with `Control` where you would set `<VisualStateManager.VisualStateGroups>` on the root element of the ControlTemplate. Because this class is implemented using the same method, it means that if you are setting `StatesProperty` on an element, the `VisualStateManager.VisualStateGroups` should not be set on the very same element, but its first child:
 ```xml
-<Page utu:VisualStateManagerExtensions.States="{Binding OnboardingState}">
+<Page utu:VisualStateManagerExtensions.States="{Binding OnboardingState, Mode=OneWay}">
     <!-- Wrong -->
     <VisualStateManager.VisualStateGroups>...
 
@@ -29,7 +29,7 @@ States\*: The accepted value can be a space, comma or semi-colon separated list 
 ```xml
 <Page ...
       xmlns:utu="using:Uno.Toolkit.UI"
-      utu:VisualStateManagerExtensions.States="{Binding PageState}">
+      utu:VisualStateManagerExtensions.States="{Binding PageState, Mode=OneWay}">
     <Grid ColumnDefinitions="Auto,*" RowDefinitions="*,*,*">
 
         <VisualStateManager.VisualStateGroups>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/VisualStateManagerExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/VisualStateManagerExtensionsSamplePage.xaml
@@ -12,7 +12,7 @@
 		<sample:SamplePageLayout.DesignAgnosticTemplate>
 			<DataTemplate>
 				<UserControl DataContext="{Binding Data}"
-							 utu:VisualStateManagerExtensions.States="{Binding PageState}"
+							 utu:VisualStateManagerExtensions.States="{Binding PageState, Mode=OneWay}"
 							 Margin="0,16,0,0">
 					<Grid>
 						<Grid.ColumnDefinitions>

--- a/src/Uno.Toolkit.UI/Behaviors/VisualStateManagerExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/VisualStateManagerExtensions.cs
@@ -7,6 +7,7 @@ using Uno.Extensions;
 using Uno.Logging;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.ComponentModel;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -44,10 +45,6 @@ public static class VisualStateManagerExtensions
 		typeof(VisualStateManagerExtensions),
 		new PropertyMetadata(default(string), OnStatesChanged));
 
-	// We need to include both a Set{PropertyName} and a Get{PropertyName} method for attached properties on Windows.
-	// Otherwise, you may end up with errors such as "System.Void should not be used in C#"
-	// See: https://learn.microsoft.com/en-us/windows/uwp/xaml-platform/custom-attached-properties#registering-a-custom-attached-property
-
 	/// <summary>
 	/// Sets the visual states of the control.
 	/// </summary>
@@ -55,12 +52,16 @@ public static class VisualStateManagerExtensions
 	/// <param name="value">A space, comma or semi-colon separated list of visual state names</param>
 	public static void SetStates(Control obj, string value) => obj.SetValue(StatesProperty, value);
 
-	
+	// We need to include both a Set{PropertyName} and a Get{PropertyName} method for attached properties on Windows.
+	// Otherwise, you may end up with errors such as "System.Void should not be used in C#" in release build.
+	// See: https://learn.microsoft.com/en-us/windows/uwp/xaml-platform/custom-attached-properties#registering-a-custom-attached-property
+
 	/// <summary>
-	/// Gets the overridden visual states of the control.
+	/// Gets the visual states of the control.
 	/// </summary>
 	/// <param name="obj"></param>
-	public static string GetOverrideStates(Control obj) => (string)obj.GetValue(OverrideStatesProperty);
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static string GetStates(Control obj) => (string)obj.GetValue(StatesProperty);
 
 	#endregion
 


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
DP getter was added in #328, and the said DP was renamed in #344.
Now, the getter cant find its DP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
