### PR TITLE
fix(AutoLayout): remove issue where padding did not behave expectedly

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -89,9 +90,6 @@ internal class AutoLayoutTest
 	[DataRow(false, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, 10, 12, 110, 78, 138)]
 	[DataRow(false, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, -20, 12, 110, 168, 248)]
 	[DataRow(false, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 108, 10, 0, 0 }, -20, 12, 110, 108, 138)]
-#if !__ANDROID__ && !__IOS__
-	[Ignore("Currently fails on wasm")]
-#endif
 	public async Task When_AbsolutePosition_WithPadding(bool isStretch, Orientation orientation, VerticalAlignment vAlign, HorizontalAlignment hAlign, int[] padding, int[] margin, int spacing, double expectedY, double expectedX, double rec1expected, double rec2expected)
 	{
 		var SUT = new AutoLayout()
@@ -160,7 +158,7 @@ internal class AutoLayoutTest
 
 		if (orientation is Orientation.Vertical)
 		{
-			Assert.AreEqual(border1Transform!.Matrix.OffsetY!, rec1expected);
+			Assert.AreEqual(border1Transform!.Matrix.OffsetY!, rec1expected);;
 			Assert.AreEqual(border2Transform!.Matrix.OffsetY!, rec2expected);
 		}
 		else
@@ -237,6 +235,69 @@ internal class AutoLayoutTest
 			Assert.AreEqual(rec1expected, border1Transform!.Matrix.OffsetX!);
 			Assert.AreEqual(rec2expected, border2Transform!.Matrix.OffsetX!);
 		}
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task When_Space_between_With_AbsolutePosition()
+	{
+		var SUT = new AutoLayout()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)),
+			Padding = new Thickness(10),
+			Justify = AutoLayoutJustify.SpaceBetween,
+			Width = 300,
+			Height = 400,
+		};
+
+		var border1 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 200,
+			Height = 50,
+		};
+
+		var border2 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 200,
+			Height = 50,
+		};
+
+		var border3 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 200,
+			Height = 50,
+		};
+
+		var border4 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 200,
+			Height = 50,
+			Margin = new Thickness(10, 280,0 ,0),
+			VerticalAlignment = VerticalAlignment.Top,
+			HorizontalAlignment = HorizontalAlignment.Left,
+		};
+
+		AutoLayout.SetIsIndependentLayout(border4, true);
+
+		SUT.Children.Add(border1);
+		SUT.Children.Add(border2);
+		SUT.Children.Add(border3);
+		SUT.Children.Add(border4);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var border1Transform = (MatrixTransform)border1.TransformToVisual(SUT);
+		var border3Transform = (MatrixTransform)border3.TransformToVisual(SUT);
+		var border4Transform = (MatrixTransform)border4.TransformToVisual(SUT);
+
+
+		Assert.AreEqual(10, border1Transform!.Matrix.OffsetY!);
+		Assert.AreEqual(340, border3Transform!.Matrix.OffsetY!);
+		Assert.AreEqual(280, border4Transform!.Matrix.OffsetY!);
 	}
 
 }

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.cs
@@ -322,7 +322,10 @@ namespace Uno.Toolkit.UI
 				{
 					_grid.Padding = new Thickness(0);
 
-					_grid.RowDefinitions.Insert(gridIndexOffSet, new RowDefinition() { Height = new GridLength(spacing < 0 ? padding.Top - spacing : padding.Top) });
+					var topPaddingSize = spacing < 0 ? padding.Top - spacing : padding.Top;
+					var topPadding = new GridLength(topPaddingSize);
+
+					_grid.RowDefinitions.Insert(gridIndexOffSet, new RowDefinition() { Height = topPadding, MaxHeight = topPaddingSize});
 					gridIndexOffSet += 1;
 
 					_grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(padding.Left )});
@@ -434,7 +437,7 @@ namespace Uno.Toolkit.UI
 					}
 				}
 
-				if (hasIndependentLayout && atLeastOneChildFillAvailableSpaceInPrimaryAxis is not true && PrimaryAxisAlignment != AutoLayoutAlignment.End)
+				if (hasIndependentLayout && atLeastOneChildFillAvailableSpaceInPrimaryAxis is not true && PrimaryAxisAlignment != AutoLayoutAlignment.End && !hasSpaceBetween)
 				{
 					//We need to make sure that the independent layout can span all across his parent
 					_grid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) });
@@ -444,7 +447,8 @@ namespace Uno.Toolkit.UI
 
 				if ( hasSpaceBetween || (hasPadding && paddingCondition))
 				{
-					_grid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(spacing < 0 ? padding.Bottom - spacing : padding.Bottom) });
+					var bottomPaddingSize = spacing < 0 ? padding.Bottom - spacing : padding.Bottom;
+					_grid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(bottomPaddingSize), MaxHeight = bottomPaddingSize });
 				}
 			}
 			else // Horizontal
@@ -469,9 +473,10 @@ namespace Uno.Toolkit.UI
 				{
 					_grid.Padding = new Thickness(0);
 
-					var firstColumnWidth = new GridLength(spacing < 0 ? padding.Left - spacing : padding.Left);
+					var firstColumnWidthSize = spacing < 0 ? padding.Left - spacing : padding.Left;
+					var firstColumnWidth = new GridLength(firstColumnWidthSize);
 
-					_grid.ColumnDefinitions.Insert(gridIndexOffSet, new ColumnDefinition() { Width = firstColumnWidth });
+					_grid.ColumnDefinitions.Insert(gridIndexOffSet, new ColumnDefinition() { Width = firstColumnWidth, MaxWidth = firstColumnWidthSize });
 					gridIndexOffSet += 1;
 
 					_grid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(padding.Top) });
@@ -593,9 +598,10 @@ namespace Uno.Toolkit.UI
 
 				if (hasSpaceBetween || (hasPadding && paddingCondition))
 				{
-					var lastColumnWidth = new GridLength(spacing < 0 ? padding.Right - spacing : padding.Right);
+					var rightPaddingsize = spacing < 0 ? padding.Right - spacing : padding.Right;
+					var lastColumnWidth = new GridLength(rightPaddingsize);
 
-					_grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = lastColumnWidth });
+					_grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = lastColumnWidth, MaxWidth = rightPaddingsize });
 				}
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/Uno.Figma/issues/1080

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?

- When autolayout is in space between mode and a children is independant and have a padding, the padding don't behave as expected. 
 
This is due to a grid bug when height is discard. the work around is to also set the MaxHeight

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

- The padding behave as expected is this configuration


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
