### PR TITLE
chore: chip selection rework

### DIFF
--- a/doc/controls/ChipAndChipGroup.md
+++ b/doc/controls/ChipAndChipGroup.md
@@ -1,6 +1,6 @@
 # Chip & ChipGroup
 
-> [!TIP] 
+> [!TIP]
 > This guide covers details for `Chip` and `ChipGroup` specifically. If you are just getting started with the Uno Toolkit Material Library, please see our [general getting started](../getting-started.md) page to make sure you have the correct setup in place.
 
 ## Summary
@@ -23,7 +23,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 <utu:Chip .../>
 ```
 
-### Inheritance 
+### Inheritance
 Object &#8594; DependencyObject &#8594; UIElement &#8594; FrameworkElement &#8594; Control &#8594; ContentControl &#8594; ButtonBase &#8594; ToggleButton &#8594; Chip
 
 ### Constructors
@@ -97,7 +97,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 </utu:ChipGroup>
 ```
 
-### Inheritance 
+### Inheritance
 Object &#8594; DependencyObject &#8594; UIElement &#8594; FrameworkElement &#8594; Control &#8594; ItemsControl &#8594; ChipGroup
 
 ### Constructors
@@ -110,10 +110,18 @@ Property|Type|Description
 -|-|-
 CanRemove|bool|Gets or sets the value of each `Chip.CanRemove`.
 IconTemplate|DataTemplate|Gets or sets the value of each `Chip.IconTemplate`.
-SelectedItem|object|Gets or sets the selected item. <br/> note: This property only works for `ChipSelectionMode.Single`.
+SelectedItem|object|Gets or sets the selected item. <br/> note: This property only works for `ChipSelectionMode.Single` or `SingleOrNone`.
 SelectedItems|IList|Gets or sets the selected items. <br/> note: The value will be null if the selection is empty. This property only works for `ChipSelectionMode.Multiple`.
 SelectionMemberPath|string|Gets or sets the path which each `Chip.IsChecked` is data-bind to.
-SelectionMode|ChipSelectionMode|Gets or sets the selection behavior: `None`, `Single`, `Multiple` <br/> note: Changing this value will cause `SelectedItem` and `SelectedItems` to be re-coerced.
+SelectionMode|ChipSelectionMode\*|Gets or sets the selection behavior: `None`, `SingleOrNone`, `Single`, `Multiple` <br/> note: Changing this value will cause `SelectedItem` and `SelectedItems` to be re-coerced.
+
+#### Remarks
+- `ChipSelectionMode`: Defines constants that specify the selection behavior for a ChipGroup.
+  > Different numbers of selected items are guaranteed: None=0, SingleOrNone=0 or 1, Single=1, Multiple=0 or many.
+  - `None`: Selection is disabled.
+  - `SingleOrNone`: Up to one item can be selected at a time. The current item can be deselected.
+  - `Single`: One item is selected at any time. The current item cannot be deselected.
+  - `Multiple`: The current item cannot be deselected.
 
 ### Events
 All events below are forwarded from the nested `Chip`s:

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.3.0-alpha-net7.4" />
-    <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.13.0-dev.45" />
+    <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
     <PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.24" />
     <PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.24" />

--- a/src/Uno.Toolkit.RuntimeTests/Extensions/ToggleButtonExtensions.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Extensions/ToggleButtonExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls.Primitives;
+#else
+using Windows.UI.Xaml.Controls.Primitives;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Extensions;
+
+internal static partial class ToggleButtonExtensions
+{
+	public static void Toggle(this ToggleButton toggle)
+	{
+		var method = toggle.GetType().GetMethod("OnToggle", BindingFlags.NonPublic | BindingFlags.Instance)
+			?? throw new MissingMethodException("ToggleButton::OnToggle not found");
+
+		method.Invoke(toggle, null);
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Helpers/UnitTestUIContentHelperEx.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Helpers/UnitTestUIContentHelperEx.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+#else
+using Windows.UI.Xaml;
+#endif
+
+using Base = Uno.UI.RuntimeTests.UnitTestsUIContentHelper;
+
+namespace Uno.Toolkit.RuntimeTests.Helpers
+{
+	internal static class UnitTestUIContentHelperEx
+	{
+		public static async Task SetContentAndWait(FrameworkElement e)
+		{
+			Base.Content = e;
+			await Base.WaitForIdle();
+			await Base.WaitForLoaded(e);
+		}
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ChipGroupTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ChipGroupTests.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Extensions;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+using ChipControl = Uno.Toolkit.UI.Chip; // ios/macos: to avoid collision with `global::Chip` namespace...
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+internal class ChipGroupTests
+{
+	/*	Test Plan
+	 *		- tap triggered selection in various SelectionMode
+	 *		- SelectedItem(s) in various SelectionMode
+	 *		- pre-assertions & post-assertions when changing SelectionMode
+	 */
+
+	#region Selection via Toggle
+
+	[TestMethod]
+	[DataRow(ChipSelectionMode.None, new[] { 1 }, null)]
+	[DataRow(ChipSelectionMode.SingleOrNone, new[] { 1 }, 1)]
+	[DataRow(ChipSelectionMode.SingleOrNone, new[] { 1, 1 }, null)] // deselection
+	[DataRow(ChipSelectionMode.SingleOrNone, new[] { 1, 2 }, 2)] // reselection
+	[DataRow(ChipSelectionMode.Single, new int[0], 0)] // selection enforced by 'Single'
+	[DataRow(ChipSelectionMode.Single, new[] { 1 }, 1)]
+	[DataRow(ChipSelectionMode.Single, new[] { 1, 1 }, 1)] // deselection denied
+	[DataRow(ChipSelectionMode.Single, new[] { 1, 2 }, 2)] // reselection
+	[DataRow(ChipSelectionMode.Multiple, new[] { 1 }, new object[] { 1 })]
+	[DataRow(ChipSelectionMode.Multiple, new[] { 1, 2 }, new object[] { 1, 2 })] // multi-select@1,2
+	[DataRow(ChipSelectionMode.Multiple, new[] { 1, 2, 2 }, new object[] { 1 })] // multi-select@1,2, deselection@2
+	public async Task VariousMode_TapSelection(ChipSelectionMode mode, int[] selectionSequence, object expectation)
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = mode,
+			ItemsSource = source,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.AreEqual(mode is ChipSelectionMode.Single ? source[0] : null, SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		foreach (var i in selectionSequence)
+		{
+			((ChipControl)SUT.ContainerFromIndex(i)).Toggle();
+		}
+		if (mode is ChipSelectionMode.SingleOrNone or ChipSelectionMode.Single)
+		{
+			Assert.AreEqual((int?)expectation, SUT.SelectedItem);
+			Assert.IsNull(SUT.SelectedItems);
+		}
+		else
+		{
+			Assert.IsNull(SUT.SelectedItem);
+			CollectionAssert.AreEqual((object[]?)expectation, SUT.SelectedItems);
+		}
+	}
+
+	[TestMethod]
+	public async Task SingleMode_Selection()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.SingleOrNone,
+			ItemsSource = source,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.IsNull(SUT.SelectedItem);
+
+		((ChipControl)SUT.ContainerFromIndex(1)).Toggle();
+		Assert.AreEqual(source[1], SUT.SelectedItem);
+	}
+
+	#endregion
+
+	#region Selection via SelectedItem & SelectItems
+
+	[TestMethod]
+	public async Task None_SetSelection()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.None,
+			ItemsSource = source,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.IsNull(SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		// invalid assignment for current selection mode will reset the selection (clear, and then coerced)
+		SUT.SelectedItem = source[1];
+		Assert.IsNull(SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		// invalid assignment for current selection mode will reset the selection (clear, and then coerced)
+		SUT.SelectedItems = source.Take(2).ToArray();
+		Assert.IsNull(SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+	}
+
+	[TestMethod]
+	public async Task Single_SetSelection()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.Single,
+			ItemsSource = source,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.AreEqual(source[0], SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		SUT.SelectedItem = source[1];
+		Assert.AreEqual(source[1], SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		// invalid assignment for current selection mode will reset the selection (clear, and then coerced)
+		SUT.SelectedItems = source.Skip(1).Take(2).ToArray();
+		Assert.AreEqual(source[0], SUT.SelectedItem); // coerced from Single
+		Assert.IsNull(SUT.SelectedItems);
+	}
+
+	[TestMethod]
+	public async Task SingleOrNone_SetSelection()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.SingleOrNone,
+			ItemsSource = source,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.IsNull(SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		SUT.SelectedItem = source[1];
+		Assert.AreEqual(source[1], SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		// invalid assignment for current selection mode will reset the selection (clear, and then coerced)
+		SUT.SelectedItems = source.Take(2).ToArray();
+		Assert.IsNull(SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+	}
+
+	[TestMethod]
+	public async Task Multiple_SetSelection()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.Multiple,
+			ItemsSource = source,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.IsNull(SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		// invalid assignment for current selection mode will reset the selection (clear, and then coerced)
+		SUT.SelectedItem = source[1];
+		Assert.IsNull(SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		var newSelection = source.Skip(1).Take(2).ToArray();
+		SUT.SelectedItems = newSelection;
+		Assert.IsNull(SUT.SelectedItem);
+		CollectionAssert.AreEqual(newSelection, SUT.SelectedItems);
+	}
+
+	[TestMethod]
+	public async Task Multiple_ReassignSelectedItems_ShouldNotStack()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.Multiple,
+			ItemsSource = source,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.IsNull(SUT.SelectedItem);
+		Assert.IsNull(SUT.SelectedItems);
+
+		// Changing SelectedItems should not create union of old & new values
+		foreach (var selection in Enumerable.Range(0, 1).Select(x => source.Skip(x).Take(2).ToArray()))
+		{
+			SUT.SelectedItems = selection;
+			Assert.IsNull(SUT.SelectedItem);
+			CollectionAssert.AreEqual(selection, SUT.SelectedItems);
+		}
+	}
+	#endregion
+
+	#region Changing SelectionMode
+
+	[TestMethod]
+	public async Task SingleOrNoneToSingle_NoneSelected_ShouldAutoSelect()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.SingleOrNone,
+			ItemsSource = source,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.IsNull(SUT.SelectedItem);
+
+		SUT.SelectionMode = ChipSelectionMode.Single;
+		Assert.AreEqual(source[0], SUT.SelectedItem);
+	}
+
+	[TestMethod]
+	public async Task SingleOrNoneToSingle_Selected_ShouldPreserveSelection()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var selected = source.Last();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.SingleOrNone,
+			ItemsSource = source,
+			SelectedItem = selected,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		Assert.AreEqual(selected, SUT.SelectedItem);
+
+		SUT.SelectionMode = ChipSelectionMode.Single;
+		Assert.AreEqual(selected, SUT.SelectedItem);
+	}
+
+	[TestMethod]
+	public async Task MultiToSingle_Selected_ShouldPreserveFirstSelection()
+	{
+		var source = Enumerable.Range(0, 3).ToArray();
+		var selected = source.Skip(1).Take(2).ToArray();
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.Multiple,
+			ItemsSource = source,
+			SelectedItems = selected,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+		CollectionAssert.AreEqual(selected, SUT.SelectedItems);
+
+		SUT.SelectionMode = ChipSelectionMode.Single;
+		Assert.AreEqual(selected.First(), SUT.SelectedItem);
+	}
+
+	#endregion
+}

--- a/src/Uno.Toolkit.UI/Controls/Chips/Chip.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/Chip.cs
@@ -22,6 +22,8 @@ namespace Uno.Toolkit.UI
 
 		private bool _isMuted;
 
+		private ChipGroup? ChipGroup => ItemsControl.ItemsControlFromItemContainer(this) as ChipGroup;
+
 		public Chip()
 		{
 			Checked += RaiseIsCheckedChanged;
@@ -93,6 +95,10 @@ namespace Uno.Toolkit.UI
 		protected override void OnToggle()
 		{
 			if (!IsCheckable) return;
+			if (IsChecked == true && ChipGroup?.SelectionMode == ChipSelectionMode.Single)
+			{
+				return;
+			}
 
 			base.OnToggle();
 		}

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.Members.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.Members.cs
@@ -57,13 +57,13 @@ namespace Uno.Toolkit.UI
 			nameof(SelectedItem),
 			typeof(object),
 			typeof(ChipGroup),
-			new PropertyMetadata(default, (s, e) => (s as ChipGroup)?.OnSelectedItemChanged(e)));
+			new PropertyMetadata(default, (s, e) => (s as ChipGroup)?.OnSelectedItemChanged()));
 
 		/// <summary>
 		/// Gets or sets the selected item.
 		/// </summary>
 		/// <remarks>
-		/// This property only works for <see cref="ChipSelectionMode.Single"/>.
+		/// This property only works for <see cref="ChipSelectionMode.SingleOrNone"/>.
 		/// </remarks>
 		public object? SelectedItem
 		{
@@ -79,7 +79,7 @@ namespace Uno.Toolkit.UI
 			nameof(SelectedItems),
 			typeof(IList),
 			typeof(ChipGroup),
-			new PropertyMetadata(default, (s, e) => (s as ChipGroup)?.OnSelectedItemsChanged(e)));
+			new PropertyMetadata(default, (s, e) => (s as ChipGroup)?.OnSelectedItemsChanged()));
 
 		/// <summary>
 		/// Gets or sets the selected items.

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipSelectionMode.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipSelectionMode.cs
@@ -4,6 +4,13 @@ using System.Text;
 
 namespace Uno.Toolkit.UI
 {
+	/// <summary>
+	/// Defines constants that specify the selection behavior for a ChipGroup.
+	/// </summary>
+	/// <remarks>
+	/// Different numbers of selected items are guaranteed:
+	/// None=0, SingleOrNone=0 or 1, Single=1, Multiple=0 or many.
+	/// </remarks>
 	public enum ChipSelectionMode
 	{
 		/// <summary>
@@ -12,8 +19,15 @@ namespace Uno.Toolkit.UI
 		None,
 
 		/// <summary>
-		/// Only one item can be selected at a time.
+		/// Up to one item can be selected at a time.
 		/// </summary>
+		/// <remarks>The current item can be deselected.</remarks>
+		SingleOrNone,
+
+		/// <summary>
+		/// One item is selected at any time.
+		/// </summary>
+		/// <remarks>The current item cannot be deselected.</remarks>
 		Single,
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #337, closes #354, re: #356

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?
- reworked `ChipGroup` selection logics
- existing `Single` selection mode now enforces a default selection and prevent the deselection of currently selected item (RadioGroup-like)
  > which aligns with the same-named mode in `ListView`
- legacy `Single` selection mode is available as `SingleOrNone` 
- added tests for ChipGroup selection

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information