### PR TITLE
fix(test): add pragma for autolayout wasm test

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -89,9 +90,6 @@ internal class AutoLayoutTest
 	[DataRow(false, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, 10, 12, 110, 78, 138)]
 	[DataRow(false, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, -20, 12, 110, 168, 248)]
 	[DataRow(false, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, -20, 12, 110, 108, 138)]
-#if !__ANDROID__ && !__IOS__
-	[Ignore("Currently fails on wasm")]
-#endif
 	public async Task When_AbsolutePosition_WithPadding(bool isStretch, Orientation orientation, VerticalAlignment vAlign, HorizontalAlignment hAlign, int[] padding, int[] margin, int spacing, double expectedY, double expectedX, double rec1expected, double rec2expected)
 	{
 		var SUT = new AutoLayout()
@@ -158,19 +156,23 @@ internal class AutoLayoutTest
 		var border2Transform = (MatrixTransform)border2.TransformToVisual(SUT);
 		var border3Transform = (MatrixTransform)border3.TransformToVisual(SUT);
 
+		//Element with border in wasm don't give the same result for TransformToVisual
+		//https://github.com/unoplatform/uno/issues/11410
+		var offset = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) ? 2 : 0;
+
 		if (orientation is Orientation.Vertical)
 		{
-			Assert.AreEqual(border1Transform!.Matrix.OffsetY!, rec1expected);
-			Assert.AreEqual(border2Transform!.Matrix.OffsetY!, rec2expected);
+			Assert.AreEqual(border1Transform!.Matrix.OffsetY!, rec1expected + offset);
+			Assert.AreEqual(border2Transform!.Matrix.OffsetY!, rec2expected + offset);
 		}
 		else
 		{
-			Assert.AreEqual(border1Transform!.Matrix.OffsetX!, rec1expected);
-			Assert.AreEqual(border2Transform!.Matrix.OffsetX!, rec2expected);
+			Assert.AreEqual(border1Transform!.Matrix.OffsetX!, rec1expected + offset);
+			Assert.AreEqual(border2Transform!.Matrix.OffsetX!, rec2expected + offset);
 		}
 
-		Assert.AreEqual(border3Transform!.Matrix.OffsetY!, expectedY);
-		Assert.AreEqual(border3Transform!.Matrix.OffsetX!, expectedX);
+		Assert.AreEqual(border3Transform!.Matrix.OffsetY!, expectedY + offset);
+		Assert.AreEqual(border3Transform!.Matrix.OffsetX!, expectedX + offset);
 	}
 
 	[TestMethod]


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

- Bugfix
-->

## What is the current behavior?

- When_AbsolutePosition_WithPadding test failling because of a different behavior in WinUI and Wasm 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

- When_AbsolutePosition_WithPadding  use different data for wasm 

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
create issue in Uno to solve the root issue

https://github.com/unoplatform/uno/issues/11410

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
