### PR TITLE
fix(autolayout): padding rules when all children are strech

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -167,4 +167,70 @@ internal class AutoLayoutTest
 		Assert.AreEqual(border3Transform!.Matrix.OffsetY!, expectedY);
 		Assert.AreEqual(border3Transform!.Matrix.OffsetX!, expectedX);
 	}
+
+	[TestMethod]
+	[DataRow(true, Orientation.Horizontal, new[] { 10, 10, 10, 10 }, 10, 298, 110, 10, 205)]
+	[DataRow(true, Orientation.Vertical, new[] { 10, 10, 10, 10 }, 10, 298, 110, 10, 205)]
+	[DataRow(false, Orientation.Vertical, new[] { 10, 10, 10, 10 }, 10, 298, 110, 10, 220)]
+	[DataRow(false, Orientation.Horizontal, new[] { 10, 10, 10, 10 }, 10, 298, 110, 10, 220)]
+	public async Task When_Padding(bool isStretch, Orientation orientation, int[] padding, int spacing, double expectedY, double expectedX, double rec1expected, double rec2expected)
+	{
+		var SUT = new AutoLayout()
+		{
+			Orientation = orientation,
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)),
+			Padding = new Thickness(padding[0], padding[1], padding[2], padding[3]),
+			Spacing = spacing,
+			Width = 400,
+			Height = 400,
+		};
+		var border1 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+		};
+
+		var border2 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 255, 0)),
+		};
+
+		if (isStretch)
+		{
+			AutoLayout.SetPrimaryAlignment(border1, AutoLayoutPrimaryAlignment.Stretch);
+			AutoLayout.SetPrimaryAlignment(border2, AutoLayoutPrimaryAlignment.Stretch);
+		}
+		else
+		{
+			border1!.Width = 200;
+			border2!.Width = 200;
+			border1!.Height = 200;
+			border2!.Height = 200;
+		}
+
+		if (orientation is Orientation.Horizontal)
+		{
+			AutoLayout.SetCounterAlignment(border1, AutoLayoutAlignment.Start);
+			AutoLayout.SetCounterAlignment(border2, AutoLayoutAlignment.Start);
+		}
+
+		SUT.Children.Add(border1);
+		SUT.Children.Add(border2);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var border1Transform = (MatrixTransform)border1.TransformToVisual(SUT);
+		var border2Transform = (MatrixTransform)border2.TransformToVisual(SUT);
+
+		if (orientation is Orientation.Vertical)
+		{
+			Assert.AreEqual(border1Transform!.Matrix.OffsetY!, rec1expected);
+			Assert.AreEqual(border2Transform!.Matrix.OffsetY!, rec2expected);
+		}
+		else
+		{
+			Assert.AreEqual(border1Transform!.Matrix.OffsetX!, rec1expected);
+			Assert.AreEqual(border2Transform!.Matrix.OffsetX!, rec2expected);
+		}
+	}
+
 }

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -440,7 +440,7 @@ namespace Uno.Toolkit.UI
 					_grid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) });
 				}
 
-				var paddingCondition = PrimaryAxisAlignment is not AutoLayoutAlignment.Start || IsVerticalHug;
+				var paddingCondition = atLeastOneChildFillAvailableSpaceInPrimaryAxis || PrimaryAxisAlignment is not AutoLayoutAlignment.Start || IsVerticalHug;
 
 				if ( hasSpaceBetween || (hasPadding && paddingCondition))
 				{
@@ -469,7 +469,9 @@ namespace Uno.Toolkit.UI
 				{
 					_grid.Padding = new Thickness(0);
 
-					_grid.ColumnDefinitions.Insert(gridIndexOffSet, new ColumnDefinition() { Width = new GridLength(spacing < 0 ? padding.Left - spacing : padding.Left) });
+					var firstColumnWidth = new GridLength(spacing < 0 ? padding.Left - spacing : padding.Left);
+
+					_grid.ColumnDefinitions.Insert(gridIndexOffSet, new ColumnDefinition() { Width = firstColumnWidth });
 					gridIndexOffSet += 1;
 
 					_grid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(padding.Top) });
@@ -587,11 +589,13 @@ namespace Uno.Toolkit.UI
 					_grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) });
 				}
 
-				var paddingCondition = PrimaryAxisAlignment is not AutoLayoutAlignment.Start || IsHorizontalHug;
+				var paddingCondition = atLeastOneChildFillAvailableSpaceInPrimaryAxis || PrimaryAxisAlignment is not AutoLayoutAlignment.Start || IsHorizontalHug;
 
 				if (hasSpaceBetween || (hasPadding && paddingCondition))
 				{
-					_grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(spacing < 0 ? padding.Right - spacing : padding.Right) });
+					var lastColumnWidth = new GridLength(spacing < 0 ? padding.Right - spacing : padding.Right);
+
+					_grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = lastColumnWidth });
 				}
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/Uno.Figma/issues/1263

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Padding didn't behave like in figma for padding and stretch children

## What is the new behavior?

- Padding behave as expected when one parent is stretch 
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
