### PR TITLE
fix(autolayout): ensure the layout is recalculated when nesting autolayout

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -26,6 +26,10 @@ namespace Uno.Toolkit.UI
 		{
 			DefaultStyleKey = typeof(AutoLayout);
 			Children = new AutoLayoutChildren();
+
+			this.RegisterDisposablePropertyChangedCallback(HorizontalAlignmentProperty, (snd, e) => UpdateAlignments());
+			this.RegisterDisposablePropertyChangedCallback(VerticalAlignmentProperty, (snd, e) => UpdateAlignments());
+			this.RegisterDisposablePropertyChangedCallback(PaddingProperty, (snd, e) => UpdateAlignments());
 		}
 
 		protected override void OnApplyTemplate()


### PR DESCRIPTION

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix
## What is the current behavior?

- updateLayout can be call before the verticalAlignment horizantalAlignment and padding are propertly set. 
Happened with xamlreader 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
- trigger updateLayout when verticalAlignment horizontalAlignment and padding are changed 

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
