### PR TITLE
fix: Removing framework reference requirement

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -19,12 +19,12 @@
     <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.2" />
     <PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-    <PackageVersion Include="Uno.Cupertino" Version="2.5.0-dev.34" />
-    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.5.0-dev.34" />
+    <PackageVersion Include="Uno.Cupertino" Version="2.5.0-dev.37" />
+    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.5.0-dev.37" />
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-    <PackageVersion Include="Uno.Material" Version="2.5.0-dev.34" />
-    <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.34" />
+    <PackageVersion Include="Uno.Material" Version="2.5.0-dev.37" />
+    <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.37" />
     <PackageVersion Include="Uno.UI" Version="4.7.37" />
     <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.9" />
     <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.37" />

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.11" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.6.0" />
     <PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.1.0" />
     <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.2" />
     <PackageVersion Include="SkiaSharp.Views" Version="2.80.2" />

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -19,8 +19,8 @@
     <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.2" />
     <PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-    <PackageVersion Include="Uno.Cupertino" Version="2.4.1" />
-    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.4.1" />
+    <PackageVersion Include="Uno.Cupertino" Version="2.5.0-dev.34" />
+    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.5.0-dev.34" />
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
     <PackageVersion Include="Uno.Material" Version="2.5.0-dev.34" />

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -25,20 +25,20 @@
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
     <PackageVersion Include="Uno.Material" Version="2.5.0-dev.34" />
     <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.34" />
-    <PackageVersion Include="Uno.UI" Version="4.6.41" />
+    <PackageVersion Include="Uno.UI" Version="4.7.37" />
     <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.9" />
-    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.41" />
-    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.41" />
-    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.41" />
-    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.41" />
-    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.41" />
+    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.37" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.3" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.3" />
-    <PackageVersion Include="Uno.WinUI" Version="4.6.41" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.6.41" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.6.41" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.6.41" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.37" />
     <PackageVersion Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.3" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.2.0.5" />
     <PackageVersion Include="Xamarin.AndroidX.Browser" Version="1.4.0.2" />

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -23,8 +23,8 @@
     <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.4.1" />
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-    <PackageVersion Include="Uno.Material" Version="2.5.0-dev.15" />
-    <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.15" />
+    <PackageVersion Include="Uno.Material" Version="2.5.0-dev.34" />
+    <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.34" />
     <PackageVersion Include="Uno.UI" Version="4.6.41" />
     <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.9" />
     <PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.41" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
@@ -30,20 +30,5 @@
 	  <ProjectReference Include="..\..\..\src\Uno.Toolkit.UI\Uno.Toolkit.WinUI.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-	<!--
-	If you encounter this error message:
-    error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
-	Please update to a newer .NET SDK in order to reference this assembly.
-
-	This means that the two packages below must be aligned with the "build" version number of
-	the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
-	must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
-	-->
-
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
-   </ItemGroup>
-
 	<Import Project="..\..\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems" Label="Shared" />
 </Project>

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
@@ -16,6 +16,7 @@
 		<Manifest Include="$(ApplicationManifest)" />
 
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
@@ -40,8 +41,8 @@
 	must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
 	-->
 
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
    </ItemGroup>
 
 	<Import Project="..\..\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems" Label="Shared" />

--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net5.0-windows10.0.18362</TargetFramework>
+		<TargetFramework>net6.0-windows10.0.18362</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>Uno.Toolkit.WinUI.Samples</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,6 +3,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.6.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" /> 
     <PackageVersion Include="Uno.Core.Extensions.Collections" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging" Version="4.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
     <PackageVersion Include="Uno.Material" Version="2.5.0-dev.34" />
     <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.34" />
-    <PackageVersion Include="Uno.UI" Version="4.6.41" />
-    <PackageVersion Include="Uno.WinUI" Version="4.6.41" />
+    <PackageVersion Include="Uno.UI" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.37" />
     <PackageVersion Include="Uno.XamlMerge.Task" Version="1.1.0-dev.12" />
     <PackageVersion Include="FluentAssertions" Version="5.10.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.166" />
     <PackageVersion Include="Uno.SourceGenerationTasks" Version="4.2.0" />
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
-    <PackageVersion Include="Uno.Material" Version="2.5.0-dev.15" />
-    <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.15" />
+    <PackageVersion Include="Uno.Material" Version="2.5.0-dev.34" />
+    <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.34" />
     <PackageVersion Include="Uno.UI" Version="4.6.41" />
     <PackageVersion Include="Uno.WinUI" Version="4.6.41" />
     <PackageVersion Include="Uno.XamlMerge.Task" Version="1.1.0-dev.12" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,13 +7,13 @@
     <PackageVersion Include="Uno.Core.Extensions.Collections" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging" Version="4.0.1" />
-    <PackageVersion Include="Uno.Cupertino" Version="2.5.0-dev.34" />
-    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.5.0-dev.34" />
+    <PackageVersion Include="Uno.Cupertino" Version="2.5.0-dev.37" />
+    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.5.0-dev.37" />
     <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.166" />
     <PackageVersion Include="Uno.SourceGenerationTasks" Version="4.2.0" />
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
-    <PackageVersion Include="Uno.Material" Version="2.5.0-dev.34" />
-    <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.34" />
+    <PackageVersion Include="Uno.Material" Version="2.5.0-dev.37" />
+    <PackageVersion Include="Uno.Material.WinUI" Version="2.5.0-dev.37" />
     <PackageVersion Include="Uno.UI" Version="4.7.37" />
     <PackageVersion Include="Uno.WinUI" Version="4.7.37" />
     <PackageVersion Include="Uno.XamlMerge.Task" Version="1.1.0-dev.12" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="Uno.Core.Extensions.Collections" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging" Version="4.0.1" />
-    <PackageVersion Include="Uno.Cupertino" Version="2.4.1" />
-    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.4.1" />
+    <PackageVersion Include="Uno.Cupertino" Version="2.5.0-dev.34" />
+    <PackageVersion Include="Uno.Cupertino.WinUI" Version="2.5.0-dev.34" />
     <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.166" />
     <PackageVersion Include="Uno.SourceGenerationTasks" Version="4.2.0" />
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />

--- a/src/Uno.Toolkit.RuntimeTests/Tests/LeakTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/LeakTest.cs
@@ -1,4 +1,4 @@
-﻿#if !WINDOWS_UWP && !NET5_0_WINDOWS10_0_18362
+﻿#if !WINDOWS_UWP && !NET6_0_WINDOWS10_0_18362
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.props
+++ b/src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.props
@@ -25,20 +25,6 @@
 		<DefineConstants Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">$(DefineConstants);WINDOWS_WINUI</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
-		<!--
-			If you encounter this error message:
-			error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
-			Please update to a newer .NET SDK in order to reference this assembly.
-
-			This means that the two packages below must be aligned with the "build" version number of
-			the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
-			must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
-		-->
-
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.UI.Xaml" Condition="'$(TargetFramework)'=='uap10.0.18362'" />

--- a/src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.props
+++ b/src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.props
@@ -14,7 +14,7 @@
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' OR $(UnoTargetFrameworkOverride.Contains('MonoAndroid12.0'))">$(TargetFrameworks);MonoAndroid12.0</TargetFrameworks>
 		<!-- condition: in addition to the above condition, we ALSO check if the right FrameworkLineage is given and that we are building on window machine -->
 		<TargetFrameworks Condition="'$(FrameworkLineage)' == 'UWP' AND $([MSBuild]::IsOSPlatform('windows')) AND ('$(UnoTargetFrameworkOverride)'=='' OR $(UnoTargetFrameworkOverride.Contains('uap10.0.18362')))">$(TargetFrameworks);uap10.0.18362</TargetFrameworks>
-		<TargetFrameworks Condition="'$(FrameworkLineage)' == 'WINUI' AND $([MSBuild]::IsOSPlatform('windows')) AND ('$(UnoTargetFrameworkOverride)'=='' OR $(UnoTargetFrameworkOverride.Contains('net5.0-windows10.0.18362')))">$(TargetFrameworks);net5.0-windows10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'$(FrameworkLineage)' == 'WINUI' AND $([MSBuild]::IsOSPlatform('windows')) AND ('$(UnoTargetFrameworkOverride)'=='' OR $(UnoTargetFrameworkOverride.Contains('net6.0-windows10.0.18362')))">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
 
 		<AssemblyName>Uno.Toolkit.RuntimeTests</AssemblyName>
 		<RootNamespace>Uno.Toolkit.RuntimeTests</RootNamespace>
@@ -22,14 +22,14 @@
 
 		<DefineConstants Condition="'$(FrameworkLineage)' == 'UWP'">$(DefineConstants);IS_UWP</DefineConstants>
 		<DefineConstants Condition="'$(FrameworkLineage)' == 'WinUI'">$(DefineConstants);IS_WINUI</DefineConstants>
-		<DefineConstants Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">$(DefineConstants);WINDOWS_WINUI</DefineConstants>
+		<DefineConstants Condition="'$(TargetFramework)'=='net6.0-windows10.0.18362'">$(DefineConstants);WINDOWS_WINUI</DefineConstants>
 	</PropertyGroup>
 
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.UI.Xaml" Condition="'$(TargetFramework)'=='uap10.0.18362'" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Condition="'$(TargetFramework)'=='net6.0-windows10.0.18362'" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Condition="'$(TargetFramework)'=='net6.0-windows10.0.18362'" />
 		
 		<PackageReference Include="Uno.UI" Condition="'$(FrameworkLineage)' == 'UWP'" />
 		<PackageReference Include="Uno.WinUI" Condition="'$(FrameworkLineage)' == 'WinUI'" />

--- a/src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.props
+++ b/src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.props
@@ -36,14 +36,15 @@
 			must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
 		-->
 
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.UI.Xaml" Condition="'$(TargetFramework)'=='uap10.0.18362'" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
-
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'" />
+		
 		<PackageReference Include="Uno.UI" Condition="'$(FrameworkLineage)' == 'UWP'" />
 		<PackageReference Include="Uno.WinUI" Condition="'$(FrameworkLineage)' == 'WinUI'" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" />

--- a/src/Uno.Toolkit.UI/Helpers/LinkerAttributes.cs
+++ b/src/Uno.Toolkit.UI/Helpers/LinkerAttributes.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-#if !NET6_0_IOS && !NET6_0_MACCATALYST && !NET6_0_MACOS && !NET6_0_ANDROID && !NET5_0_WINDOWS10_0_18362
+#if !NET6_0_IOS && !NET6_0_MACCATALYST && !NET6_0_MACOS && !NET6_0_ANDROID && !NET6_0_WINDOWS10_0_18362
 namespace System.Diagnostics.CodeAnalysis
 {
 	/// <summary>

--- a/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
@@ -31,8 +31,9 @@
 
 	<ItemGroup Condition="$(_IsWinUI)">
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
@@ -32,8 +32,6 @@
 	<ItemGroup Condition="$(_IsWinUI)">
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
+++ b/src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj
@@ -7,7 +7,7 @@
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'!=''">$(UnoTargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'==''">netstandard2.0;xamarinios10;xamarinmac20;MonoAndroid12.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(DisableNet6MobileTargets)'==''">$(TargetFrameworks);net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(OS)'=='Windows_NT'">$(TargetFrameworks);net5.0-windows10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(OS)'=='Windows_NT'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<DefineConstants>$(DefineConstants);IS_WINUI</DefineConstants>

--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -20,7 +20,7 @@
 			Available build targets
 
 				uap10.0.18362 (Windows)
-				net5.0-windows10.0.18362 (WinAppSDK Windows)
+				net6.0-windows10.0.18362 (WinAppSDK Windows)
 				xamarinios10 (iOS)
 				MonoAndroid12.0 (Android 12.0)
 				netstandard2.0 (WebAssembly, Skia)

--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
@@ -34,8 +34,6 @@
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
 		<Page Remove="Generated\*.xaml" />
 	</ItemGroup>
 

--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
@@ -8,7 +8,7 @@
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'!=''">$(UnoTargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'==''">netstandard2.0;xamarinios10;xamarinmac20;MonoAndroid12.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(DisableNet6MobileTargets)'==''">$(TargetFrameworks);net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(OS)'=='Windows_NT'">$(TargetFrameworks);net5.0-windows10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(OS)'=='Windows_NT'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<DefineConstants>$(DefineConstants);IS_WINUI</DefineConstants>
@@ -30,7 +30,7 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
+	<ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows10.0.18362'">
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		

--- a/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
+++ b/src/library/Uno.Toolkit.Cupertino/Uno.Toolkit.WinUI.Cupertino.csproj
@@ -32,8 +32,10 @@
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
+		
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
 		<Page Remove="Generated\*.xaml" />
 	</ItemGroup>
 

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
@@ -31,10 +31,11 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
-
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
+		
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
 		<Page Remove="Generated\*.xaml" />
 
 	</ItemGroup>

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
@@ -34,8 +34,6 @@
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
 		<Page Remove="Generated\*.xaml" />
 
 	</ItemGroup>

--- a/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
+++ b/src/library/Uno.Toolkit.Material/Uno.Toolkit.WinUI.Material.csproj
@@ -8,7 +8,7 @@
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'!=''">$(UnoTargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'==''">netstandard2.0;xamarinios10;xamarinmac20;MonoAndroid12.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(DisableNet6MobileTargets)'==''">$(TargetFrameworks);net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(OS)'=='Windows_NT'">$(TargetFrameworks);net5.0-windows10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(OS)'=='Windows_NT'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<DefineConstants>$(DefineConstants);IS_WINUI</DefineConstants>
@@ -30,7 +30,7 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
+	<ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows10.0.18362'">
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		

--- a/src/library/Uno.Toolkit.WinUI.Markup/Uno.Toolkit.WinUI.Markup.csproj
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Uno.Toolkit.WinUI.Markup.csproj
@@ -7,7 +7,7 @@
 	<PropertyGroup>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'!=''">$(TargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'==''">netstandard2.0</TargetFrameworks>
-		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'=='' and '$(DisableNet6MobileTargets)'!='true'">$(TargetFrameworks);net5.0-windows10.0.18362;net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'=='' and '$(DisableNet6MobileTargets)'!='true'">$(TargetFrameworks);net6.0-windows10.0.18362;net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/library/Uno.Toolkit.WinUI.Markup/Uno.Toolkit.WinUI.Markup.csproj
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Uno.Toolkit.WinUI.Markup.csproj
@@ -20,11 +20,6 @@
 		<PackageReference Include="Uno.WinUI.Markup" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_IsWinUI)">
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\..\Uno.Toolkit.UI\Uno.Toolkit.WinUI.csproj" />
 	</ItemGroup>

--- a/src/library/Uno.Toolkit.WinUI.Material.Markup/Uno.Toolkit.WinUI.Material.Markup.csproj
+++ b/src/library/Uno.Toolkit.WinUI.Material.Markup/Uno.Toolkit.WinUI.Material.Markup.csproj
@@ -7,7 +7,7 @@
 	<PropertyGroup>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'!=''">$(TargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'==''">netstandard2.0</TargetFrameworks>
-		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'=='' and '$(DisableNet6MobileTargets)'!='true'">$(TargetFrameworks);net5.0-windows10.0.18362;net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'=='' and '$(DisableNet6MobileTargets)'!='true'">$(TargetFrameworks);net6.0-windows10.0.18362;net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/library/Uno.Toolkit.WinUI.Material.Markup/Uno.Toolkit.WinUI.Material.Markup.csproj
+++ b/src/library/Uno.Toolkit.WinUI.Material.Markup/Uno.Toolkit.WinUI.Material.Markup.csproj
@@ -15,11 +15,6 @@
 		<UseWinUI>true</UseWinUI>
 	</PropertyGroup>
 
-	<ItemGroup Condition="$(_IsWinUI)">
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <ProjectReference Include="..\Uno.Toolkit.Material\Uno.Toolkit.WinUI.Material.csproj" />
 	  <ProjectReference Include="..\Uno.Toolkit.WinUI.Markup\Uno.Toolkit.WinUI.Markup.csproj" />

--- a/src/winappsdk-workaround.targets
+++ b/src/winappsdk-workaround.targets
@@ -2,7 +2,7 @@
 	<!--
 		Workaround to avoid including Uno.Toolkit.UI XBFs in the PRI file:
 			> C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(5097,5):
-			> error MSB3030: Could not copy the file "D:\a\1\s\src\Uno.Toolkit.UI\obj\Uno.Toolkit.WinUI\Release\net5.0-windows10.0.18362\Controls\AutoLayout\AutoLayout.xbf" because it was not found.
+			> error MSB3030: Could not copy the file "D:\a\1\s\src\Uno.Toolkit.UI\obj\Uno.Toolkit.WinUI\Release\net6.0-windows10.0.18362\Controls\AutoLayout\AutoLayout.xbf" because it was not found.
 			> [D:\a\1\s\src\Uno.Toolkit.RuntimeTests\Uno.Toolkit.RuntimeTests.WinUI.csproj]
 		Just <Import /> this file into the winui project appearing in the `[]` bracket.
 	-->


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When adding toolkit to a WinUI project, it's necessary to update the frameworkreference - hard for developers to diagnose

## What is the new behavior?

Toolkit should be able to be added to winui project without affecting compilation or requiring additional steps

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
