### PR TITLE
fix: Windows crash

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Cupertino" Version="2.4.1" />
+    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.4.1" />
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
     <PackageVersion Include="Uno.Material" Version="2.4.1" />

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
@@ -384,7 +384,7 @@
 												ContentTransitions="{TemplateBinding ContentTransitions}"
 												Foreground="{TemplateBinding Foreground}"
 												FontFamily="{ThemeResource MaterialRegularFontFamily}"
-												FontSize="{ThemeResource TitleLargeFontWeight}"
+												FontSize="{ThemeResource TitleLargeFontSize}"
 												FontWeight="{ThemeResource TitleLargeFontWeight}"
 												HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 												VerticalAlignment="{TemplateBinding VerticalContentAlignment}"


### PR DESCRIPTION
Crash when using M3 NavigationBar styles on Windows, also missing Cupertino.WinUI reference