### PR TITLE
update Uno.Extensions.Markup

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Uno.Core.Extensions.Logging" Version="4.0.1" />
     <PackageVersion Include="Uno.Cupertino" Version="2.4.1" />
     <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.4.1" />
-    <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.125" />
-    <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.12" />
+    <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.166" />
+    <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
     <PackageVersion Include="Uno.Material" Version="2.4.1" />
     <PackageVersion Include="Uno.Material.WinUI" Version="2.4.1" />
     <PackageVersion Include="Uno.UI" Version="4.6.19" />

--- a/src/library/Uno.Toolkit.WinUI.Markup/AssemblyInfo.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Generator;
+﻿using Uno.Extensions.Markup.Generator;
 using System.Reflection;
 
 [assembly: GenerateMarkupForAssembly(typeof(Uno.Toolkit.UI.ToolkitResources))]


### PR DESCRIPTION
GitHub Issue (If applicable): #

n/a

## PR Type

What kind of change does this PR introduce?

- Other - Dependency Update

## What is the current behavior?

References old version of Markup with base Microsoft.UI.Xaml namespace

## What is the new behavior?

References updated Markup libraries with breaking Uno.Extensions.Markup namespace