### PR TITLE
feat(Cards): add IsClickable property

### DIFF
--- a/doc/controls/CardAndCardContentControl.md
+++ b/doc/controls/CardAndCardContentControl.md
@@ -1,6 +1,6 @@
 # Card & CardContentControl
 
-> [!TIP] 
+> [!TIP]
 > This guide covers details for `Card` and `CardContentControl` specifically. If you are just getting started with the Uno Toolkit Material Library, please see our [general getting started](../getting-started.md) page to make sure you have the correct setup in place.
 
 ## Summary
@@ -8,7 +8,7 @@
 A card's layout and dimensions depend on its contents.
 
 ## Remarks
-Currently, there are three [Material](https://m3.material.io/components/cards/) styles for `Card` and `CardContentControl` that you can use. 
+Currently, there are three [Material](https://m3.material.io/components/cards/) styles for `Card` and `CardContentControl` that you can use.
 Depending on the amount of user attention you want to draw to the content you can use:
 - `ElevatedCardStyle` or `ElevatedCardContentControlStyle` to add a subtle z-axis elevation.
 - `FilledCardStyle` or `FilledCardContentControlStyle` to display a simple background color without any elevation or border for the card.
@@ -30,7 +30,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 <utu:Card .../>
 ```
 
-### Inheritance 
+### Inheritance
 Object &#8594; DependencyObject &#8594; UIElement &#8594; FrameworkElement &#8594; Control &#8594; Card
 
 ### Constructors
@@ -56,7 +56,8 @@ The Card control comes with all the built-in properties of a `Control`, and also
 | IconsContent              | object            | Gets or sets the content for the control's icons.                                             |
 | IconsContentTemplate      | DataTemplate      | Gets or sets the `DataTemplate` used to display the content of the control's icons.           |
 | Elevation                 | double            | Gets or sets the elevation of the control.                                                    |
-| ShadowColor               | Windows.UI.Color  | Gets or sets the color to use for the shadow of the control.                                  |
+| ShadowColor               | Color             | Gets or sets the color to use for the shadow of the control.                                  |
+| IsClickable               | bool              | Gets or sets a value indicating whether the control will respond to pointer and focus events. |
 
 > [!TIP]
 > Consider using [CardContentControl](#cardcontentcontrol) if you need full control over the content layout.
@@ -123,7 +124,8 @@ The Card control comes with all the built-in properties of a `ContentControl`, a
 | Property                  | Type              | Description                                                                                   |
 |---------------------------|-------------------|-----------------------------------------------------------------------------------------------|
 | Elevation                 | double            | Gets or sets the elevation of the control.                                                    |
-| ShadowColor               | Windows.UI.Color  | Gets or sets the color to use for the shadow of the control.  
+| ShadowColor               | Color             | Gets or sets the color to use for the shadow of the control.
+| IsClickable               | bool              | Gets or sets a value indicating whether the control will respond to pointer and focus events. |
 
 ### Usage
 ```xml

--- a/doc/controls/CardAndCardContentControl.md
+++ b/doc/controls/CardAndCardContentControl.md
@@ -44,17 +44,17 @@ The Card control comes with all the built-in properties of a `Control`, and also
 | Property                  | Type              | Description                                                                                   |
 |---------------------------|-------------------|-----------------------------------------------------------------------------------------------|
 | HeaderContent             | object            | Gets or sets the content for the control's header.                                            |
-| HeaderContentTemplate     | DataTemplate      | Gets or sets the `DataTemplate` used to display the content of the control's header.          |
+| HeaderContentTemplate     | DataTemplate      | Gets or sets the data template used to display the content of the control's header.           |
 | SubHeaderContent          | object            | Gets or sets the content for the control's subheader.                                         |
-| SubHeaderContentTemplate  | DataTemplate      | Gets or sets the `DataTemplate` used to display the content of the control's subheader.       |
+| SubHeaderContentTemplate  | DataTemplate      | Gets or sets the data template used to display the content of the control's subheader.        |
 | AvatarContent             | object            | Gets or sets the content for the control's avatar.                                            |
-| AvatarContentTemplate     | DataTemplate      | Gets or sets the `DataTemplate` used to display the content of the control's avatar.          |
+| AvatarContentTemplate     | DataTemplate      | Gets or sets the data template used to display the content of the control's avatar.           |
 | MediaContent              | object            | Gets or sets the content for the control's media area.                                        |
-| MediaContentTemplate      | DataTemplate      | Gets or sets the `DataTemplate` used to display the content of the control's media area.      |
+| MediaContentTemplate      | DataTemplate      | Gets or sets the data template used to display the content of the control's media area.       |
 | SupportingContent         | object            | Gets or sets the content for the control's supporting area.                                   |
-| SupportingContentTemplate | DataTemplate      | Gets or sets the `DataTemplate` used to display the content of the control's supporting area. |
+| SupportingContentTemplate | DataTemplate      | Gets or sets the data template used to display the content of the control's supporting area.  |
 | IconsContent              | object            | Gets or sets the content for the control's icons.                                             |
-| IconsContentTemplate      | DataTemplate      | Gets or sets the `DataTemplate` used to display the content of the control's icons.           |
+| IconsContentTemplate      | DataTemplate      | Gets or sets the data template used to display the content of the control's icons.            |
 | Elevation                 | double            | Gets or sets the elevation of the control.                                                    |
 | ShadowColor               | Color             | Gets or sets the color to use for the shadow of the control.                                  |
 | IsClickable               | bool              | Gets or sets a value indicating whether the control will respond to pointer and focus events. |
@@ -124,7 +124,7 @@ The Card control comes with all the built-in properties of a `ContentControl`, a
 | Property                  | Type              | Description                                                                                   |
 |---------------------------|-------------------|-----------------------------------------------------------------------------------------------|
 | Elevation                 | double            | Gets or sets the elevation of the control.                                                    |
-| ShadowColor               | Color             | Gets or sets the color to use for the shadow of the control.
+| ShadowColor               | Color             | Gets or sets the color to use for the shadow of the control.                                  |
 | IsClickable               | bool              | Gets or sets a value indicating whether the control will respond to pointer and focus events. |
 
 ### Usage

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
@@ -48,6 +48,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(object)));
 
+		/// <summary>
+		/// Gets or sets the content for the control's header.
+		/// </summary>
 		public object HeaderContent
 		{
 			get => (object)GetValue(HeaderContentProperty);
@@ -63,6 +66,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(DataTemplate)));
 
+		/// <summary>
+		/// Gets or sets the data template used to display the content of the control's header.
+		/// </summary>
 		public DataTemplate HeaderContentTemplate
 		{
 			get => (DataTemplate)GetValue(HeaderContentTemplateProperty);
@@ -78,6 +84,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(object)));
 
+		/// <summary>
+		/// Gets or sets the content for the control's subheader.
+		/// </summary>
 		public object SubHeaderContent
 		{
 			get => (object)GetValue(SubHeaderContentProperty);
@@ -93,6 +102,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(DataTemplate)));
 
+		/// <summary>
+		/// Gets or sets the data template used to display the content of the control's subheader.
+		/// </summary>
 		public DataTemplate SubHeaderContentTemplate
 		{
 			get => (DataTemplate)GetValue(SubHeaderContentTemplateProperty);
@@ -108,6 +120,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(object)));
 
+		/// <summary>
+		/// Gets or sets the content for the control's avatar.
+		/// </summary>
 		public object AvatarContent
 		{
 			get => (object)GetValue(AvatarContentProperty);
@@ -123,6 +138,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(DataTemplate)));
 
+		/// <summary>
+		/// Gets or sets the data template used to display the content of the control's avatar.
+		/// </summary>
 		public DataTemplate AvatarContentTemplate
 		{
 			get => (DataTemplate)GetValue(AvatarContentTemplateProperty);
@@ -138,6 +156,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(object)));
 
+		/// <summary>
+		/// Gets or sets the content for the control's media area.
+		/// </summary>
 		public object MediaContent
 		{
 			get => (object)GetValue(MediaContentProperty);
@@ -153,6 +174,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(DataTemplate)));
 
+		/// <summary>
+		/// Gets or sets the data template used to display the content of the control's media area.
+		/// </summary>
 		public DataTemplate MediaContentTemplate
 		{
 			get => (DataTemplate)GetValue(MediaContentTemplateProperty);
@@ -168,6 +192,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(object)));
 
+		/// <summary>
+		/// Gets or sets the content for the control's supporting area.
+		/// </summary>
 		public object SupportingContent
 		{
 			get => (object)GetValue(SupportingContentProperty);
@@ -183,6 +210,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(DataTemplate)));
 
+		/// <summary>
+		/// Gets or sets the data template used to display the content of the control's supporting area.
+		/// </summary>
 		public DataTemplate SupportingContentTemplate
 		{
 			get => (DataTemplate)GetValue(SupportingContentTemplateProperty);
@@ -198,6 +228,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(object)));
 
+		/// <summary>
+		/// Gets or sets the content for the control's icons.
+		/// </summary>
 		public object IconsContent
 		{
 			get => (object)GetValue(IconsContentProperty);
@@ -213,6 +246,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(DataTemplate)));
 
+		/// <summary>
+		/// Gets or sets the data template used to display the content of the control's icons.
+		/// </summary>
 		public DataTemplate IconsContentTemplate
 		{
 			get => (DataTemplate)GetValue(IconsContentTemplateProperty);
@@ -229,6 +265,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(default(double)));
 
+		/// <summary>
+		/// Gets or sets the elevation of the control.
+		/// </summary>
 		public
 #if __ANDROID__
 			new
@@ -248,6 +287,9 @@ namespace Uno.Toolkit.UI
 			typeof(Card),
 			new PropertyMetadata(DefaultShadowColor));
 
+		/// <summary>
+		/// Gets or sets the color to use for the shadow of the control.
+		/// </summary>
 		public Windows.UI.Color ShadowColor
 		{
 			get => (Windows.UI.Color)GetValue(ShadowColorProperty);

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
@@ -14,158 +14,264 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.Toolkit.UI
 {
-	public partial class Card : Control
+	public partial class Card
 	{
-#if __ANDROID__
-		private static readonly Windows.UI.Color _defaultShadowColor = Colors.Black;
-#else
-		private static readonly Windows.UI.Color _defaultShadowColor = Windows.UI.Color.FromArgb(64, 0, 0, 0);
-#endif
-
-#region HeaderContent and HeaderContentTemplate
-		public object HeaderContent
+		private static class CommonStates
 		{
-			get { return (object)GetValue(HeaderContentProperty); }
-			set { SetValue(HeaderContentProperty, value); }
+			public const string Normal = nameof(Normal);
+			public const string PointerOver = nameof(PointerOver);
+			public const string Pressed = nameof(Pressed);
+			public const string Disabled = nameof(Disabled);
+		}
+		private static class FocusStates
+		{
+			public const string Unfocused = nameof(Unfocused);
+			public const string Focused = nameof(Focused);
+			public const string PointerFocused = nameof(PointerFocused);
 		}
 
-		public static readonly DependencyProperty HeaderContentProperty =
-			DependencyProperty.Register("HeaderContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+		private static readonly Windows.UI.Color DefaultShadowColor
+#if __ANDROID__
+			= Colors.Black;
+#else
+			= Windows.UI.Color.FromArgb(64, 0, 0, 0);
+#endif
+	}
+
+	public partial class Card
+	{
+		#region DependencyProperty: HeaderContent
+
+		public static DependencyProperty HeaderContentProperty { get; } = DependencyProperty.Register(
+			nameof(HeaderContent),
+			typeof(object),
+			typeof(Card),
+			new PropertyMetadata(default(object)));
+
+		public object HeaderContent
+		{
+			get => (object)GetValue(HeaderContentProperty);
+			set => SetValue(HeaderContentProperty, value);
+		}
+
+		#endregion
+		#region DependencyProperty: HeaderContentTemplate
+
+		public static DependencyProperty HeaderContentTemplateProperty { get; } = DependencyProperty.Register(
+			nameof(HeaderContentTemplate),
+			typeof(DataTemplate),
+			typeof(Card),
+			new PropertyMetadata(default(DataTemplate)));
 
 		public DataTemplate HeaderContentTemplate
 		{
-			get { return (DataTemplate)GetValue(HeaderContentTemplateProperty); }
-			set { SetValue(HeaderContentTemplateProperty, value); }
+			get => (DataTemplate)GetValue(HeaderContentTemplateProperty);
+			set => SetValue(HeaderContentTemplateProperty, value);
 		}
 
-		public static readonly DependencyProperty HeaderContentTemplateProperty =
-			DependencyProperty.Register("HeaderContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
-#endregion
+		#endregion
+		#region DependencyProperty: SubHeaderContent
 
-#region SubHeaderContent and SubHeaderContentTemplate
+		public static DependencyProperty SubHeaderContentProperty { get; } = DependencyProperty.Register(
+			nameof(SubHeaderContent),
+			typeof(object),
+			typeof(Card),
+			new PropertyMetadata(default(object)));
+
 		public object SubHeaderContent
 		{
-			get { return (object)GetValue(SubHeaderContentProperty); }
-			set { SetValue(SubHeaderContentProperty, value); }
+			get => (object)GetValue(SubHeaderContentProperty);
+			set => SetValue(SubHeaderContentProperty, value);
 		}
 
-		public static readonly DependencyProperty SubHeaderContentProperty =
-			DependencyProperty.Register("SubHeaderContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+		#endregion
+		#region DependencyProperty: SubHeaderContentTemplate
+
+		public static DependencyProperty SubHeaderContentTemplateProperty { get; } = DependencyProperty.Register(
+			nameof(SubHeaderContentTemplate),
+			typeof(DataTemplate),
+			typeof(Card),
+			new PropertyMetadata(default(DataTemplate)));
 
 		public DataTemplate SubHeaderContentTemplate
 		{
-			get { return (DataTemplate)GetValue(SubHeaderContentTemplateProperty); }
-			set { SetValue(SubHeaderContentTemplateProperty, value); }
+			get => (DataTemplate)GetValue(SubHeaderContentTemplateProperty);
+			set => SetValue(SubHeaderContentTemplateProperty, value);
 		}
 
-		public static readonly DependencyProperty SubHeaderContentTemplateProperty =
-			DependencyProperty.Register("SubHeaderContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
-#endregion
+		#endregion
+		#region DependencyProperty: AvatarContent
 
-#region AvatarContent and AvatarContentTemplate
+		public static DependencyProperty AvatarContentProperty { get; } = DependencyProperty.Register(
+			nameof(AvatarContent),
+			typeof(object),
+			typeof(Card),
+			new PropertyMetadata(default(object)));
+
 		public object AvatarContent
 		{
-			get { return (object)GetValue(AvatarContentProperty); }
-			set { SetValue(AvatarContentProperty, value); }
+			get => (object)GetValue(AvatarContentProperty);
+			set => SetValue(AvatarContentProperty, value);
 		}
 
-		public static readonly DependencyProperty AvatarContentProperty =
-			DependencyProperty.Register("AvatarContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+		#endregion
+		#region DependencyProperty: AvatarContentTemplate
+
+		public static DependencyProperty AvatarContentTemplateProperty { get; } = DependencyProperty.Register(
+			nameof(AvatarContentTemplate),
+			typeof(DataTemplate),
+			typeof(Card),
+			new PropertyMetadata(default(DataTemplate)));
 
 		public DataTemplate AvatarContentTemplate
 		{
-			get { return (DataTemplate)GetValue(AvatarContentTemplateProperty); }
-			set { SetValue(AvatarContentTemplateProperty, value); }
+			get => (DataTemplate)GetValue(AvatarContentTemplateProperty);
+			set => SetValue(AvatarContentTemplateProperty, value);
 		}
 
-		public static readonly DependencyProperty AvatarContentTemplateProperty =
-			DependencyProperty.Register("AvatarContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
-#endregion
+		#endregion
+		#region DependencyProperty: MediaContent
 
-#region MediaContent and MediaContentTemplate
+		public static DependencyProperty MediaContentProperty { get; } = DependencyProperty.Register(
+			nameof(MediaContent),
+			typeof(object),
+			typeof(Card),
+			new PropertyMetadata(default(object)));
+
 		public object MediaContent
 		{
-			get { return (object)GetValue(MediaContentProperty); }
-			set { SetValue(MediaContentProperty, value); }
+			get => (object)GetValue(MediaContentProperty);
+			set => SetValue(MediaContentProperty, value);
 		}
 
-		public static readonly DependencyProperty MediaContentProperty =
-			DependencyProperty.Register("MediaContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+		#endregion
+		#region DependencyProperty: MediaContentTemplate
+
+		public static DependencyProperty MediaContentTemplateProperty { get; } = DependencyProperty.Register(
+			nameof(MediaContentTemplate),
+			typeof(DataTemplate),
+			typeof(Card),
+			new PropertyMetadata(default(DataTemplate)));
 
 		public DataTemplate MediaContentTemplate
 		{
-			get { return (DataTemplate)GetValue(MediaContentTemplateProperty); }
-			set { SetValue(MediaContentTemplateProperty, value); }
+			get => (DataTemplate)GetValue(MediaContentTemplateProperty);
+			set => SetValue(MediaContentTemplateProperty, value);
 		}
 
-		public static readonly DependencyProperty MediaContentTemplateProperty =
-			DependencyProperty.Register("MediaContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
-#endregion
+		#endregion
+		#region DependencyProperty: SupportingContent
 
-#region SupportingContent and SupportingContentTemplate
+		public static DependencyProperty SupportingContentProperty { get; } = DependencyProperty.Register(
+			nameof(SupportingContent),
+			typeof(object),
+			typeof(Card),
+			new PropertyMetadata(default(object)));
+
 		public object SupportingContent
 		{
-			get { return (object)GetValue(SupportingContentProperty); }
-			set { SetValue(SupportingContentProperty, value); }
+			get => (object)GetValue(SupportingContentProperty);
+			set => SetValue(SupportingContentProperty, value);
 		}
 
-		public static readonly DependencyProperty SupportingContentProperty =
-			DependencyProperty.Register("SupportingContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+		#endregion
+		#region DependencyProperty: SupportingContentTemplate
+
+		public static DependencyProperty SupportingContentTemplateProperty { get; } = DependencyProperty.Register(
+			nameof(SupportingContentTemplate),
+			typeof(DataTemplate),
+			typeof(Card),
+			new PropertyMetadata(default(DataTemplate)));
 
 		public DataTemplate SupportingContentTemplate
 		{
-			get { return (DataTemplate)GetValue(SupportingContentTemplateProperty); }
-			set { SetValue(SupportingContentTemplateProperty, value); }
+			get => (DataTemplate)GetValue(SupportingContentTemplateProperty);
+			set => SetValue(SupportingContentTemplateProperty, value);
 		}
 
-		public static readonly DependencyProperty SupportingContentTemplateProperty =
-			DependencyProperty.Register("SupportingContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
-#endregion
+		#endregion
+		#region DependencyProperty: IconsContent
 
-#region IconsContent and IconsContentTemplate
+		public static DependencyProperty IconsContentProperty { get; } = DependencyProperty.Register(
+			nameof(IconsContent),
+			typeof(object),
+			typeof(Card),
+			new PropertyMetadata(default(object)));
+
 		public object IconsContent
 		{
-			get { return (object)GetValue(IconsContentProperty); }
-			set { SetValue(IconsContentProperty, value); }
+			get => (object)GetValue(IconsContentProperty);
+			set => SetValue(IconsContentProperty, value);
 		}
 
-		public static readonly DependencyProperty IconsContentProperty =
-			DependencyProperty.Register("IconsContent", typeof(object), typeof(Card), new PropertyMetadata(null));
+		#endregion
+		#region DependencyProperty: IconsContentTemplate
+
+		public static DependencyProperty IconsContentTemplateProperty { get; } = DependencyProperty.Register(
+			nameof(IconsContentTemplate),
+			typeof(DataTemplate),
+			typeof(Card),
+			new PropertyMetadata(default(DataTemplate)));
 
 		public DataTemplate IconsContentTemplate
 		{
-			get { return (DataTemplate)GetValue(IconsContentTemplateProperty); }
-			set { SetValue(IconsContentTemplateProperty, value); }
+			get => (DataTemplate)GetValue(IconsContentTemplateProperty);
+			set => SetValue(IconsContentTemplateProperty, value);
 		}
 
-		public static readonly DependencyProperty IconsContentTemplateProperty =
-			DependencyProperty.Register("IconsContentTemplate", typeof(DataTemplate), typeof(Card), new PropertyMetadata(null));
-#endregion
+		#endregion
 
-#region Elevation
+		#region DependencyProperty: Elevation
+
+		public static DependencyProperty ElevationProperty { get; } = DependencyProperty.Register(
+			nameof(Elevation),
+			typeof(double),
+			typeof(Card),
+			new PropertyMetadata(default(double)));
+
 		public
 #if __ANDROID__
 			new
 #endif
 			double Elevation
 		{
-			get { return (double)GetValue(ElevationProperty); }
-			set { SetValue(ElevationProperty, value); }
+			get => (double)GetValue(ElevationProperty);
+			set => SetValue(ElevationProperty, value);
 		}
 
-		public static readonly DependencyProperty ElevationProperty =
-			DependencyProperty.Register("Elevation", typeof(double), typeof(Card), new PropertyMetadata(0));
-#endregion
+		#endregion
+		#region DependencyProperty: ShadowColor = DefaultShadowColor
 
-#region ShadowColor
+		public static DependencyProperty ShadowColorProperty { get; } = DependencyProperty.Register(
+			nameof(ShadowColor),
+			typeof(Windows.UI.Color),
+			typeof(Card),
+			new PropertyMetadata(DefaultShadowColor));
+
 		public Windows.UI.Color ShadowColor
 		{
-			get { return (Windows.UI.Color)GetValue(ShadowColorProperty); }
-			set { SetValue(ShadowColorProperty, value); }
+			get => (Windows.UI.Color)GetValue(ShadowColorProperty);
+			set => SetValue(ShadowColorProperty, value);
 		}
 
-		public static readonly DependencyProperty ShadowColorProperty =
-			DependencyProperty.Register("ShadowColor", typeof(Windows.UI.Color), typeof(Card), new PropertyMetadata(_defaultShadowColor));
-#endregion
+		#endregion
+		#region DependencyProperty: IsClickable = true
+
+		public static DependencyProperty IsClickableProperty { get; } = DependencyProperty.Register(
+			nameof(IsClickable),
+			typeof(bool),
+			typeof(Card),
+			new PropertyMetadata(true));
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the control will respond to pointer and focus events.
+		/// </summary>
+		public bool IsClickable
+		{
+			get => (bool)GetValue(IsClickableProperty);
+			set => SetValue(IsClickableProperty, value);
+		}
+
+		#endregion
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.cs
@@ -22,59 +22,70 @@ namespace Uno.Toolkit.UI
 
 		protected override void OnApplyTemplate()
 		{
-			if (IsEnabled)
-			{
-				VisualStateManager.GoToState(this, "Normal", true);
-			}
-			else
-			{
-				VisualStateManager.GoToState(this, "Disabled", true);
-			}
+			VisualStateManager.GoToState(this, IsEnabled ? CommonStates.Normal : CommonStates.Disabled, true);
 
 			base.OnApplyTemplate();
 		}
 
 		protected override void OnPointerEntered(PointerRoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "PointerOver", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, CommonStates.PointerOver, true);
 
-			base.OnPointerEntered(e);
+				base.OnPointerEntered(e);
+			}
 		}
 
 		protected override void OnPointerExited(PointerRoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Normal", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, CommonStates.Normal, true);
 
-			base.OnPointerExited(e);
+				base.OnPointerExited(e);
+			}
 		}
 
 		protected override void OnPointerPressed(PointerRoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Pressed", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, CommonStates.Pressed, true);
 
-			base.OnPointerPressed(e);
+				base.OnPointerPressed(e);
+			}
 		}
 
 		protected override void OnPointerReleased(PointerRoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Normal", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, CommonStates.Normal, true);
 
-			base.OnPointerReleased(e);
+				base.OnPointerReleased(e);
+			}
 		}
 
 		protected override void OnGotFocus(RoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Focused", true);
-			VisualStateManager.GoToState(this, "PointerFocused", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, FocusStates.Focused, true);
+				VisualStateManager.GoToState(this, FocusStates.PointerFocused, true);
 
-			base.OnGotFocus(e);
+				base.OnGotFocus(e);
+			}
 		}
 
 		protected override void OnLostFocus(RoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Unfocused", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, FocusStates.Unfocused, true);
 
-			base.OnLostFocus(e);
+				base.OnLostFocus(e);
+			}
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControl.cs
@@ -55,6 +55,9 @@ namespace Uno.Toolkit.UI
 			typeof(CardContentControl),
 			new PropertyMetadata(default(double)));
 
+		/// <summary>
+		/// Gets or sets the elevation of the control.
+		/// </summary>
 		public
 #if __ANDROID__
 			new
@@ -74,6 +77,9 @@ namespace Uno.Toolkit.UI
 			typeof(CardContentControl),
 			new PropertyMetadata(DefaultShadowColor));
 
+		/// <summary>
+		/// Gets or sets the color to use for the shadow of the control.
+		/// </summary>
 		public Windows.UI.Color ShadowColor
 		{
 			get => (Windows.UI.Color)GetValue(ShadowColorProperty);

--- a/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControl.cs
@@ -18,23 +18,43 @@ using Windows.UI.Xaml.Input;
 
 namespace Uno.Toolkit.UI
 {
+	public partial class CardContentControl
+	{
+		private static class CommonStates
+		{
+			public const string Normal = nameof(Normal);
+			public const string PointerOver = nameof(PointerOver);
+			public const string Pressed = nameof(Pressed);
+			public const string Disabled = nameof(Disabled);
+		}
+		private static class FocusStates
+		{
+			public const string Unfocused = nameof(Unfocused);
+			public const string Focused = nameof(Focused);
+			public const string PointerFocused = nameof(PointerFocused);
+		}
+
+		private static readonly Windows.UI.Color DefaultShadowColor
+#if __ANDROID__
+			= Colors.Black;
+#else
+			= Windows.UI.Color.FromArgb(64, 0, 0, 0);
+#endif
+	}
+
 	/// <summary>
 	/// Represents a control used to visually group related child elements and information.
 	/// </summary>
 	public partial class CardContentControl : ContentControl
 	{
-#if __ANDROID__
-		private static readonly Windows.UI.Color _defaultShadowColor = Colors.Black;
-#else
-		private static readonly Windows.UI.Color _defaultShadowColor = Windows.UI.Color.FromArgb(64, 0, 0, 0);
-#endif
+		#region DependencyProperty: Elevation
 
-		public CardContentControl()
-		{
-			DefaultStyleKey = typeof(CardContentControl);
-		}
+		public static DependencyProperty ElevationProperty { get; } = DependencyProperty.Register(
+			nameof(Elevation),
+			typeof(double),
+			typeof(CardContentControl),
+			new PropertyMetadata(default(double)));
 
-		#region Elevation
 		public
 #if __ANDROID__
 			new
@@ -45,76 +65,112 @@ namespace Uno.Toolkit.UI
 			set => SetValue(ElevationProperty, value);
 		}
 
-		public static readonly DependencyProperty ElevationProperty =
-			DependencyProperty.Register("Elevation", typeof(double), typeof(CardContentControl), new PropertyMetadata(0));
 		#endregion
+		#region DependencyProperty: ShadowColor = DefaultShadowColor
 
-		#region ShadowColor
+		public static DependencyProperty ShadowColorProperty { get; } = DependencyProperty.Register(
+			nameof(ShadowColor),
+			typeof(Windows.UI.Color),
+			typeof(CardContentControl),
+			new PropertyMetadata(DefaultShadowColor));
+
 		public Windows.UI.Color ShadowColor
 		{
 			get => (Windows.UI.Color)GetValue(ShadowColorProperty);
 			set => SetValue(ShadowColorProperty, value);
 		}
 
-		public static readonly DependencyProperty ShadowColorProperty =
-			DependencyProperty.Register("ShadowColor", typeof(Windows.UI.Color), typeof(CardContentControl), new PropertyMetadata(_defaultShadowColor));
 		#endregion
+		#region DependencyProperty: IsClickable = true
+
+		public static DependencyProperty IsClickableProperty { get; } = DependencyProperty.Register(
+			nameof(IsClickable),
+			typeof(bool),
+			typeof(CardContentControl),
+			new PropertyMetadata(true));
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the control will respond to pointer and focus events.
+		/// </summary>
+		public bool IsClickable
+		{
+			get => (bool)GetValue(IsClickableProperty);
+			set => SetValue(IsClickableProperty, value);
+		}
+
+		#endregion
+
+		public CardContentControl()
+		{
+			DefaultStyleKey = typeof(CardContentControl);
+		}
 
 		protected override void OnApplyTemplate()
 		{
-			if (IsEnabled)
-			{
-				VisualStateManager.GoToState(this, "Normal", true);
-			}
-			else
-			{
-				VisualStateManager.GoToState(this, "Disabled", true);
-			}
+			VisualStateManager.GoToState(this, IsEnabled ? CommonStates.Normal : CommonStates.Disabled, true);
 
 			base.OnApplyTemplate();
 		}
 
 		protected override void OnPointerEntered(PointerRoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "PointerOver", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, CommonStates.PointerOver, true);
 
-			base.OnPointerEntered(e);
+				base.OnPointerEntered(e);
+			}
 		}
 
 		protected override void OnPointerExited(PointerRoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Normal", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, CommonStates.Normal, true);
 
-			base.OnPointerExited(e);
+				base.OnPointerExited(e);
+			}
 		}
 
 		protected override void OnPointerPressed(PointerRoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Pressed", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, CommonStates.Pressed, true);
 
-			base.OnPointerPressed(e);
+				base.OnPointerPressed(e);
+			}
 		}
 
 		protected override void OnPointerReleased(PointerRoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Normal", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, CommonStates.Normal, true);
 
-			base.OnPointerReleased(e);
+				base.OnPointerReleased(e);
+			}
 		}
 
 		protected override void OnGotFocus(RoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Focused", true);
-			VisualStateManager.GoToState(this, "PointerFocused", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, FocusStates.Focused, true);
+				VisualStateManager.GoToState(this, FocusStates.PointerFocused, true);
 
-			base.OnGotFocus(e);
+				base.OnGotFocus(e);
+			}
 		}
 
 		protected override void OnLostFocus(RoutedEventArgs e)
 		{
-			VisualStateManager.GoToState(this, "Unfocused", true);
+			if (IsClickable)
+			{
+				VisualStateManager.GoToState(this, FocusStates.Unfocused, true);
 
-			base.OnLostFocus(e);
+				base.OnLostFocus(e);
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #465

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Card and CardContentControl always respond to pointer & focus events, with no way of disabling this behavior.

## What is the new behavior?
This behavior can now be toggled with the new `IsClickable` property on both controls, that is set to `true` by default.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Internal Issue (If applicable):
closes unoplatform/uno.chefs#113