### PR TITLE
feat: ItemsRepeater support for CommandExtensions

### DIFF
--- a/doc/helpers/control-extensions.md
+++ b/doc/helpers/control-extensions.md
@@ -4,7 +4,7 @@ Provides Command/CommandParameter attached properties for common scenarios.
 ## Properties
 Property|Type|Description
 -|-|-
-Command|ICommand|Sets the command to execute for: <br>- `TextBox`/`PasswordBox` enter key press\*<br>- `ListView` item click\*<br>- `NavigationView` item click
+Command|ICommand|Sets the command to execute when `TextBox`/`PasswordBox` enter key is pressed, `ListViewBase.ItemClick`, `NavigationView.ItemInvoked`, and `ItemsRepeater` item tapped.
 CommandParameter|ICommand|Sets the parameter to pass to the Command property.
 
 Command on `TextBox`/`PasswordBox`\*: Having this set will also cause the keyboard dismiss on enter.
@@ -17,6 +17,7 @@ Command on `ListView`\*: [`IsItemClickEnabled`](https://docs.microsoft.com/en-us
   - `PasswordBox.Password`
   - `ItemClickEventArgs.ClickedItem` from `ListView.ItemClick`
   - `NavigationViewItemInvokedEventArgs.InvokedItem` from `NavigationView.ItemInvoked`
+  - `ItemsRepeater`'s item root's DataContext
 
 ## Usage
 ```xml
@@ -36,4 +37,6 @@ Command on `ListView`\*: [`IsItemClickEnabled`](https://docs.microsoft.com/en-us
 		<NavigationViewItem Content="Cactus" />
 	</NavigationView.MenuItems>
 </NavigationView>
+
+<muxc:ItemsRepeater ItemsSource="123" utu:CommandExtensions.Command="{Binding UpdateSelection}" />
 ```

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml
@@ -3,12 +3,12 @@
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
 	  xmlns:sample="using:Uno.Toolkit.Samples"
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-
 
 	<Grid Background="{ThemeResource SurfaceBrush}">
 		<sample:SamplePageLayout x:Name="SamplePageLayout" IsDesignAgnostic="True">
@@ -33,7 +33,13 @@
 									  utu:CommandExtensions.Command="{Binding DebugSelectionCommand}">
 								<ListView.ItemTemplate>
 									<DataTemplate>
-										<TextBlock>Item #<Run Text="{Binding}" /></TextBlock>
+										<Border BorderThickness="1"
+												BorderBrush="Black"
+												Padding="16"
+												Background="SkyBlue"
+												Margin="16,8">
+											<TextBlock>Item #<Run Text="{Binding}" /></TextBlock>
+										</Border>
 									</DataTemplate>
 								</ListView.ItemTemplate>
 							</ListView>
@@ -52,6 +58,24 @@
 							</NavigationView>
 						</StackPanel>
 
+						<!-- ItemsRepeater[Command] example -->
+						<StackPanel>
+							<TextBlock Text="- ItemsRepeater item tapped" />
+							<TextBlock Text="{Binding ItemsRepeaterDebugText}" />
+							<muxc:ItemsRepeater ItemsSource="123" utu:CommandExtensions.Command="{Binding DebugItemsRepeaterCommand}">
+								<muxc:ItemsRepeater.ItemTemplate>
+									<DataTemplate>
+										<Border BorderThickness="1"
+												BorderBrush="Black"
+												Padding="16"
+												Background="SkyBlue"
+												Margin="16,8">
+											<TextBlock>Item #<Run Text="{Binding}" /></TextBlock>
+										</Border>
+									</DataTemplate>
+								</muxc:ItemsRepeater.ItemTemplate>
+							</muxc:ItemsRepeater>
+						</StackPanel>
 					</StackPanel>
 				</DataTemplate>
 			</sample:SamplePageLayout.DesignAgnosticTemplate>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml.cs
@@ -28,14 +28,17 @@ namespace Uno.Toolkit.Samples.Content.Controls
 			public string InputDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string SelectionDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string NavigationDebugText { get => GetProperty<string>(); set => SetProperty(value); }
+			public string ItemsRepeaterDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 
 			public ICommand DebugInputCommand => new Command(DebugInput);
 			public ICommand DebugSelectionCommand => new Command(DebugSelection);
 			public ICommand DebugNavigationCommand => new Command(DebugNavigation);
+			public ICommand DebugItemsRepeaterCommand => new Command(DebugItemsRepeater);
 
 			private void DebugInput(object parameter) => InputDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugSelection(object parameter) => SelectionDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugNavigation(object parameter) => NavigationDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
+			private void DebugItemsRepeater(object parameter) => ItemsRepeaterDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
@@ -17,6 +17,7 @@ using Microsoft.UI.Xaml.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
 #endif
 
 namespace Uno.Toolkit.UI
@@ -28,7 +29,8 @@ namespace Uno.Toolkit.UI
 		#region DependencyProperty: Command
 
 		/// <summary>
-		/// Backing property for the command to execute when <see cref="TextBox"/>/<see cref="PasswordBox"/> enter key is pressed, <see cref="ListViewBase.ItemClick" /> and <see cref="NavigationView.ItemInvoked"/>.
+		/// Backing property for the command to execute when <see cref="TextBox"/>/<see cref="PasswordBox"/> enter key is pressed,
+		/// <see cref="ListViewBase.ItemClick" />, <see cref="NavigationView.ItemInvoked"/>, or <see cref="ItemsRepeater"/> item tapped.
 		/// </summary>
 		/// <remarks>
 		/// For Command, the relevant parameter is also provided for the <see cref="ICommand.CanExecute(object)"/> and <see cref="ICommand.Execute(object)"/> call:
@@ -36,7 +38,8 @@ namespace Uno.Toolkit.UI
 		///   <item><see cref="TextBox.Text"/></item>
 		///   <item><see cref="PasswordBox.Password"/></item>
 		///   <item><see cref="ItemClickEventArgs.ClickedItem"/> from <see cref="ListViewBase.ItemClick"/></item>
-		///   <item><see cref="NavigationViewItemInvokedEventArgs.InvokedItem"/> from <see cref="NavigationView.ItemInvoked"/> </item>
+		///   <item><see cref="NavigationViewItemInvokedEventArgs.InvokedItem"/> from <see cref="NavigationView.ItemInvoked"/></item>
+		///   <item><see cref="ItemsRepeater"/>'s item root's DataContext</item>
 		/// </list>
 		/// Unless <see cref="CommandParameterProperty"/> is set, which replaces the above.
 		/// </remarks>
@@ -59,10 +62,10 @@ namespace Uno.Toolkit.UI
 			"CommandParameter",
 			typeof(object),
 			typeof(CommandExtensions),
-			new PropertyMetadata(default(object)));
+			new PropertyMetadata(default(object?)));
 
-		public static object GetCommandParameter(DependencyObject obj) => (object)obj.GetValue(CommandParameterProperty);
-		public static void SetCommandParameter(DependencyObject obj, object value) => obj.SetValue(CommandParameterProperty, value);
+		public static object? GetCommandParameter(DependencyObject? obj) => obj.GetValue(CommandParameterProperty);
+		public static void SetCommandParameter(DependencyObject obj, object? value) => obj.SetValue(CommandParameterProperty, value);
 
 		#endregion
 
@@ -72,6 +75,10 @@ namespace Uno.Toolkit.UI
 			{
 				// for input controls, this will be implemented in InputExtensions.
 				InputExtensions.OnEnterCommandChanged(sender, e);
+			}
+			if (sender is ItemsRepeater ir)
+			{
+				ItemsRepeaterExtensions.OnItemCommandChanged(ir, e);
 			}
 			else if (sender is ListViewBase lvb)
 			{
@@ -103,26 +110,29 @@ namespace Uno.Toolkit.UI
 			}
 		}
 
+		internal static bool TryInvokeCommand(DependencyObject owner) => TryInvokeCommand(owner, GetCommandParameter(owner));
+		internal static bool TryInvokeCommand(DependencyObject owner, object? parameter)
+		{
+			if (GetCommand(owner) is { } command &&
+				command.CanExecute(parameter))
+			{
+				command.Execute(parameter);
+				return true;
+			}
+
+			return false;
+		}
+
 		private static void OnListViewItemClick(object sender, ItemClickEventArgs e)
 		{
 			if (sender is not ListViewBase host) return;
 
-			if (GetCommand(host) is { } command &&
-				GetCommandParameter(host) is var parameter &&
-				command.CanExecute(parameter ?? e.ClickedItem))
-			{
-				command.Execute(parameter ?? e.ClickedItem);
-			}
+			TryInvokeCommand(host, GetCommandParameter(host) ?? e.ClickedItem);
 		}
 
 		private static void OnNavigationViewItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs e)
 		{
-			if (GetCommand(sender) is { } command &&
-				GetCommandParameter(sender) is var parameter &&
-				command.CanExecute(parameter ?? e.InvokedItem))
-			{
-				command.Execute(parameter ?? e.InvokedItem);
-			}
+			TryInvokeCommand(sender, GetCommandParameter(sender) ?? e.InvokedItem);
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
@@ -139,27 +139,11 @@ namespace Uno.Toolkit.UI
 			if (e.Key != VirtualKey.Enter) return;
 
 			// handle enter command
-			var command = CommandExtensions.GetCommand(host);
-			if (command != null &&
-				(CommandExtensions.GetCommandParameter(host) ?? GetInputParameter()) is var parameter &&
-				command.CanExecute(parameter))
-			{
-				command.Execute(parameter);
-			}
-
-			object? GetInputParameter() => sender switch
-			{
-				TextBox tb => tb.Text,
-#if !HAS_UNO // note: on uno, PasswordBox inherits from TextBox which isnt the case on uwp...
-				PasswordBox pb => pb.Password,
-#endif
-
-				_ => default,
-			};
+			CommandExtensions.TryInvokeCommand(host, CommandExtensions.GetCommandParameter(host) ?? GetInputParameter());
 
 			// dismiss keyboard
 			if (GetAutoDismiss(host) ||
-				command != null) // we should also dismiss keyboard if a command has been executed (even if CanExecute failed)
+				CommandExtensions.GetCommand(host) != null) // we should also dismiss keyboard if a command has been executed (even if CanExecute failed)
 			{
 				InputPane.GetForCurrentView().TryHide();
 			}
@@ -172,6 +156,16 @@ namespace Uno.Toolkit.UI
 
 				target?.Focus(FocusState.Keyboard);
 			}
+
+			object? GetInputParameter() => sender switch
+			{
+				TextBox tb => tb.Text,
+#if !HAS_UNO // note: on uno, PasswordBox inherits from TextBox which isnt the case on uwp...
+				PasswordBox pb => pb.Password,
+#endif
+
+				_ => default,
+			};
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Behaviors/ItemsRepeaterExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/ItemsRepeaterExtensions.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Input;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	public static partial class ItemsRepeaterExtensions
+	{
+		internal static void OnItemCommandChanged(ItemsRepeater sender, DependencyPropertyChangedEventArgs e)
+		{
+			if (e.OldValue is ICommand)
+			{
+				if (e.NewValue is not ICommand) // tear down
+				{
+					sender.Tapped -= OnItemsRepeaterTapped;
+				}
+				else
+				{
+					// When transitioning from one command to another, there is no need to rewire the event.
+					// Since the handler is setup to invoke the command in the DP.
+				}
+			}
+			else if (e.NewValue is ICommand command)
+			{
+				sender.Tapped += OnItemsRepeaterTapped;
+			}
+		}
+
+		private static void OnItemsRepeaterTapped(object sender, TappedRoutedEventArgs e)
+		{
+			// ItemsRepeater is more closely related to Panel than ItemsControl, and it cannot be templated.
+			// It is safe to assume all direct children of IR are materialized item template,
+			// and there can't be header/footer or wrapper (ItemContainer) among them.
+
+			if (sender is not ItemsRepeater owner) return;
+			if (e.OriginalSource is ItemsRepeater) return;
+			if (e.OriginalSource is DependencyObject source)
+			{
+				// e.OriginalSource is the top-most element under the cursor.
+				// In order to find the materialized item template, we have to walk up the visual-tree, to the first element right below IR:
+				// ItemsRepeater > (item template root) > (layer0...n) > (tapped element)
+				var element = source.GetAncestors(includeCurrent: true)
+					.ZipSkipOne()
+					.FirstOrDefault(x => x.Current is ItemsRepeater)
+					.Previous;
+				if (element is FrameworkElement fe)
+				{
+					CommandExtensions.TryInvokeCommand(owner, CommandExtensions.GetCommandParameter(fe) ?? fe.DataContext);
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Extensions/EnumerableExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Uno.Toolkit.UI;
+
+internal static class EnumerableExtensions
+{
+	/// <summary>
+	/// Functionally the same as <code>source.Zip(source.Skip(1))</code> without double iterating.
+	/// </summary>
+	public static IEnumerable<(T Previous, T Current)> ZipSkipOne<T>(this IEnumerable<T> source)
+	{
+		var etor = source.GetEnumerator();
+		etor.MoveNext();
+
+		var previous = etor.Current;
+		while (etor.MoveNext())
+		{
+			yield return (previous, etor.Current);
+			previous = etor.Current;
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): re #395

## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
n/a

## What is the new behavior?
added CommandExtensions.Command support for ItemsRepeater


## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->