### PR TITLE
fix: Handle case when SelectedItem is not of type TabBarItem

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
@@ -146,7 +146,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		{
 			const int NumItems = 3;
 			const double ItemSize = 100d;
-			var source = Enumerable.Range(0, NumItems).Select(x => new TabBarItem { Content = x }).ToArray();
+			var source = Enumerable.Range(0, NumItems).ToArray();
 			var indicator = new Border() { Background = new SolidColorBrush(Colors.Red) };
 			var SUT = new TabBar
 			{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
@@ -239,10 +239,10 @@ namespace Uno.Toolkit.UI
 			TabBarItem? oldItem = null;
 			if (args?.OldValue is int oldIndex)
 			{
-				oldItem = this.FindContainerByIndex<TabBarItem>(oldIndex);
+				oldItem = this.ContainerFromIndex(oldIndex) as TabBarItem;
 			}
 
-			var newItem = this.FindContainerByIndex<TabBarItem>(SelectedIndex);
+			var newItem = this.ContainerFromIndex(SelectedIndex) as TabBarItem;
 
 			if (TryUpdateTabBarItemSelectedState(oldItem, newItem))
 			{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarSelectionIndicatorPresenter.cs
@@ -324,7 +324,15 @@ namespace Uno.Toolkit.UI
 
 		private void UpdateSelectionIndicatorPosition(Point? destination = null)
 		{
-			destination ??= GetRelativePosition(Owner?.SelectedItem as TabBarItem);
+			if (Owner is not { } tabBar)
+			{
+				return;
+			}
+
+			if (destination == null && tabBar.SelectedIndex != -1)
+			{
+				destination = GetRelativePosition(tabBar.ContainerFromIndex(tabBar.SelectedIndex) as TabBarItem);
+			}
 
 			if (destination == null ||
 				GetSelectionIndicator() is not { } indicator ||


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.toolkit.ui/issues/515
