### PR TITLE
fix: Restore net6.0 compatible TargetPlatformVersion

### DIFF
--- a/src/PlatformItemGroups.props
+++ b/src/PlatformItemGroups.props
@@ -32,20 +32,24 @@
 	<PropertyGroup Condition="$(_IsIOS)">
 		<DefineConstants>$(DefineConstants);IOS1_0;XAMARIN;XAMARIN_IOS;XAMARIN_IOS_UNIFIED</DefineConstants>
 		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+		<TargetPlatformVersion>15.4</TargetPlatformVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(_IsMacOS)">
 		<DefineConstants>$(DefineConstants);XAMARIN</DefineConstants>
 		<SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
+		<TargetPlatformVersion>12.3</TargetPlatformVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(_IsCatalyst)">
 		<SupportedOSPlatformVersion>13.1</SupportedOSPlatformVersion>
+		<TargetPlatformVersion>15.4</TargetPlatformVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(_IsAndroid)">
 		<DefineConstants>$(DefineConstants);__ANDROID__;XAMARIN;MONOANDROID5_0;XAMARIN_ANDROID</DefineConstants>
 		<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+		<TargetPlatformVersion>31.0</TargetPlatformVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Upgrading the SDK forced a higher version which can cause incorrect resolution of assemblies for net6.0-built apps (gallery, specifically).