### PR TITLE
fix: TabBarItem Icon should respect templated parent Foreground

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
@@ -332,7 +332,7 @@
 														 HorizontalAlignment="Center">
 													<ContentPresenter x:Name="Icon"
 																	  Content="{TemplateBinding Icon}"
-																	  Foreground="{ThemeResource OnSurfaceVariantBrush}" />
+																	  Foreground="{TemplateBinding Foreground}" />
 												</Viewbox>
 											</Border>
 


### PR DESCRIPTION
Both Content and Icon should follow the Foreground set on TabBarItem