### PR TITLE
chore: Aligning uno version reference and fixing macos build issue for local dev

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -2,4 +2,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
+
+	<Import Project="..\src\xamarinmac-workaround.targets" Condition="$(TargetFramework.ToLower().StartsWith('xamarin')) and $(TargetFramework.ToLower().Contains('mac'))" />
+
 </Project>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
@@ -71,7 +71,7 @@
       <Version>2.3.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Gtk/Uno.Toolkit.Samples.Skia.Gtk.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Gtk/Uno.Toolkit.Samples.Skia.Gtk.csproj
@@ -33,8 +33,8 @@
     <PackageReference Include="SkiaSharp.Views.Uno" Version="2.88.1-preview.79" />
     <PackageReference Include="Uno.Cupertino" Version="2.3.0" />
     <PackageReference Include="Uno.Material" Version="2.3.0" />
-    <PackageReference Include="Uno.UI.Skia.Gtk" Version="4.5.9" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.573" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.9" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Tizen/Uno.Toolkit.Samples.Skia.Tizen.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Tizen/Uno.Toolkit.Samples.Skia.Tizen.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="SkiaSharp.Views" Version="2.80.2" />
-    <PackageReference Include="Uno.UI.Skia.Tizen" Version="4.5.9" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.573" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <Import Project="..\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems" Label="Shared" />
 </Project>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Wpf.Host/Uno.Toolkit.Samples.Skia.Wpf.Host.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Wpf.Host/Uno.Toolkit.Samples.Skia.Wpf.Host.csproj
@@ -7,8 +7,8 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.5.9" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.573" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Wpf/Uno.Toolkit.Samples.Skia.Wpf.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Skia.Wpf/Uno.Toolkit.Samples.Skia.Wpf.csproj
@@ -6,8 +6,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.5.9" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.573" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <ItemGroup>
     <UpToDateCheckInput Include="..\Uno.Toolkit.Samples.Shared\**\*.xaml" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Wasm/Uno.Toolkit.Samples.Wasm.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Wasm/Uno.Toolkit.Samples.Wasm.csproj
@@ -48,8 +48,8 @@
 		<PackageReference Include="Uno.Cupertino" Version="2.3.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageReference Include="Uno.Material" Version="2.3.0" />
-		<PackageReference Include="Uno.UI.WebAssembly" Version="4.5.9" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.WebAssembly" Version="4.6.0-dev.573" />
+		<PackageReference Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="4.0.0-dev.174" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="4.0.0-dev.174" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.macOS/Uno.Toolkit.Samples.macOS.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.macOS/Uno.Toolkit.Samples.macOS.csproj
@@ -80,7 +80,7 @@
       <Version>2.3.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.6.0-dev.573" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.9" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/Uno.Toolkit.WinUI.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/Uno.Toolkit.WinUI.Samples.Droid.csproj
@@ -77,7 +77,7 @@
       <Version>2.3.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Skia.Gtk/Uno.Toolkit.WinUI.Samples.Skia.Gtk.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Skia.Gtk/Uno.Toolkit.WinUI.Samples.Skia.Gtk.csproj
@@ -37,8 +37,8 @@
     <PackageReference Include="SkiaSharp.Skottie" Version="2.88.1-preview.79" />
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.1-preview.79" />
     <PackageReference Include="Uno.Material.WinUI" Version="2.3.0" />
-    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.5.9" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.6.0-dev.573" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.9" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.UWP/Uno.Toolkit.WinUI.Samples.UWP.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.UWP/Uno.Toolkit.WinUI.Samples.UWP.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
-    <PackageReference Include="Uno.WinUI" Version="4.5.9"/>
+    <PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573"/>
   </ItemGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Wasm/Uno.Toolkit.WinUI.Samples.Wasm.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Wasm/Uno.Toolkit.WinUI.Samples.Wasm.csproj
@@ -49,8 +49,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
     <PackageReference Include="Uno.Material.WinUI" Version="2.3.0" />
-    <PackageReference Include="Uno.WinUI.WebAssembly" Version="4.5.9" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.WinUI.WebAssembly" Version="4.6.0-dev.573" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
 	  <PackageReference Include="Uno.Wasm.Bootstrap" Version="4.0.0-dev.174" />
 	  <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="4.0.0-dev.174" />
 	  <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.1" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.macOS/Uno.Toolkit.WinUI.Samples.macOS.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.macOS/Uno.Toolkit.WinUI.Samples.macOS.csproj
@@ -76,7 +76,7 @@
       <Version>2.3.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.WinUI" Version="4.6.0-dev.573" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.5.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.573" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.9" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,15 +52,6 @@
 		</When>
 	</Choose>
 
-	<ItemGroup Condition="$(TargetFramework.ToLower().StartsWith('xamarinmac'))">
-		<Reference Include="Xamarin.Mac">
-			<HintPath Condition="Exists('C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio')">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
-			<HintPath Condition="Exists('C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\Xamarin.VisualStudio')">C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
-			<HintPath Condition="Exists('C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\Xamarin.VisualStudio')">C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
-			<HintPath Condition="Exists('C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\Extensions\Xamarin.VisualStudio')">C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
-		</Reference>
-	</ItemGroup>
-
 	<!--
   Adjust the output paths for runtime project in order for those
   projects to stay in the same folder as the original reference one.
@@ -72,4 +63,5 @@
 	</PropertyGroup>
 
 	<Import Project="Uno.CrossTargeting.props" />
+	<Import Project="xamarinmac-workaround.targets" Condition="$(TargetFramework.ToLower().StartsWith('xamarin')) and $(TargetFramework.ToLower().Contains('mac'))" />
 </Project>

--- a/src/xamarinmac-workaround.targets
+++ b/src/xamarinmac-workaround.targets
@@ -1,0 +1,10 @@
+<Project>
+	<ItemGroup>
+		<Reference Include="Xamarin.Mac">
+			<HintPath Condition="Exists('C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio')">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
+			<HintPath Condition="Exists('C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\Xamarin.VisualStudio')">C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
+			<HintPath Condition="Exists('C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\Xamarin.VisualStudio')">C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
+			<HintPath Condition="Exists('C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\Extensions\Xamarin.VisualStudio')">C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
This is mainly just housekeeping
- aligning all projects to use the same uno version as the toolkit (which was updated to pick up a fix in uno for the native frame presenter)
- apply the fix for the macos build issue (which is now happening to me locally as well as on CI) to sample projects as well as the core toolkit libraries