### PR TITLE
fix(AutoLayout): Properly call the UpdateAutoLayout method during the OnLoaded

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -27,6 +27,8 @@ namespace Uno.Toolkit.UI
 			DefaultStyleKey = typeof(AutoLayout);
 			Children = new AutoLayoutChildren();
 
+			Loaded += OnLoaded;
+
 			this.RegisterDisposablePropertyChangedCallback(HorizontalAlignmentProperty, (snd, e) => UpdateAutoLayout());
 			this.RegisterDisposablePropertyChangedCallback(VerticalAlignmentProperty, (snd, e) => UpdateAutoLayout());
 			this.RegisterDisposablePropertyChangedCallback(PaddingProperty, (snd, e) => UpdateAutoLayout());
@@ -39,6 +41,11 @@ namespace Uno.Toolkit.UI
 			base.OnApplyTemplate();
 
 			UpdateAutoLayout();
+		}
+
+		private static void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			(sender as AutoLayout)?.UpdateAutoLayout();
 		}
 
 		public static readonly DependencyProperty IsReverseZIndexProperty = DependencyProperty.Register(


### PR DESCRIPTION
GitHub Issue (If applicable): #https://github.com/unoplatform/uno.chefs/issues/178

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

AutoLayout IsLoaded return false for all platforms except WinUI
(Explain by the fact that the sequence of events is different between Windows and WinUI)


## What is the new behavior?

Properly call the UpdateAutoLayout method during the OnLoaded that way IsLoaded is "true" for all platforms at the correct time

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
