### PR TITLE
fix(autolayout): When SpaceBetween no spacing

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/AutoLayoutPage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/AutoLayoutPage.xaml
@@ -212,7 +212,17 @@
                                 <Rectangle Fill="{ThemeResource SecondaryVariantLightBrush}" utu:AutoLayout.CounterAlignment="Start" utu:AutoLayout.PrimaryAlignment="Stretch" Width="188" />
                                 <Rectangle Fill="{ThemeResource PrimaryInverseBrush}" utu:AutoLayout.CounterAlignment="Start" Width="188" Height="67" />
                             </utu:AutoLayout>
-                        </StackPanel>
+
+							<TextBlock Text="AutoLayout with Spacing and padding "
+									   Style="{StaticResource BodyTextBlockStyle}"
+									   Margin="0,24,0,0" />
+
+							<utu:AutoLayout Spacing="50" Padding="10" Justify="SpaceBetween" Width="188" Height="241">
+								<Rectangle Fill="{ThemeResource PrimaryBrush}" utu:AutoLayout.CounterAlignment="Start" Width="152" Height="80" />
+								<Rectangle Fill="{ThemeResource SecondaryVariantDarkBrush}" utu:AutoLayout.CounterAlignment="Start" Width="143" Height="61" />
+								<Rectangle Fill="{ThemeResource PrimaryInverseBrush}" utu:AutoLayout.CounterAlignment="Start" Width="152" Height="55" />
+							</utu:AutoLayout>
+						</StackPanel>
 					</ScrollViewer>
 				</DataTemplate>
 			</sample:SamplePageLayout.DesignAgnosticTemplate>

--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Extensions;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+#endif
+using AutoLayoutControl = Uno.Toolkit.UI.AutoLayout;
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+internal class AutoLayoutTest
+{
+	[TestMethod]
+	public async Task When_SpaceBetween_with_spacing()
+	{
+		var SUT = new AutoLayout()
+		{
+			Justify = AutoLayoutJustify.SpaceBetween,
+			Padding = new Thickness(10),
+			Spacing = 100,
+			Width = 190,
+			Height = 360,
+		};
+
+		var border1 = new Border() { Width = 150, Height = 100 };
+		var border2 = new Border() { Width = 150, Height = 100 };
+		var border3 = new Border() { Width = 150, Height = 100 };
+
+		AutoLayout.SetCounterAlignment(border1, AutoLayoutAlignment.Start);
+		AutoLayout.SetCounterAlignment(border2, AutoLayoutAlignment.Start);
+		AutoLayout.SetCounterAlignment(border3, AutoLayoutAlignment.Start);
+
+		SUT.Children.Add(border1);
+		SUT.Children.Add(border2);
+		SUT.Children.Add(border3);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var layoutRect0Actual = LayoutInformation.GetLayoutSlot(SUT.Children[0] as FrameworkElement);
+		Assert.AreEqual(layoutRect0Actual.Y, 10);
+		var layoutRect1Actual = LayoutInformation.GetLayoutSlot(SUT.Children[1] as FrameworkElement);
+		Assert.AreEqual(layoutRect1Actual.Y, 135);
+		var layoutRect2Actual = LayoutInformation.GetLayoutSlot(SUT.Children[2] as FrameworkElement);
+		Assert.AreEqual(layoutRect2Actual.Y, 260);
+	}
+}
+

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -214,11 +214,11 @@ namespace Uno.Toolkit.UI
 				return;
 			}
 
-			var spacing = Spacing;
 			var padding = Padding;
 			var hasPadding = !padding.Equals(default(Thickness));
 			var isVertical = Orientation is Orientation.Vertical;
 			var isSpaceBetween = Justify == AutoLayoutJustify.SpaceBetween;
+			var spacing = isSpaceBetween ? 0 : Spacing;
 
 			var childrenCount = Children.Count;
 
@@ -276,7 +276,13 @@ namespace Uno.Toolkit.UI
 			}
 
 			// Set inter-element spacing
-			if (isVertical)
+			if (isSpaceBetween)
+			{
+				_grid.ClearValue(Grid.ColumnSpacingProperty);
+				_grid.ClearValue(Grid.RowSpacingProperty);
+
+			}
+			else if (isVertical)
 			{
 				_grid.RowSpacing = spacing;
 				_grid.ClearValue(Grid.ColumnSpacingProperty);


### PR DESCRIPTION

GitHub Issue (If applicable): [#1128](https://github.com/unoplatform/Uno.Figma/issues/1128)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- when in spacebetween the spacing is still use, setting a minimal space between autolayout children

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- when spacebetween the spacing will be ignore

## PR Checklist

Please check if your PR fulfills the following requirements:

- [c] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [c] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [c] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
