### PR TITLE
fix(AutoLayout): Making sure the AutoLayout is correctly loaded before updating the layout

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -27,9 +27,9 @@ namespace Uno.Toolkit.UI
 			DefaultStyleKey = typeof(AutoLayout);
 			Children = new AutoLayoutChildren();
 
-			this.RegisterDisposablePropertyChangedCallback(HorizontalAlignmentProperty, (snd, e) => UpdateAlignments());
-			this.RegisterDisposablePropertyChangedCallback(VerticalAlignmentProperty, (snd, e) => UpdateAlignments());
-			this.RegisterDisposablePropertyChangedCallback(PaddingProperty, (snd, e) => UpdateAlignments());
+			this.RegisterDisposablePropertyChangedCallback(HorizontalAlignmentProperty, (snd, e) => UpdateAutoLayout());
+			this.RegisterDisposablePropertyChangedCallback(VerticalAlignmentProperty, (snd, e) => UpdateAutoLayout());
+			this.RegisterDisposablePropertyChangedCallback(PaddingProperty, (snd, e) => UpdateAutoLayout());
 		}
 
 		protected override void OnApplyTemplate()
@@ -38,7 +38,7 @@ namespace Uno.Toolkit.UI
 
 			base.OnApplyTemplate();
 
-			UpdateAlignments();
+			UpdateAutoLayout();
 		}
 
 		public static readonly DependencyProperty IsReverseZIndexProperty = DependencyProperty.Register(
@@ -192,7 +192,7 @@ namespace Uno.Toolkit.UI
 		{
 			if (d is AutoLayout al)
 			{
-				al.UpdateAlignments();
+				al.UpdateAutoLayout();
 			}
 		}
 
@@ -202,14 +202,14 @@ namespace Uno.Toolkit.UI
 			{
 				if (fe.Parent is AutoLayout al)
 				{
-					al.UpdateAlignments();
+					al.UpdateAutoLayout();
 				}
 			}
 		}
 
-		private void UpdateAlignments()
+		private void UpdateAutoLayout()
 		{
-			if (_grid == null)
+			if (_grid == null || IsLoaded is false)
 			{
 				return;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/unoplatform/uno.chefs/issues/178

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The layout was updated even though the AutoLayout was not loaded


## What is the new behavior?

Making sure the AutoLayout is correctly loaded before updating the layout


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

