### PR TITLE
fix: TabBar Selection Indicator adapts to collapsed items

### DIFF
--- a/build/workflow/templates/dotnet-workload-install-mac.yml
+++ b/build/workflow/templates/dotnet-workload-install-mac.yml
@@ -1,5 +1,5 @@
 parameters:
-  DotNetVersion: '6.0.400'
+  DotNetVersion: '6.0.401'
   UnoCheck_Version: '1.5.4'
   UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/34b1a60f5c1c51604b47362781969dde46979fd5/manifests/uno.ui.manifest.json'
   Dotnet_Root: '/usr/local/share/dotnet/'

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarSamplePage.xaml.cs
@@ -33,13 +33,13 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Uno.Toolkit.Samples.Content.Controls
 {
-    [SamplePage(SampleCategory.Controls, "TabBar", DataType = typeof(TabBarViewModel))]
-    public sealed partial class TabBarSamplePage : Page
-    {
-        public TabBarSamplePage()
-        {
-            this.InitializeComponent();
-        }
+	[SamplePage(SampleCategory.Controls, "TabBar", DataType = typeof(TabBarViewModel))]
+	public sealed partial class TabBarSamplePage : Page
+	{
+		public TabBarSamplePage()
+		{
+			this.InitializeComponent();
+		}
 
 		private void ShowM3MaterialTopBarSampleInNestedFrame(object sender, RoutedEventArgs e)
 		{
@@ -47,29 +47,29 @@ namespace Uno.Toolkit.Samples.Content.Controls
 		}
 
 		private void ShowMaterialTopBarSampleInNestedFrame(object sender, RoutedEventArgs e)
-        {
-            Shell.GetForCurrentView()?.ShowNestedSample<MaterialTopBarSampleNestedPage>(clearStack: true);
-        }
+		{
+			Shell.GetForCurrentView()?.ShowNestedSample<MaterialTopBarSampleNestedPage>(clearStack: true);
+		}
 
 		private void ShowM3MaterialBottomBarSampleInNestedFrame(object sender, RoutedEventArgs e)
-        {
-            Shell.GetForCurrentView()?.ShowNestedSample<M3MaterialBottomBarSampleNestedPage>(clearStack: true);
-        }
+		{
+			Shell.GetForCurrentView()?.ShowNestedSample<M3MaterialBottomBarSampleNestedPage>(clearStack: true);
+		}
 
-        private void ShowMaterialBottomBarSampleInNestedFrame(object sender, RoutedEventArgs e)
-        {
-            Shell.GetForCurrentView()?.ShowNestedSample<MaterialBottomBarSampleNestedPage>(clearStack: true);
-        }
+		private void ShowMaterialBottomBarSampleInNestedFrame(object sender, RoutedEventArgs e)
+		{
+			Shell.GetForCurrentView()?.ShowNestedSample<MaterialBottomBarSampleNestedPage>(clearStack: true);
+		}
 
-        private void ShowCupertinoBottomBarSampleInNestedFrame(object sender, RoutedEventArgs e)
-        {
-            Shell.GetForCurrentView()?.ShowNestedSample<CupertinoBottomBarSampleNestedPage>(clearStack: true);
-        }
+		private void ShowCupertinoBottomBarSampleInNestedFrame(object sender, RoutedEventArgs e)
+		{
+			Shell.GetForCurrentView()?.ShowNestedSample<CupertinoBottomBarSampleNestedPage>(clearStack: true);
+		}
 
 		private void ShowM3MaterialVerticalBarSampleInNestedFrame(object sender, RoutedEventArgs e)
-        {
-            Shell.GetForCurrentView()?.ShowNestedSample<M3MaterialVerticalBarSampleNestedPage>(clearStack: true);
-        }
+		{
+			Shell.GetForCurrentView()?.ShowNestedSample<M3MaterialVerticalBarSampleNestedPage>(clearStack: true);
+		}
 	}
 
 	public class TabBarViewModel : ViewModelBase

--- a/src/Uno.Toolkit.RuntimeTests/Helpers/UnitTestUIContentHelperEx.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Helpers/UnitTestUIContentHelperEx.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Uno.UI.RuntimeTests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -21,6 +24,32 @@ namespace Uno.Toolkit.RuntimeTests.Helpers
 			Base.Content = e;
 			await Base.WaitForIdle();
 			await Base.WaitForLoaded(e);
+		}
+
+		/// <summary>
+		/// Wait until a specified <paramref name="condition"/> is met. 
+		/// </summary>
+		/// <param name="timeoutMS">The maximum time to wait before failing the test, in milliseconds.</param>
+		public static async Task WaitFor(Func<bool> condition, int timeoutMS = 1000, string? message = null, [CallerMemberName] string? callerMemberName = null, [CallerLineNumber] int lineNumber = 0)
+		{
+			if (condition())
+			{
+				return;
+			}
+
+			var stopwatch = Stopwatch.StartNew();
+			while (stopwatch.ElapsedMilliseconds < timeoutMS)
+			{
+				await Base.WaitForIdle();
+				if (condition())
+				{
+					return;
+				}
+			}
+
+			message ??= $"{callerMemberName}():{lineNumber}";
+
+			throw new AssertFailedException("Timed out waiting for condition to be met: " + message);
 		}
 	}
 }

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
@@ -8,10 +8,17 @@ using Uno.Toolkit.RuntimeTests.Extensions;
 using Uno.Toolkit.RuntimeTests.Helpers;
 using Uno.Toolkit.UI;
 using Uno.UI.RuntimeTests;
+
 #if IS_WINUI
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Media;
 #else
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
 #endif
 
 namespace Uno.Toolkit.RuntimeTests.Tests
@@ -73,7 +80,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			Assert.IsTrue(source[1].IsSelected);
 		}
 
-		
 		[TestMethod]
 		public async Task SetSelectedIndex()
 		{
@@ -101,5 +107,35 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			Assert.AreEqual(1, SUT.SelectedIndex);
 			Assert.IsTrue(source[1].IsSelected);
 		}
+
+		[TestMethod]
+		public async Task Verify_Indicator_Max_Size()
+		{
+			var source = Enumerable.Range(0, 3).Select(x => new TabBarItem { Content = x }).ToArray();
+			var indicator = new Border() { Height = 5, Background = new SolidColorBrush(Colors.Red) };
+			var SUT = new TabBar
+			{
+				ItemsSource = source,
+				SelectionIndicatorContent = indicator,
+			};
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			source[0].IsSelected = true;
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			var expectedWidth = SUT.ActualWidth / 3;
+			var indicatorWidth = indicator.ActualWidth;
+			Assert.AreEqual(expectedWidth, indicatorWidth, delta: 1f);
+
+			source[1].Visibility = Visibility.Collapsed;
+
+			await UnitTestsUIContentHelper.WaitForIdle();
+			await UnitTestUIContentHelperEx.WaitFor(() => indicator.ActualWidth > indicatorWidth, timeoutMS: 2000);
+
+			expectedWidth = SUT.ActualWidth / 2;
+			Assert.AreEqual(expectedWidth, indicator.ActualWidth, delta: 1f);
+		}
+
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.Properties.cs
@@ -19,7 +19,7 @@ namespace Uno.Toolkit.UI
 			nameof(SelectedItem),
 			typeof(object),
 			typeof(TabBar),
-			new PropertyMetadata(default(object), OnPropertyChanged));
+			new PropertyMetadata(null, OnPropertyChanged));
 
 		public object SelectedItem
 		{
@@ -79,7 +79,7 @@ namespace Uno.Toolkit.UI
 			nameof(SelectionIndicatorContent),
 			typeof(object),
 			typeof(TabBar),
-			new PropertyMetadata(default(object), OnPropertyChanged));
+			new PropertyMetadata(null, OnPropertyChanged));
 
 		public object SelectionIndicatorContent
 		{
@@ -94,7 +94,7 @@ namespace Uno.Toolkit.UI
 			nameof(SelectionIndicatorContentTemplate),
 			typeof(DataTemplate),
 			typeof(TabBar),
-			new PropertyMetadata(default(DataTemplate), OnPropertyChanged));
+			new PropertyMetadata(null, OnPropertyChanged));
 
 		public DataTemplate SelectionIndicatorContentTemplate
 		{
@@ -109,7 +109,7 @@ namespace Uno.Toolkit.UI
 			nameof(SelectionIndicatorPresenterStyle),
 			typeof(Style),
 			typeof(TabBar),
-			new PropertyMetadata(default(Style), OnPropertyChanged));
+			new PropertyMetadata(null, OnPropertyChanged));
 
 		public Style SelectionIndicatorPresenterStyle
 		{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
@@ -239,10 +239,10 @@ namespace Uno.Toolkit.UI
 			TabBarItem? oldItem = null;
 			if (args?.OldValue is int oldIndex)
 			{
-				oldItem = FindContainerByIndex(oldIndex);
+				oldItem = this.FindContainerByIndex<TabBarItem>(oldIndex);
 			}
 
-			var newItem = FindContainerByIndex(SelectedIndex);
+			var newItem = this.FindContainerByIndex<TabBarItem>(SelectedIndex);
 
 			if (TryUpdateTabBarItemSelectedState(oldItem, newItem))
 			{
@@ -258,7 +258,7 @@ namespace Uno.Toolkit.UI
 				_isUpdatingSelectedItem = true;
 				_previouslySelectedItem = oldItem;
 
-				var container = FindContainer(newItem);
+				var container = this.FindContainer<TabBarItem>(newItem);
 				if (container?.IsSelectable ?? false)
 				{
 					container.IsSelected = true;
@@ -284,7 +284,7 @@ namespace Uno.Toolkit.UI
 			{
 				_isSynchronizingSelection = true;
 
-				foreach (var container in GetItemContainers())
+				foreach (var container in this.GetItemContainers<TabBarItem>())
 				{
 					if (!container.IsSelected)
 					{
@@ -320,35 +320,8 @@ namespace Uno.Toolkit.UI
 			SelectionChanged?.Invoke(this, eventArgs);
 		}
 
-		private TabBarItem? FindContainer(object? item)
-		{
-			if (item == null)
-		{
-				return null;
-			}
-
-			return item as TabBarItem ??
-				ContainerFromItem(item) as TabBarItem;
-		}
-
 		private bool IsReady => _isLoaded && HasItems;
 
-		private bool HasItems => GetItems().Any();
-
-		/// <summary>
-		/// Get the item containers.
-		/// </summary>
-		/// <remarks>An empty enumerable will returned if the <see cref="ItemsControl.ItemsPanelRoot"/> and the containers have not been materialized.</remarks>
-		private IEnumerable<TabBarItem> GetItemContainers() =>
-			ItemsPanelRoot?.Children.OfType<TabBarItem>() ??
-			Enumerable.Empty<TabBarItem>();
-		private IEnumerable GetItems() =>
-			ItemsSource as IEnumerable ??
-			(ItemsSource as CollectionViewSource)?.View ??
-			Items ??
-			Enumerable.Empty<object>();
-
-		private TabBarItem? FindContainerByIndex(int index) => 
-			GetItems()?.OfType<TabBarItem>().Skip(index).FirstOrDefault();
+		private bool HasItems => this.GetItems().Any();
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.Properties.cs
@@ -14,7 +14,7 @@ namespace Uno.Toolkit.UI
 			nameof(Owner),
 			typeof(TabBar),
 			typeof(TabBarSelectionIndicatorPresenter),
-			new PropertyMetadata(default(TabBar), OnPropertyChanged));
+			new PropertyMetadata(null, OnPropertyChanged));
 
 		public TabBar Owner
 		{
@@ -44,7 +44,7 @@ namespace Uno.Toolkit.UI
 			nameof(TemplateSettings),
 			typeof(TabBarSelectionIndicatorPresenterTemplateSettings),
 			typeof(TabBarSelectionIndicatorPresenter),
-			new PropertyMetadata(default(TabBarSelectionIndicatorPresenterTemplateSettings)));
+			new PropertyMetadata(null));
 
 		public TabBarSelectionIndicatorPresenterTemplateSettings TemplateSettings
 		{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.cs
@@ -146,7 +146,7 @@ namespace Uno.Toolkit.UI
 			var property = args.Property;
 			if (property == OwnerProperty)
 			{
-				SetupOwner();
+				SetupOwner(forceRewire: true);
 				UpdateIndicator();
 			}
 		}

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Uno.Disposables;
 using Windows.Foundation;
 using System.Reflection;
+using Uno.Extensions;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -53,12 +54,11 @@ namespace Uno.Toolkit.UI
 		private Storyboard? _verticalStoryboard;
 		private Storyboard? _horizontalStoryboard;
 		private bool _isTemplateApplied;
+		private bool _isLoaded;
 
+		private readonly SerialDisposable _indicatorSubscriptions = new SerialDisposable();
+		private readonly SerialDisposable _ownerSubscriptions = new SerialDisposable();
 		private readonly SerialDisposable _tabBarItemSizeChangedRevoker = new SerialDisposable();
-		private readonly SerialDisposable _indicatorSizeChangedRevoker = new SerialDisposable();
-		private readonly SerialDisposable _offsetChangedRevoker = new SerialDisposable();
-		private readonly SerialDisposable _tabBarOrientationChangedRevoker = new SerialDisposable();
-		private readonly SerialDisposable _tabBarEventsRevoker = new SerialDisposable();
 
 		/// <summary>
 		/// Returns the view within the presenter being used as the selection indicator
@@ -78,13 +78,24 @@ namespace Uno.Toolkit.UI
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
-			UpdateOwner();
+			_isLoaded = true;
+
+			if (IsReady)
+			{
+				SetupOwner();
+				SetupIndicator();
+
+				UpdateIndicator();
+			}
 		}
 
 		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
+			_isLoaded = false;
+
 			ResetOwner();
 			ResetIndicator();
+			_tabBarItemSizeChangedRevoker.Disposable = null;
 		}
 
 		protected override void OnApplyTemplate()
@@ -98,18 +109,31 @@ namespace Uno.Toolkit.UI
 			_verticalStoryboard = GetTemplateChild(TemplateParts.VerticalStoryboardName) as Storyboard;
 			_horizontalStoryboard = GetTemplateChild(TemplateParts.HorizontalStoryboardName) as Storyboard;
 
-			if (_contentPresenter is { } selectionIndicator)
-			{
-				selectionIndicator.SizeChanged += OnSizeChanged;
-				_indicatorSizeChangedRevoker.Disposable = Disposable.Create(() => selectionIndicator.SizeChanged -= OnSizeChanged);
-			}
-
 			SizeChanged += OnSizeChanged;
 
 			_isTemplateApplied = true;
 
-			UpdateOwner();
-			UpdateIndicator();
+			if (IsReady && _ownerSubscriptions.Disposable == null)
+			{
+				SetupOwner();
+				SetupIndicator();
+
+				UpdateIndicator();
+			}
+		}
+
+		private void SetupIndicator()
+		{
+			if (!IsReady || _indicatorSubscriptions.Disposable != null)
+			{
+				return;
+			}
+
+			if (_contentPresenter is { } selectionIndicator)
+			{
+				selectionIndicator.SizeChanged += OnSizeChanged;
+				_indicatorSubscriptions.Disposable = Disposable.Create(() => selectionIndicator.SizeChanged -= OnSizeChanged);
+			}
 		}
 
 		private void OnSizeChanged(object sender, SizeChangedEventArgs args)
@@ -122,36 +146,39 @@ namespace Uno.Toolkit.UI
 			var property = args.Property;
 			if (property == OwnerProperty)
 			{
-				UpdateOwner();
+				SetupOwner();
+				UpdateIndicator();
 			}
 		}
 
 		private void ResetIndicator()
 		{
 			StopStoryboards();
-			_indicatorSizeChangedRevoker.Disposable = null;
-			_contentPresenter = null;
+			_indicatorSubscriptions.Disposable = null;
 		}
 
 		private void ResetOwner()
 		{
-			_tabBarEventsRevoker.Disposable = null;
-			_offsetChangedRevoker.Disposable = null;
-			_tabBarItemSizeChangedRevoker.Disposable = null;
+			_ownerSubscriptions.Disposable = null;
 		}
 
-		private void UpdateOwner()
+		private void SetupOwner(bool forceRewire = false)
 		{
-			ResetOwner();
+			if (!IsReady || (_ownerSubscriptions.Disposable != null && !forceRewire))
+			{
+				return;
+			}
+
+			var disposables = new CompositeDisposable();
+			_ownerSubscriptions.Disposable = disposables;
 
 			if (Owner is TabBar tabBar)
 			{
-				_tabBarOrientationChangedRevoker.Disposable = tabBar.RegisterDisposablePropertyChangedCallback(TabBar.OrientationProperty, OnTabBarOrientationChanged);
+				tabBar.RegisterDisposablePropertyChangedCallback(TabBar.OrientationProperty, OnTabBarOrientationChanged)
+					.DisposeWith(disposables);
 
-				_offsetChangedRevoker.Disposable = tabBar.RegisterDisposablePropertyChangedCallback(SelectorExtensions.SelectionOffsetProperty, OnSelectionOffsetChanged);
-
-				var disposables = new CompositeDisposable();
-				_tabBarEventsRevoker.Disposable = disposables;
+				tabBar.RegisterDisposablePropertyChangedCallback(SelectorExtensions.SelectionOffsetProperty, OnSelectionOffsetChanged)
+					.DisposeWith(disposables);
 
 				tabBar.SelectionChanged += OnTabBarSelectionChanged;
 				Disposable
@@ -167,8 +194,6 @@ namespace Uno.Toolkit.UI
 				Disposable
 					.Create(() => tabBar.Items.VectorChanged -= OnTabBarItemsChanged)
 					.DisposeWith(disposables);
-
-				UpdateIndicator();
 			}
 		}
 
@@ -184,11 +209,12 @@ namespace Uno.Toolkit.UI
 
 		private void UpdateIndicator()
 		{
-			if (!_isTemplateApplied)
+			if (!IsReady)
 			{
 				return;
 			}
 
+			SynchronizeSelection();
 			UpdateSelectionIndicatorMaxSize();
 			UpdateSelectionIndicatorPosition();
 		}
@@ -198,13 +224,14 @@ namespace Uno.Toolkit.UI
 			if (Owner is { } tabBar
 				&& GetSelectionIndicator() is { } indicator)
 			{
-				var numItems = tabBar.Items.Count;
-				if (numItems < 1)
+				var tabBarItems = tabBar.GetItemContainers<TabBarItem>().Where(tbi => tbi.Visibility == Visibility.Visible);
+				if (tabBarItems.None())
 				{
 					return;
 				}
 
 				var maxSize = new Size();
+				var numItems = tabBarItems.Count();
 
 				if (tabBar.Orientation == Orientation.Vertical)
 				{
@@ -250,21 +277,24 @@ namespace Uno.Toolkit.UI
 
 		private void OnTabBarSelectionChanged(TabBar sender, TabBarSelectionChangedEventArgs args)
 		{
+			UpdateIndicator();
+		}
+
+		private void SynchronizeSelection()
+		{
 			_tabBarItemSizeChangedRevoker.Disposable = null;
 
-			if (args.NewItem is TabBarItem tabBarItem)
+			if (Owner is not { } tabBar ||
+				tabBar.ContainerFromIndex(tabBar.SelectedIndex) is not TabBarItem newSelectedItem)
 			{
-				tabBarItem.SizeChanged += OnSelectedTabBarItemSizeChanged;
-				_tabBarItemSizeChangedRevoker.Disposable = Disposable.Create(() => tabBarItem.SizeChanged -= OnSelectedTabBarItemSizeChanged);
-
-				//If a selection is being made for the first time, start showing the indicator
-				if (!(_isSelectorPresent && IndicatorTransitionMode == IndicatorTransitionMode.Slide)
-					|| args.OldItem == null)
-				{
-					Opacity = (Content ?? ContentTemplate) is { } ? 1f : 0f;
-					UpdateSelectionIndicatorPosition(tabBarItem);
-				}
+				Opacity = 0f;
+				return;
 			}
+		
+			newSelectedItem.SizeChanged += OnSelectedTabBarItemSizeChanged;
+			_tabBarItemSizeChangedRevoker.Disposable = Disposable.Create(() => newSelectedItem.SizeChanged -= OnSelectedTabBarItemSizeChanged);
+
+			Opacity = (Content ?? ContentTemplate) is { } ? 1f : 0f;
 		}
 
 		private Storyboard? GetStoryboardForCurrentOrientation()
@@ -312,5 +342,7 @@ namespace Uno.Toolkit.UI
 				storyboard.SkipToFill();
 			}
 		}
+
+		private bool IsReady => _isLoaded && _isTemplateApplied;
 	}
 }

--- a/src/Uno.Toolkit.UI/Extensions/ItemsControlExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/ItemsControlExtensions.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+#else
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	internal static class ItemsControlExtensions
+	{
+		/// <summary>
+		/// Get the items.
+		/// </summary>
+		public static IEnumerable GetItems(this ItemsControl itemsControl) =>
+			itemsControl.ItemsSource as IEnumerable ??
+			(itemsControl.ItemsSource as CollectionViewSource)?.View ??
+			itemsControl.Items ??
+			Enumerable.Empty<object>();
+
+		/// <summary>
+		/// Gets the container for the given item.
+		/// </summary>
+		/// <remarks>The item itself maybe its own container.</remarks>
+		public static T? FindContainer<T>(this ItemsControl itemsControl, object? item)
+			where T : class?
+		{
+			if (item == null) return null;
+
+			// For some obscure reason, ContainerFromItem returns null when item is an enum.
+			// Note however that it works fine for other value types such as int.
+			// Because of this, we retrieve the container using the index instead.
+			if (item is Enum)
+			{
+				var index = itemsControl.GetItems().OfType<object>().ToList().IndexOf(item);
+				if (index != -1)
+				{
+					return itemsControl.ContainerFromIndex(index) as T;
+				}
+			}
+
+			return
+				item as T ??
+				itemsControl.ContainerFromItem(item) as T;
+		}
+
+		/// <summary>
+		/// Get the item containers.
+		/// </summary>
+		/// <remarks>An empty enumerable will returned if the <see cref="ItemsControl.ItemsPanelRoot"/> and the containers have not been materialized.</remarks>
+		public static IEnumerable<T> GetItemContainers<T>(this ItemsControl itemsControl) =>
+			itemsControl.ItemsPanelRoot?.Children.OfType<T>() ??
+			Enumerable.Empty<T>();
+
+		/// <summary>
+		/// Gets the container for the given index.
+		/// </summary>
+		public static T? FindContainerByIndex<T>(this ItemsControl itemsControl, int index) where T : class? => 
+			itemsControl.GetItems()?.OfType<T>().Skip(index).FirstOrDefault();
+	}
+}

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
@@ -45,10 +45,7 @@
 
 	<!--#region TabBar Styles-->
 
-	<!--WORKAROUND: Set the ControlTemplate directly in each TabBar Style to ensure 
-	that the ItemContainerStyle Setter appears before the Template Setter.
-	Issue: https://github.com/unoplatform/uno/issues/10786 -->
-	
+
 
 	<Style x:Key="MaterialVerticalTabBarStyle"
 		   BasedOn="{StaticResource DefaultTabBarStyle}"
@@ -63,9 +60,6 @@
 				Value="VisibleBounds" />
 		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource MaterialVerticalTabBarItemStyle}" />
-		<!--WORKAROUND: Set the ControlTemplate directly in each TabBar Style to ensure 
-		that the ItemContainerStyle Setter appears before the Template Setter.
-		Issue: https://github.com/unoplatform/uno/issues/10786 -->
 	</Style>
 
 	<Style x:Key="MaterialBottomTabBarStyle"
@@ -81,9 +75,6 @@
 				Value="Bottom" />
 		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource MaterialBottomTabBarItemStyle}" />
-		<!--WORKAROUND: Set the ControlTemplate directly in each TabBar Style to ensure 
-		that the ItemContainerStyle Setter appears before the Template Setter.
-		Issue: https://github.com/unoplatform/uno/issues/10786 -->
 	</Style>
 
 	<Style x:Key="MaterialTopTabBarStyle"
@@ -100,16 +91,15 @@
 		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource MaterialTopTabBarItemStyle}" />
 		<Setter Property="SelectionIndicatorPresenterStyle"
-				Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}"/>
-		<!--WORKAROUND: Set the ControlTemplate directly in each TabBar Style to ensure 
-		that the ItemContainerStyle Setter appears before the Template Setter.
-		Issue: https://github.com/unoplatform/uno/issues/10786 -->
-		<Setter Property="SelectionIndicatorContent">
+				Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}" />
+		<Setter Property="SelectionIndicatorContentTemplate">
 			<Setter.Value>
-				<Border Height="2"
-						Margin="0,0,0,1"
-						VerticalAlignment="Bottom"
-						Background="{ThemeResource PrimaryBrush}" />
+				<DataTemplate>
+					<Border Height="2"
+							Margin="0,0,0,1"
+							VerticalAlignment="Bottom"
+							Background="{ThemeResource PrimaryBrush}" />
+				</DataTemplate>
 			</Setter.Value>
 		</Setter>
 	</Style>
@@ -126,18 +116,17 @@
 		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource MaterialColoredTopTabBarItemStyle}" />
 		<Setter Property="SelectionIndicatorPresenterStyle"
-				Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}"/>
-		<Setter Property="SelectionIndicatorContent">
+				Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}" />
+		<Setter Property="SelectionIndicatorContentTemplate">
 			<Setter.Value>
-				<Border Height="2"
-						Margin="0,0,0,1"
-						VerticalAlignment="Bottom"
-						Background="{ThemeResource OnPrimaryBrush}" />
+				<DataTemplate>
+					<Border Height="2"
+							Margin="0,0,0,1"
+							VerticalAlignment="Bottom"
+							Background="{ThemeResource OnPrimaryBrush}" />
+				</DataTemplate>
 			</Setter.Value>
 		</Setter>
-		<!--WORKAROUND: Set the ControlTemplate directly in each TabBar Style to ensure 
-		that the ItemContainerStyle Setter appears before the Template Setter.
-		Issue: https://github.com/unoplatform/uno/issues/10786 -->
 	</Style>
 	<!--#endregion-->
 
@@ -525,41 +514,41 @@
 								   Feedback="{ThemeResource PrimaryBrush}"
 								   FeedbackOpacity="{StaticResource PressedOpacity}">
 							<um:Ripple.Content>
-								<Grid>
-									<Rectangle x:Name="PointerRectangle"
-											   Fill="Transparent"
-											   Visibility="Collapsed" />
+							<Grid>
+								<Rectangle x:Name="PointerRectangle"
+										   Fill="Transparent"
+										   Visibility="Collapsed" />
 
-									<Grid x:Name="ContentGrid"
-										  ColumnSpacing="8">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition x:Name="IconRow"
-															  Width="*" />
-											<ColumnDefinition x:Name="ContentRow"
-															  Width="Auto" />
-										</Grid.ColumnDefinitions>
-										<Viewbox x:Name="IconBox"
-												 Width="{StaticResource MaterialTopTabBarItemIconHeight}"
-												 Height="{StaticResource MaterialTopTabBarItemIconHeight}">
-											<ContentPresenter x:Name="Icon"
-															  Content="{TemplateBinding Icon}"
-															  Foreground="{TemplateBinding Foreground}" />
-										</Viewbox>
-										<ContentPresenter x:Name="ContentPresenter"
-														  Grid.Column="1"
-														  Margin="{StaticResource MaterialTopTabBarItemContentMargin}"
-														  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-														  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-														  AutomationProperties.AccessibilityView="Raw"
-														  Content="{TemplateBinding Content}"
-														  ContentTemplate="{TemplateBinding ContentTemplate}"
-														  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-														  ContentTransitions="{TemplateBinding ContentTransitions}"
-														  FontSize="{TemplateBinding FontSize}"
-														  Foreground="{TemplateBinding Foreground}"
-														  TextWrapping="NoWrap" />
-									</Grid>
+								<Grid x:Name="ContentGrid"
+									  ColumnSpacing="8">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition x:Name="IconRow"
+														  Width="*" />
+										<ColumnDefinition x:Name="ContentRow"
+														  Width="Auto" />
+									</Grid.ColumnDefinitions>
+									<Viewbox x:Name="IconBox"
+											 Width="{StaticResource MaterialTopTabBarItemIconHeight}"
+											 Height="{StaticResource MaterialTopTabBarItemIconHeight}">
+										<ContentPresenter x:Name="Icon"
+														  Content="{TemplateBinding Icon}"
+														  Foreground="{TemplateBinding Foreground}" />
+									</Viewbox>
+									<ContentPresenter x:Name="ContentPresenter"
+													  Grid.Column="1"
+													  Margin="{StaticResource MaterialTopTabBarItemContentMargin}"
+													  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+													  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+													  AutomationProperties.AccessibilityView="Raw"
+													  Content="{TemplateBinding Content}"
+													  ContentTemplate="{TemplateBinding ContentTemplate}"
+													  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+													  ContentTransitions="{TemplateBinding ContentTransitions}"
+													  FontSize="{TemplateBinding FontSize}"
+													  Foreground="{TemplateBinding Foreground}"
+													  TextWrapping="NoWrap" />
 								</Grid>
+							</Grid>
 							</um:Ripple.Content>
 						</um:Ripple>
 					</Grid>
@@ -909,19 +898,19 @@
 								<VisualState x:Name="Horizontal">
 									<Storyboard x:Name="IndicatorTransitionHorizontalStoryboard">
 										<DoubleAnimation Storyboard.TargetName="IndicatorTransform"
-													 Storyboard.TargetProperty="TranslateX"
-													 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.X}"
-													 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.X}"
-													 Duration="00:00:00.200" />
+														 Storyboard.TargetProperty="TranslateX"
+														 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.X}"
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.X}"
+														 Duration="00:00:00.200" />
 									</Storyboard>
 								</VisualState>
 								<VisualState x:Name="Vertical">
 									<Storyboard x:Name="IndicatorTransitionVerticalStoryboard">
 										<DoubleAnimation Storyboard.TargetName="IndicatorTransform"
-													 Storyboard.TargetProperty="TranslateY"
-													 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.Y}"
-													 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.Y}"
-													 Duration="00:00:00.200" />
+														 Storyboard.TargetProperty="TranslateY"
+														 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.Y}"
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.Y}"
+														 Duration="00:00:00.200" />
 									</Storyboard>
 								</VisualState>
 							</VisualStateGroup>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.toolkit.ui/issues/495

TabBarSelectionIndicatorPresenter needs to change MaxSize of the indicator when items in the list are Visibility.Collapsed

## PR Type

What kind of change does this PR introduce?
- Bugfix