### PR TITLE
fix(autolayout): conflict with padding and spacing vs primary alignment

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -77,10 +77,17 @@ internal class AutoLayoutTest
 	}
 
 	[TestMethod]
-	[DataRow(Orientation.Vertical, VerticalAlignment.Bottom, HorizontalAlignment.Left, new [] { 10, 10, 10, 10 }, new[] { 108, 0, 0, 10 }, 298, 110, 12,185)]
-	[DataRow(Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, 12, 110, 12, 185)]
-	[DataRow(Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 10, 10, 0, 0 }, 12, 12, 12, 105)]
-	public async Task When_AbsolutePosition_WithPadding(Orientation orientation, VerticalAlignment vAlign, HorizontalAlignment hAlign, int[] padding, int[] margin, double expectedY, double expectedX, double rec1expected, double rec2expected)
+	[DataRow(true, Orientation.Vertical, VerticalAlignment.Bottom, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 0, 0, 10 }, 10, 298, 110, 12, 185)]
+	[DataRow(true, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, 10, 12, 110, 12, 185)]
+	[DataRow(true, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, -30, 12, 110, 12, 165)]
+	[DataRow(true, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 10, 10, 0, 0 }, 10, 12, 12, 12, 105)]
+	[DataRow(true, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 10, 10, 0, 0 }, 10, 12, 12, 12, 105)]
+	[DataRow(true, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 10, 10, 0, 0 }, -30, 12, 12, 12, 85)]
+	[DataRow(false, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, 10, 12, 110, 138, 248)]
+	[DataRow(false, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, 10, 12, 110, 78, 138)]
+	[DataRow(false, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, -20, 12, 110, 168, 248)]
+	[DataRow(false, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, -20, 12, 110, 108, 138)]
+	public async Task When_AbsolutePosition_WithPadding(bool isStretch, Orientation orientation, VerticalAlignment vAlign, HorizontalAlignment hAlign, int[] padding, int[] margin, int spacing, double expectedY, double expectedX, double rec1expected, double rec2expected)
 	{
 		var SUT = new AutoLayout()
 		{
@@ -89,7 +96,7 @@ internal class AutoLayoutTest
 			BorderBrush = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)),
 			BorderThickness = new Thickness(2),
 			Padding = new Thickness(padding[0], padding[1], padding[2], padding[3]),
-			Spacing = 10,
+			Spacing = spacing,
 			Width = 200,
 			Height = 360,
 		};
@@ -117,8 +124,24 @@ internal class AutoLayoutTest
 
 		AutoLayout.SetIsIndependentLayout(border3, true);
 
-		AutoLayout.SetPrimaryAlignment(border1, AutoLayoutPrimaryAlignment.Stretch);
-		AutoLayout.SetPrimaryAlignment(border2, AutoLayoutPrimaryAlignment.Stretch);
+		if (isStretch)
+		{
+			AutoLayout.SetPrimaryAlignment(border1, AutoLayoutPrimaryAlignment.Stretch);
+			AutoLayout.SetPrimaryAlignment(border2, AutoLayoutPrimaryAlignment.Stretch);
+		}
+		else
+		{
+			if (orientation is Orientation.Vertical)
+			{
+				border1!.Height = 100;
+				border2!.Height = 100;
+			}
+			else
+			{
+				border1!.Width = 50;
+				border2!.Width = 50;
+			}
+		}
 
 		SUT.Children.Add(border1);
 		SUT.Children.Add(border2);


### PR DESCRIPTION


GitHub Issue (If applicable): #436

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?

- when absolute positionned element was under the padding and the padding same size or less than spacing, the element was not properly positionned.
![image](https://user-images.githubusercontent.com/16021239/211941364-73cb1287-0575-4335-a653-771a71451fd0.png)
- when PrimaryAxisAlignment="Center" or "End" and one item set to fill and a other item was absolute positionned the autolayout behaved like if not items was fill
![image](https://user-images.githubusercontent.com/16021239/211941656-99a75b49-457c-4548-ba7c-7e7bd425f9e0.png)

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- absolute position with margin and padding behave as expected 
![image](https://user-images.githubusercontent.com/16021239/212170754-6ced6efe-5e94-415b-a70c-201a6864f98f.png)
- spacebeetween margin fixes
![image](https://user-images.githubusercontent.com/16021239/212170862-0c5bba4a-6496-4c48-81ee-a9e9a460d02c.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
