### PR TITLE
fix(NativeFramePresenter): Allow Frame BackStack manipulation

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
@@ -21,7 +21,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\Uno.Toolkit.Samples.Shared\Strings</ResourcesDirectory>
-
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -71,7 +70,7 @@
     <PackageReference Include="Uno.Material">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.5.9" />
+    <PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NativeFrameSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NativeFrameSamplePage.xaml
@@ -1,0 +1,25 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.Controls.NativeFrameSamplePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.Controls"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:nested="Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:sample="using:Uno.Toolkit.Samples"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	  mc:Ignorable="d">
+
+	<sample:SamplePageLayout IsDesignAgnostic="True" x:Name="NativeFrameSamplePageLayout">
+		<sample:SamplePageLayout.DesignAgnosticTemplate>
+			<DataTemplate>
+				<StackPanel Margin="50"
+							Spacing="8">
+					<Button AutomationProperties.AutomationId="NativeFrame_Launch_Sample_Button"
+							Click="LaunchNestedSample"
+							Content="Show Sample" />
+				</StackPanel>
+			</DataTemplate>
+		</sample:SamplePageLayout.DesignAgnosticTemplate>
+	</sample:SamplePageLayout>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NativeFrameSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NativeFrameSamplePage.xaml.cs
@@ -1,0 +1,36 @@
+﻿using Uno.Toolkit.Samples.Entities;
+using Uno.Toolkit.Samples.Content.NestedSamples;
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.Controls
+{
+	[SamplePage(SampleCategory.Controls, "NativeFrame")]
+	public sealed partial class NativeFrameSamplePage : Page
+	{
+		public NativeFrameSamplePage()
+		{
+			this.InitializeComponent();
+		}
+
+		private void LaunchNestedSample(object sender, RoutedEventArgs e)
+		{
+			Shell.GetForCurrentView().ShowNestedSample<NativeFrame_MainPage>(clearStack: true);
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_MainPage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_MainPage.xaml
@@ -1,0 +1,26 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.NativeFrame_MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  Background="Blue"
+	  mc:Ignorable="d">
+
+	<StackPanel utu:SafeArea.Insets="VisibleBounds">
+		<TextBlock Margin="20"
+				   AutomationProperties.AutomationId="NativeFrame_MainPage_Title"
+				   FontSize="30"
+				   Text="Main Page" />
+		<Button AutomationProperties.AutomationId="NativeFrame_MainPage_NextBtn"
+				Click="NextClick"
+				Content="Next Page" />
+		<Button AutomationProperties.AutomationId="NativeFrame_MainPage_DeeplinkBtn"
+				Click="DeeplinkToPage2"
+				Content="Deeplink to Page 2" />
+		<Button AutomationProperties.AutomationId="NativeFrame_MainPage_ExitBtn"
+				Click="ExitNestedSample"
+				Content="Exit Sample" />
+	</StackPanel>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_MainPage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_MainPage.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+	public sealed partial class NativeFrame_MainPage : Page
+	{
+		public NativeFrame_MainPage()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ExitNestedSample(object sender, RoutedEventArgs e)
+		{
+			Shell.GetForCurrentView()?.BackNavigateFromNestedSample();
+		}
+
+		private void NextClick(object sender, RoutedEventArgs e)
+		{
+			this.Frame.Navigate(typeof(NativeFrame_Page1));
+		}
+
+		private void DeeplinkToPage2(object sender, RoutedEventArgs e)
+		{
+			this.Frame.Navigate(typeof(NativeFrame_Page2));
+			this.Frame.BackStack.Clear();
+			this.Frame.BackStack.Add(new PageStackEntry(typeof(NativeFrame_MainPage), null, null));
+			this.Frame.BackStack.Add(new PageStackEntry(typeof(NativeFrame_Page1), null, null));
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_Page1.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_Page1.xaml
@@ -1,0 +1,23 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.NativeFrame_Page1"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  Background="Red"
+	  mc:Ignorable="d">
+
+	<StackPanel utu:SafeArea.Insets="VisibleBounds">
+		<TextBlock Margin="20"
+				   AutomationProperties.AutomationId="NativeFrame_Page1_Title"
+				   FontSize="30"
+				   Text="Page 1" />
+		<Button AutomationProperties.AutomationId="NativeFrame_Page1_NextBtn"
+				Click="NextClick"
+				Content="Next" />
+		<Button AutomationProperties.AutomationId="NativeFrame_Page1_BackBtn"
+				Click="BackClick"
+				Content="Back" />
+	</StackPanel>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_Page1.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_Page1.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+	public sealed partial class NativeFrame_Page1 : Page
+	{
+		public NativeFrame_Page1()
+		{
+			this.InitializeComponent();
+		}
+
+		private void NextClick(object sender, RoutedEventArgs e)
+		{
+			this.Frame.Navigate(typeof(NativeFrame_Page2));
+		}
+		private void BackClick(object sender, RoutedEventArgs e)
+		{
+			this.Frame.GoBack();
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_Page2.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_Page2.xaml
@@ -1,0 +1,23 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.NativeFrame_Page2"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  Background="Purple"
+	  mc:Ignorable="d">
+
+	<StackPanel utu:SafeArea.Insets="VisibleBounds">
+		<TextBlock Margin="20"
+				   AutomationProperties.AutomationId="NativeFrame_Page2_Title"
+				   FontSize="30"
+				   Text="Page 2" />
+		<Button AutomationProperties.AutomationId="NativeFrame_Page2_BackBtn"
+				Click="BackClick"
+				Content="Back" />
+		<Button AutomationProperties.AutomationId="NativeFrame_Page2_BackWithBackStackBtn"
+				Click="ChangeBackStackClick"
+				Content="Back using BackStack manipulation" />
+	</StackPanel>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_Page2.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/NativeFrame_Page2.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+	public sealed partial class NativeFrame_Page2 : Page
+	{
+		public NativeFrame_Page2()
+		{
+			this.InitializeComponent();
+		}
+
+		private void BackClick(object sender, RoutedEventArgs e)
+		{
+			this.Frame.GoBack();
+		}
+
+		private void ChangeBackStackClick(object sender, RoutedEventArgs e)
+		{
+			var entry = this.Frame.BackStack.Last();
+			var newEntry = new PageStackEntry(entry.SourcePageType, new Dictionary<string, object>(), entry.NavigationTransitionInfo);
+			this.Frame.BackStack.Remove(entry);
+			this.Frame.BackStack.Add(newEntry);
+			this.Frame.GoBack();
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
@@ -38,6 +38,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\LoadingViewSample.xaml.cs">
       <DependentUpon>LoadingViewSample.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\NativeFrameSamplePage.xaml.cs">
+      <DependentUpon>NativeFrameSamplePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\Controls\SafeAreaSamplePage.xaml.cs">
       <DependentUpon>SafeAreaSamplePage.xaml</DependentUpon>
     </Compile>
@@ -82,6 +85,15 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\MaterialNavigationBarSample_DataContext_NestedPage1.xaml.cs">
       <DependentUpon>MaterialNavigationBarSample_DataContext_NestedPage1.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\NativeFrame_MainPage.xaml.cs">
+      <DependentUpon>NativeFrame_MainPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\NativeFrame_Page1.xaml.cs">
+      <DependentUpon>NativeFrame_Page1.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\NativeFrame_Page2.xaml.cs">
+      <DependentUpon>NativeFrame_Page2.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeAreaSamplePage_NestedPage.xaml.cs">
       <DependentUpon>SafeAreaSamplePage_NestedPage.xaml</DependentUpon>
@@ -217,6 +229,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\Controls\NativeFrameSamplePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Content\Controls\SafeAreaSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -274,6 +290,18 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\MaterialNavigationBarSample_DataContext_NestedPage1.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\NativeFrame_MainPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\NativeFrame_Page1.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\NativeFrame_Page2.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.UWP/Uno.Toolkit.Samples.UWP.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.UWP/Uno.Toolkit.Samples.UWP.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Uno.Material">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.5.9" />
+    <PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.iOS/Uno.Toolkit.Samples.iOS.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.iOS/Uno.Toolkit.Samples.iOS.csproj
@@ -12,7 +12,6 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <ResourcesDirectory>..\Uno.Toolkit.Samples.Shared\Strings</ResourcesDirectory>
-
     <ProvisioningType>manual</ProvisioningType>
   </PropertyGroup>
   <PropertyGroup>
@@ -32,7 +31,6 @@
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-
     <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. -->
     <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
   </PropertyGroup>
@@ -46,7 +44,6 @@
     <MtouchArch>x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-
     <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. -->
     <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
   </PropertyGroup>
@@ -64,7 +61,6 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-
     <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. -->
     <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
   </PropertyGroup>
@@ -198,7 +194,7 @@
     <PackageReference Include="Uno.Material">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.5.9" />
+    <PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.macOS/Uno.Toolkit.Samples.macOS.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.macOS/Uno.Toolkit.Samples.macOS.csproj
@@ -11,7 +11,6 @@
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
-
   </PropertyGroup>
   <PropertyGroup>
     <!-- Workaround for https://github.com/unoplatform/uno/discussions/5007 -->
@@ -80,7 +79,7 @@
     <PackageReference Include="Uno.Material">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.5.9" />
+    <PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/Uno.Toolkit.WinUI.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/Uno.Toolkit.WinUI.Samples.Droid.csproj
@@ -21,7 +21,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\Uno.Toolkit.Samples.Shared\Strings</ResourcesDirectory>
-
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -77,7 +76,7 @@
     <PackageReference Include="Uno.Material.WinUI">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.WinUI" Version="4.5.9" />
+    <PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.iOS/Uno.Toolkit.WinUI.Samples.iOS.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.iOS/Uno.Toolkit.WinUI.Samples.iOS.csproj
@@ -12,7 +12,6 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <ResourcesDirectory>..\Uno.Toolkit.WinUI.Samples.Shared\Strings</ResourcesDirectory>
-
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -27,8 +26,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-
-    <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. --> 
+    <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. -->
     <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
@@ -41,8 +39,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-
-    <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. --> 
+    <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. -->
     <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
@@ -59,8 +56,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-
-    <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. --> 
+    <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. -->
     <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
@@ -77,8 +73,7 @@
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
     <BuildIpa>true</BuildIpa>
     <MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-
-    <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. --> 
+    <!-- uno#9430: Building for the iOS Simulator requires the use of the static registrar. -->
     <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
@@ -142,7 +137,7 @@
     <PackageReference Include="Uno.Material.WinUI">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.WinUI" Version="4.5.9" />
+    <PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.macOS/Uno.Toolkit.WinUI.Samples.macOS.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.macOS/Uno.Toolkit.WinUI.Samples.macOS.csproj
@@ -11,7 +11,6 @@
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
-
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -76,7 +75,7 @@
     <PackageReference Include="Uno.Material.WinUI">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Uno.WinUI" Version="4.5.9" />
+    <PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
@@ -401,14 +401,16 @@ namespace Uno.Toolkit.UI
 
 		private void ForceFrameStateIntoNavigationController()
 		{
+		var viewControllers2 = _frame?.BackStack
+				.Concat(FrameNavigationHelper.GetCurrentEntry(_frame))
+				.Where(entry => entry != null)
+				.ToArray();
 			var viewControllers = _frame?.BackStack
 				.Concat(FrameNavigationHelper.GetCurrentEntry(_frame))
 				.Where(entry => entry != null)
 				.Distinct()
 				.OfType<PageStackEntry>()
-				.Select(entry => FrameNavigationHelper.GetInstance(entry) is { } instance
-						? instance.FindViewController() ?? new PageViewController(instance)
-						: new PageViewController(null))
+				.Select(FindOrCreateViewController)
 				.ToArray() ?? Array.Empty<PageViewController>();
 
 			if (!viewControllers.SequenceEqual(NavigationController.ViewControllers))
@@ -429,8 +431,18 @@ namespace Uno.Toolkit.UI
 				{
 					NavigationController.SetViewControllers(viewControllers, animated: true);
 				}
-
 			}
+		}
+
+		private UIViewController FindOrCreateViewController(PageStackEntry entry)
+		{
+			if (FrameNavigationHelper.GetInstance(entry) is { } pageInstance)
+			{
+				return pageInstance.FindViewController() ?? new PageViewController(pageInstance);
+			}
+
+			var page = FrameNavigationHelper.EnsurePageInitialized(_frame, entry);
+			return new PageViewController(page);
 		}
 
 		private bool GetIsAnimated(NavigationTransitionInfo transitionInfo)

--- a/src/Uno.Toolkit.UI/Uno.Toolkit.UI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.UI.csproj
@@ -21,7 +21,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.UI" Version="4.5.9" />
+		<PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
 		<PackageReference Include="Uno.Core.Extensions.Collections" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Logging" Version="4.0.1" />

--- a/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.5.9" />
+		<PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573" />
 		<PackageReference Include="Uno.Core.Extensions.Collections" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Logging" Version="4.0.1" />

--- a/src/Uno.Toolkit.UITest/Controls/NativeFrame/Given_NativeFrame.cs
+++ b/src/Uno.Toolkit.UITest/Controls/NativeFrame/Given_NativeFrame.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UITest;
+using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
+using Uno.Toolkit.UITest.Extensions;
+using System.Collections;
+using Uno.Toolkit.UITest.Framework;
+using OpenQA.Selenium.DevTools;
+using Uno.UITest.Helpers;
+
+namespace Uno.Toolkit.UITest.Controls.NativeFrame
+{
+	[TestFixture]
+	public class Given_NativeFrame : TestBase
+	{
+		protected override string SampleName => "NativeFrame";
+
+		[Test]
+		[ActivePlatforms(Platform.iOS)]
+		public void When_BackStack_Changed()
+		{
+			NavigateToNestedSample("NativeFrame_MainPage");
+
+			App.WaitForElementWithMessage("NativeFrame_MainPage_Title");
+
+			App.FastTap("NativeFrame_MainPage_DeeplinkBtn");
+
+			App.WaitForElementWithMessage("NativeFrame_Page2_Title");
+
+			App.FastTap("NativeFrame_Page2_BackWithBackStackBtn");
+
+			App.WaitForElementWithMessage("NativeFrame_Page1_Title");
+
+			App.Repl();
+
+			App.FastTap("NativeFrame_Page1_BackBtn");
+			
+			App.WaitForElementWithMessage("NativeFrame_MainPage_Title");
+		}
+	}
+}

--- a/src/Uno.Toolkit.UITest/Controls/NativeFrame/Given_NativeFrame.cs
+++ b/src/Uno.Toolkit.UITest/Controls/NativeFrame/Given_NativeFrame.cs
@@ -37,8 +37,6 @@ namespace Uno.Toolkit.UITest.Controls.NativeFrame
 
 			App.WaitForElementWithMessage("NativeFrame_Page1_Title");
 
-			App.Repl();
-
 			App.FastTap("NativeFrame_Page1_BackBtn");
 			
 			App.WaitForElementWithMessage("NativeFrame_MainPage_Title");

--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.UI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.UI.Cupertino.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Cupertino" Version="2.3.0" />
-		<PackageReference Include="Uno.UI" Version="4.5.9" />
+		<PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
@@ -19,7 +19,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="2.3.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.5.9" />
+		<PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573" />
 	</ItemGroup>
 
 	<Choose>

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.UI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.UI.Material.csproj
@@ -42,7 +42,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Material" Version="2.3.0" />
-		<PackageReference Include="Uno.UI" Version="4.5.9" />
+		<PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
@@ -19,7 +19,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Material.WinUI" Version="2.3.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.5.9" />
+		<PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.24" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.24" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
 	</ItemGroup>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.toolkit.ui/issues/346

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Manually editing backstack while NativeFramePresenter is being used can lead to blank pages

## What is the new behavior?

Properly assign Page instances to viewcontrollers 

