### PR TITLE
feat(SafeArea): Include ScrollViewer in SafeArea template

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/MainActivity.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/MainActivity.cs
@@ -13,7 +13,8 @@ namespace Uno.Toolkit.Samples.Droid
 	[Activity(
 			MainLauncher = true,
 			ConfigurationChanges = global::Uno.UI.ActivityHelper.AllConfigChanges,
-			WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden
+			// SoftInput.AdjustNothing is required by SafeArea
+			WindowSoftInputMode = SoftInput.AdjustNothing | SoftInput.StateHidden
 		)]
 	public class MainActivity : Windows.UI.Xaml.ApplicationActivity
 	{

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Properties/AndroidManifest.xml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Uno.Toolkit.Samples" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="31" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<application android:label="Uno.Toolkit.Samples"></application>
 </manifest>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Droid/Uno.Toolkit.Samples.Droid.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Uno.Cupertino" />
     <PackageReference Include="Uno.Material" />
     <PackageReference Include="Uno.UI" />
-    <PackageReference Include="Uno.UI.RemoteControl"  Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
@@ -75,9 +75,9 @@
     <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources" />
     <PackageReference Include="Xamarin.AndroidX.Browser" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging"  />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
     <PackageReference Include="Uno.Core.Extensions.Compatibility" />
-    <PackageReference Include="Uno.Core.Extensions.Logging.Singleton"  />
+    <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
     <PackageReference Include="Xamarin.Jetbrains.Annotations" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SafeAreaSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SafeAreaSamplePage.xaml
@@ -34,6 +34,12 @@
 
 					<Button HorizontalAlignment="Center"
 							VerticalAlignment="Center"
+							AutomationProperties.AutomationId="SafeArea_Launch_SoftInput_Scroll_Sample_Button"
+							Click="LaunchSoftInputScrollSample"
+							Content="Show SoftInput Scroll Sample" />
+
+					<Button HorizontalAlignment="Center"
+							VerticalAlignment="Center"
 							AutomationProperties.AutomationId="SafeArea_Launch_Modal_Button"
 							Click="LaunchModalSample"
 							Content="Show Modal Sample" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SafeAreaSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/SafeAreaSamplePage.xaml.cs
@@ -61,6 +61,11 @@ namespace Uno.Toolkit.Samples.Content.Controls
 			Shell.GetForCurrentView().ShowNestedSample<SafeArea_SoftInput_NestedPage>(clearStack: true);
 		}
 
+		private void LaunchSoftInputScrollSample(object sender, RoutedEventArgs e)
+		{
+			Shell.GetForCurrentView().ShowNestedSample<SafeArea_SoftInput_Scroll>(clearStack: true);
+		}
+
 		private void LaunchModalSample(object sender, RoutedEventArgs e)
 		{
 #if __IOS__

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_SoftInput_Scroll.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_SoftInput_Scroll.xaml
@@ -1,0 +1,98 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.SafeArea_SoftInput_Scroll"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Background="Blue">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="SafeArea Sample Page"
+						   MainCommandMode="Action"
+						   Style="{StaticResource MaterialPrimaryNavigationBarStyle}">
+			<utu:NavigationBar.MainCommand>
+				<AppBarButton Click="NavigateBack"
+							  Style="{StaticResource MaterialPrimaryAppBarButtonStyle}">
+					<AppBarButton.Icon>
+						<BitmapIcon ShowAsMonochrome="False"
+									UriSource="ms-appx:///Assets/CloseIcon.png" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+			</utu:NavigationBar.MainCommand>
+		</utu:NavigationBar>
+		<utu:SafeArea x:Name="SafeAreaControl"
+					  AutomationProperties.AutomationId="SafeAreaControl"
+					  Insets="SoftInput"
+					  Background="CornflowerBlue"
+					  Grid.Row="1">
+			<Grid x:Name="SafeAreaContent">
+				<Grid.RowDefinitions>
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="*"
+								   x:Name="Spacer" />
+					<RowDefinition Height="Auto" />
+				</Grid.RowDefinitions>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
+				<TextBox HorizontalAlignment="Center"
+						 Grid.Column="1"
+						 x:Name="TopTextBox"
+						 PlaceholderText="Top"
+						 AutomationProperties.AutomationId="TopTextBox" />
+				<Border Grid.Row="1"
+						Grid.Column="1"
+						Width="50"
+						Background="Green"
+						x:Name="SpacerBorder"
+						AutomationProperties.AutomationId="SpacerBorder" />
+				<TextBox Grid.Row="2"
+						 HorizontalAlignment="Center"
+						 x:Name="BottomTextBox"
+						 Grid.Column="1"
+						 AutomationProperties.AutomationId="BottomTextBox"
+						 PlaceholderText="Bottom" />
+				<StackPanel Grid.Row="1"
+							VerticalAlignment="Center">
+					<TextBlock Text="Constraint Mode:" />
+					<RadioButton x:Name="SoftConstraintMode"
+								 GroupName="ConstraintMode"
+								 AutomationProperties.AutomationId="SoftConstraintMode"
+								 Checked="SoftChecked"
+								 Content="Soft"
+								 IsChecked="True" />
+					<RadioButton x:Name="HardConstraintMode"
+								 GroupName="ConstraintMode"
+								 AutomationProperties.AutomationId="HardConstraintMode"
+								 Checked="HardChecked"
+								 Content="Hard" />
+				</StackPanel>
+				<StackPanel Grid.Row="1"
+							Grid.Column="2"
+							VerticalAlignment="Center">
+					<TextBlock Text="Inset Mode:" />
+					<RadioButton x:Name="PaddingMode"
+								 GroupName="InsetMode"
+								 AutomationProperties.AutomationId="PaddingMode"
+								 Checked="PaddingChecked"
+								 Content="Padding"
+								 IsChecked="True" />
+					<RadioButton x:Name="MarginMode"
+								 GroupName="InsetMode"
+								 AutomationProperties.AutomationId="MarginMode"
+								 Checked="MarginChecked"
+								 Content="Margin" />
+				</StackPanel>
+			</Grid>
+		</utu:SafeArea>
+	</Grid>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_SoftInput_Scroll.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/SafeArea_SoftInput_Scroll.xaml.cs
@@ -1,0 +1,66 @@
+﻿using static Uno.Toolkit.UI.SafeArea;
+using System;
+using Uno.Toolkit.UI;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Controls;
+using XamlWindow = Microsoft.UI.Xaml.Window;
+using Microsoft.UI;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI;
+using XamlWindow = Windows.UI.Xaml.Window;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+	public sealed partial class SafeArea_SoftInput_Scroll : Page
+	{
+		private double _constraintHeight = 0d;
+		public SafeArea_SoftInput_Scroll()
+		{
+			this.InitializeComponent();
+			SpacerBorder.SizeChanged += OnSizeChanged;
+		}
+
+		private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			if (Spacer.ActualHeight > 0)
+			{
+				SpacerBorder.SizeChanged -= OnSizeChanged;
+				_constraintHeight = Spacer.ActualHeight;
+			}
+		}
+
+		private void MarginChecked(object sender, RoutedEventArgs e)
+		{
+			SafeArea.SetMode(SafeAreaControl, InsetMode.Margin);
+		}
+
+		private void PaddingChecked(object sender, RoutedEventArgs e)
+		{
+			SafeArea.SetMode(SafeAreaControl, InsetMode.Padding);
+		}
+
+		private void SoftChecked(object sender, RoutedEventArgs e)
+		{
+			SpacerBorder.Background = new SolidColorBrush(Colors.Green);
+			SpacerBorder.MinHeight = 0d;
+		}
+
+		private void HardChecked(object sender, RoutedEventArgs e)
+		{
+			SpacerBorder.Background = new SolidColorBrush(Colors.Red);
+			SpacerBorder.MinHeight = _constraintHeight;
+		}
+
+		private void NavigateBack(object sender, RoutedEventArgs e)
+		{
+			Shell.GetForCurrentView()?.BackNavigateFromNestedSample();
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
@@ -107,6 +107,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_SoftInput_NestedPage.xaml.cs">
       <DependentUpon>SafeArea_SoftInput_NestedPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_SoftInput_Scroll.xaml.cs">
+      <DependentUpon>SafeArea_SoftInput_Scroll.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\StatusBarSample_NestedPage1.xaml.cs">
       <DependentUpon>StatusBarSample_NestedPage1.xaml</DependentUpon>
     </Compile>
@@ -318,6 +321,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_SoftInput_NestedPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\SafeArea_SoftInput_Scroll.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/MainActivity.cs
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Droid/MainActivity.cs
@@ -14,7 +14,8 @@ namespace Uno.Toolkit.WinUI.Samples.Droid
 	[Activity(
 			MainLauncher = true,
 			ConfigurationChanges = global::Uno.UI.ActivityHelper.AllConfigChanges,
-			WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden
+			// SoftInput.AdjustNothing is required by SafeArea
+			WindowSoftInputMode = SoftInput.AdjustNothing | SoftInput.StateHidden
 		)]
 	public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
 	{

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.xaml
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.xaml
@@ -3,21 +3,91 @@
 					xmlns:utu="using:Uno.Toolkit.UI">
 
 	<Style TargetType="utu:SafeArea">
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:SafeArea">
-					<Grid HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-						  VerticalAlignment="{TemplateBinding VerticalAlignment}"
+					<Grid x:Name="LayoutRoot"
 						  Background="{TemplateBinding Background}"
+						  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+						  VerticalAlignment="{TemplateBinding VerticalAlignment}"
 						  BorderBrush="{TemplateBinding BorderBrush}"
 						  BorderThickness="{TemplateBinding BorderThickness}"
 						  CornerRadius="{TemplateBinding CornerRadius}">
-						<ContentPresenter Margin="{TemplateBinding Padding}"
-										  Content="{TemplateBinding Content}"
-										  ContentTemplate="{TemplateBinding ContentTemplate}"
-										  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-										  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="InsetStates">
+								<VisualState x:Name="Default" />
+								<VisualState x:Name="SoftInput">
+									<VisualState.Setters>
+										<Setter Target="SafeAreaPresenter.Style"
+												Value="{StaticResource ScrollableSafeAreaPresenterStyle}" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="NoSoftInput">
+									<VisualState.Setters>
+										<Setter Target="SafeAreaPresenter.Style"
+												Value="{StaticResource SafeAreaPresenterStyle}" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+						<utu:SafeAreaPresenter x:Name="SafeAreaPresenter"
+											   Margin="{TemplateBinding Padding}"
+											   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+											   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+											   Content="{TemplateBinding Content}"
+											   ContentTemplate="{TemplateBinding ContentTemplate}"
+											   ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
 					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<!-- Empty ControlTemplate by default since we will apply a style with a proper template upon enetering the SoftInput/NoSoftInput VisualStates -->
+	<!-- Avoid loading views that may be unnecessary if the VisualState change will automatically replace the style anyway -->
+	<Style TargetType="utu:SafeAreaPresenter">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:SafeAreaPresenter" />
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="SafeAreaPresenterStyle"
+		   TargetType="utu:SafeAreaPresenter">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:SafeAreaPresenter">
+					<ContentPresenter Content="{TemplateBinding Content}"
+									  ContentTemplate="{TemplateBinding ContentTemplate}"
+									  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" 
+									  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+									  VerticalAlignment="{TemplateBinding VerticalAlignment}" />
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="ScrollableSafeAreaPresenterStyle"
+		   TargetType="utu:SafeAreaPresenter">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:SafeAreaPresenter">
+					<ScrollViewer x:Name="SafeAreaScrollViewer">
+						<ContentPresenter Content="{TemplateBinding Content}"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" 
+										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalAlignment}" />
+					</ScrollViewer>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeAreaPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeAreaPresenter.cs
@@ -1,0 +1,16 @@
+﻿#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	internal partial class SafeAreaPresenter : ContentControl
+	{
+		public SafeAreaPresenter()
+		{
+			DefaultStyleKey = typeof(SafeAreaPresenter);
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Uno.Toolkit.UI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.UI.csproj
@@ -21,10 +21,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.UI"  />
-		<PackageReference Include="Uno.Core.Extensions.Collections"  />
-		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton"  />
-		<PackageReference Include="Uno.Core.Extensions.Logging"  />
+		<PackageReference Include="Uno.UI" />
+		<PackageReference Include="Uno.Core.Extensions.Collections" />
+		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
+		<PackageReference Include="Uno.Core.Extensions.Logging" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">

--- a/src/Uno.Toolkit.UITest/Extensions/AppExtensions.cs
+++ b/src/Uno.Toolkit.UITest/Extensions/AppExtensions.cs
@@ -20,6 +20,17 @@ namespace Uno.Toolkit.UITest.Extensions
 		{
 			var rect = app.WaitForElementWithMessage(elementName).Single().Rect;
 
+			return app.ToPhysicalRect(rect);
+		}
+		
+		public static IAppRect GetPhysicalScreenDimensions(this IApp app)
+		{
+			var rect = app.GetScreenDimensions();
+
+			return app.ToPhysicalRect(rect);
+		}
+		public static IAppRect ToPhysicalRect(this IApp app, IAppRect rect)
+		{
 			return AppInitializer.GetLocalPlatform() switch
 			{
 				Platform.Android => rect,

--- a/src/Uno.Toolkit.sln
+++ b/src/Uno.Toolkit.sln
@@ -2532,11 +2532,17 @@ Global
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{11b59cbe-c1a9-4d2f-ab33-a2662a0349c3}*SharedItemsImports = 4
+		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{14fca22f-5826-493a-9ea6-1972ed990c8e}*SharedItemsImports = 4
+		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{19cdf829-d365-4886-826e-780715ba0965}*SharedItemsImports = 4
 		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{3ba9e671-8a80-47e1-b3e6-883bcfadd40b}*SharedItemsImports = 4
 		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{54bc2530-f225-40e6-b4ff-9848f322d9e1}*SharedItemsImports = 5
 		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{6279c845-92f8-4333-ab99-3d213163593c}*SharedItemsImports = 13
+		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{667e94c2-cb90-4b1d-b427-100cf48162f0}*SharedItemsImports = 5
 		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{8cf9707a-d702-4c62-b05e-8213e1ab76ba}*SharedItemsImports = 4
+		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{8f623960-73cd-43ab-8e70-366361e76943}*SharedItemsImports = 5
 		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{b16adbc5-5dd4-4982-b56b-01f568e44572}*SharedItemsImports = 4
 		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{c2264db6-2dbd-449f-a28d-83b4f7e7e5e5}*SharedItemsImports = 4
+		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{c75a93ad-b237-41e6-9a40-7941d106735b}*SharedItemsImports = 5
+		..\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems*{f271e677-7ccd-417a-b3d7-86a0ffb58ca3}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
relates to https://github.com/unoplatform/uno.toolkit.ui/issues/345

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature

Change the SafeArea control to have a ScrollViewer inside of its ControlTemplate. Encourage use of ScrollViewers when using the SafeArea.SoftInput inset mask. 

Green = "soft" constraint
Red = "hard" constraint

## Soft Constraint -> Tapping Top TextBox
<img src="https://user-images.githubusercontent.com/4793020/196586776-8e0df84c-229c-490c-aef8-c9026bc608df.png" height="750">

## Soft Constraint -> Tapping Bottom TextBox
<img src="https://user-images.githubusercontent.com/4793020/196586812-28e4b390-beb2-4716-b28d-b50c6abf9616.png" height="750">

## Hard Constraint -> Tapping Top TextBox
<img src="https://user-images.githubusercontent.com/4793020/196586876-c49fd9d5-f857-4e57-9188-8b41acc08a04.png" height="750">
## Hard Constraint -> Tapping Bottom TextBox
<img src="https://user-images.githubusercontent.com/4793020/196586869-e5d4961f-c090-4dc5-9e7a-a85541f4c63c.png" height="750">