### PR TITLE
fix(AutoLayout): CounterAlignment set to Stretch was not supported by the Padding

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/AutoLayoutPage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/AutoLayoutPage.xaml
@@ -35,7 +35,7 @@
                             <TextBlock Text="AutoLayout with negative spacing"
 									   Style="{StaticResource BodyTextBlockStyle}"
 									   Margin="0,24,0,0" />
-                            
+
                             <utu:AutoLayout Spacing="-10" Padding="10">
                                 <Rectangle Fill="Red" utu:AutoLayout.CounterAlignment="Center" utu:AutoLayout.PrimaryLength="73" utu:AutoLayout.CounterLength="232" />
                                 <Rectangle Fill="Yellow" utu:AutoLayout.CounterAlignment="Center" utu:AutoLayout.PrimaryLength="66" utu:AutoLayout.CounterLength="163" />
@@ -57,7 +57,7 @@
                             <TextBlock Text="Horizontal AutoLayout with a independent element"
 									   Style="{StaticResource BodyTextBlockStyle}"
 									   Margin="0,24,0,0" />
-                            
+
                             <utu:AutoLayout Padding="10" Orientation="Horizontal" Height="300">
                                 <Rectangle Width="232" Height="100" Fill="Red" />
                                 <Rectangle Height="50" Width="232" Fill="Yellow" Margin="0,0,50,0" 
@@ -78,7 +78,7 @@
                                 <Rectangle Fill="Blue" Margin="108,69,0,0" Width="100" Height="100" utu:AutoLayout.IsIndependentLayout="True" VerticalAlignment="Top" HorizontalAlignment="Right" />
                                 <Rectangle Fill="Green" utu:AutoLayout.CounterAlignment="Center" utu:AutoLayout.PrimaryLength="20" utu:AutoLayout.CounterLength="20" />
                             </utu:AutoLayout>
-                            
+
                             <TextBlock Text="Vertical AutoLayout with a independent element"
 									   Style="{StaticResource BodyTextBlockStyle}"
 									   Margin="0,24,0,0" />
@@ -88,7 +88,7 @@
                                 <utu:AutoLayout Background="{ThemeResource PrimaryBrush}" PrimaryAxisAlignment="Center" Orientation="Horizontal" utu:AutoLayout.CounterAlignment="Center" Width="246" Height="11" />
                                 <utu:AutoLayout Background="{ThemeResource OnPrimaryContainerBrush}" PrimaryAxisAlignment="Center" Orientation="Horizontal" utu:AutoLayout.CounterAlignment="Center" Width="397" Height="135" />
                             </utu:AutoLayout>
-                            
+
                             <TextBlock Text="Horizontal AutoLayout with a Padding"
 									   Style="{StaticResource BodyTextBlockStyle}"
 									   Margin="0,24,0,0" />
@@ -120,6 +120,34 @@
                                 <utu:AutoLayout Background="{ThemeResource SecondaryVariantLightBrush}" IsIndependentLayout="True" Margin="137,295,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="463" Height="79" />
                                 <utu:AutoLayout Background="{ThemeResource OnSecondaryContainerBrush}" utu:AutoLayout.CounterAlignment="Start" Width="388" Height="95" />
                             </utu:AutoLayout>
+
+                            <TextBlock Text="Horizontal AutoLayout with padding and a CounterAlignment set to stretch"
+									   Style="{StaticResource BodyTextBlockStyle}"
+									   Margin="0,24,0,0" />
+                            
+                            <utu:AutoLayout Background="{ThemeResource SecondaryDraggedBrush}"
+                            BorderBrush="{ThemeResource SecondaryBrush}"
+                            BorderThickness="2"
+                            Padding="12,12,12,12"
+                            Spacing="5"
+                            CornerRadius="10"
+                            Orientation="Horizontal">
+                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+                                utu:AutoLayout.PrimaryAlignment="Stretch"
+                                            Background="Pink">
+                                    <Rectangle Fill="Red"
+                                           utu:AutoLayout.PrimaryAlignment="Stretch"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Stretch"
+                                           Height="40"/>
+                                </utu:AutoLayout>
+                                <utu:AutoLayout Spacing="6" Background="Yellow" Width="20">
+                                    <Rectangle Fill="Blue"
+                                                   Height="40"
+                                                   Width="40"/>
+                                </utu:AutoLayout>
+                            </utu:AutoLayout>
+
                         </StackPanel>
                     </ScrollViewer>
                 </DataTemplate>

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -355,6 +355,7 @@ namespace Uno.Toolkit.UI
 								Grid.SetColumnSpan(child, 2);
 								break;
 							case HorizontalAlignment.Stretch:
+								Grid.SetColumn(child, 1);
 								break;
 							default:
 								break;
@@ -489,6 +490,7 @@ namespace Uno.Toolkit.UI
 								Grid.SetRowSpan(child, 2);
 								break;
 							case VerticalAlignment.Stretch:
+								Grid.SetRow(child, 1);
 								break;
 							default:
 								break;


### PR DESCRIPTION


GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Padding in AutoLayout did not support CounterALignment set to stretch from children

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- Padding behave properly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
