### PR TITLE
fix: Remove unnecessary GestureInterceptorMargin and TrueToVisible converter in the DrawerControl style to fix UWP Sample

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Converters.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Converters.xaml
@@ -1,11 +1,12 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:converters="using:Uno.Toolkit.Samples.Converters">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:converters="using:Uno.Toolkit.Samples.Converters">
+	
 	<converters:FromStringToValueConverter x:Key="IsNullOrEmptyToCollapsed"
 										   Check="IsNullOrEmpty"
 										   TrueValue="Collapsed"
 										   FalseValue="Visible" />
+	
 	<converters:FromStringToValueConverter x:Key="SelectedItemToVisible"
 										   Check="IsEqualToParameterValue"
 										   TrueValue="Visible"
@@ -13,15 +14,12 @@
 
 	<converters:EnumDescriptionConverter x:Name="EnumToDescription" />
 
-	<converters:FromBoolToValueConverter x:Key="TrueToVisible"
-										 TrueValue="Visible"
-										 NullOrFalseValue="Collapsed" />
-
 	<converters:FromBoolToValueConverter x:Key="NotTrue"
 										 TrueValue="False"
 										 NullOrFalseValue="True" />
-    
+
 	<converters:FromBoolToValueConverter x:Key="IsFalse"
 										 FalseValue="True"
 										 NullOrTrueValue="False" />
+	
 </ResourceDictionary>

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
@@ -54,8 +54,7 @@
 						<!-- see: https://github.com/unoplatform/nventive-private/issues/271 -->
 						<Border x:Name="GestureInterceptor"
 								Background="Transparent"
-								Visibility="{Binding IsGestureEnabled, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TrueToVisible}}"
-								Margin="{TemplateBinding GestureInterceptorMargin}" />
+								Visibility="{Binding IsGestureEnabled, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TrueToVisible}}" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
@@ -54,7 +54,7 @@
 						<!-- see: https://github.com/unoplatform/nventive-private/issues/271 -->
 						<Border x:Name="GestureInterceptor"
 								Background="Transparent"
-								Visibility="{Binding IsGestureEnabled, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TrueToVisible}}" />
+								Visibility="{Binding IsGestureEnabled, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialTrueToVisible}}" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.toolkit.ui/issues/290, [#9487](https://github.com/unoplatform/uno/issues/9487)

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Remove unused GestureInterceptorMargin TemplateBinding in the DrawerControl style to fix UWP Sample

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## Other information
re: #290