### PR TITLE
fix(uwp): Cannot locate resource '**/*.xaml'

### DIFF
--- a/src/PlatformItemGroups.props
+++ b/src/PlatformItemGroups.props
@@ -23,7 +23,7 @@
 		<_IsNetStd Condition="'$(TargetFramework)'=='netstandard2.0' or $(_IsNetCore)">true</_IsNetStd>
 
 		<_IsUWP>false</_IsUWP>
-		<_IsUWP Condition="'$(TargetFramework)'=='uap10.0'">true</_IsUWP>
+		<_IsUWP Condition="$(TargetFramework.StartsWith('uap10.0'))">true</_IsUWP>
 
 		<_IsWinUI>false</_IsWinUI>
 		<_IsWinUI Condition="$(TargetFramework.Contains('-windows'))">true</_IsWinUI>


### PR DESCRIPTION
GitHub Issue (If applicable): resolved #396

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
UWP Sample crashes with: Cannot locate resource from 'ms-appx:///Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.xaml'.

## What is the new behavior?
No crash.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
regression from: #383