### PR TITLE
fix: add tint support back to tabbar, refactor tabbar styles

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
@@ -239,10 +239,10 @@ namespace Uno.Toolkit.UI
 			TabBarItem? oldItem = null;
 			if (args?.OldValue is int oldIndex)
 			{
-				oldItem = this.ContainerFromIndex(oldIndex) as TabBarItem;
+				oldItem = this.ContainerFromIndexSafe<TabBarItem>(oldIndex);
 			}
 
-			var newItem = this.ContainerFromIndex(SelectedIndex) as TabBarItem;
+			var newItem = this.ContainerFromIndexSafe<TabBarItem>(SelectedIndex);
 
 			if (TryUpdateTabBarItemSelectedState(oldItem, newItem))
 			{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.xaml
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.xaml
@@ -5,70 +5,42 @@
 	<ResourceDictionary.ThemeDictionaries>
 		<ResourceDictionary x:Key="Dark">
 
-			<StaticResource x:Key="TabBarItemBackground"
-							ResourceKey="SystemControlTransparentBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundPointerOver"
-							ResourceKey="SystemControlHighlightListLowBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundPressed"
-							ResourceKey="SystemControlHighlightListMediumBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundSelected"
-							ResourceKey="SystemControlHighlightListAccentLowBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundSelectedPointerOver"
-							ResourceKey="SystemControlHighlightListAccentMediumBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundSelectedPressed"
-							ResourceKey="SystemControlHighlightListAccentHighBrush" />
+			<StaticResource x:Key="TabBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentMediumBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentHighBrush" />
 
-			<StaticResource x:Key="TabBarItemForeground"
-							ResourceKey="SystemControlForegroundBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundPointerOver"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundPressed"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundDisabled"
-							ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-			<StaticResource x:Key="TabBarItemForegroundSelected"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundSelectedPointerOver"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundSelectedPressed"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+			<StaticResource x:Key="TabBarItemForegroundSelected" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundSelectedPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundSelectedPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
 
-			<StaticResource x:Key="TabBarItemBorderBrush"
-							ResourceKey="SystemControlTransparentBrush" />
+			<StaticResource x:Key="TabBarItemBorderBrush" ResourceKey="SystemControlTransparentBrush" />
 		</ResourceDictionary>
 
 		<ResourceDictionary x:Key="Light">
 
-			<StaticResource x:Key="TabBarItemBackground"
-							ResourceKey="SystemControlTransparentBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundPointerOver"
-							ResourceKey="SystemControlHighlightListLowBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundPressed"
-							ResourceKey="SystemControlHighlightListMediumBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundSelected"
-							ResourceKey="SystemControlHighlightListAccentLowBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundSelectedPointerOver"
-							ResourceKey="SystemControlHighlightListAccentMediumBrush" />
-			<StaticResource x:Key="TabBarItemBackgroundSelectedPressed"
-							ResourceKey="SystemControlHighlightListAccentHighBrush" />
+			<StaticResource x:Key="TabBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentMediumBrush" />
+			<StaticResource x:Key="TabBarItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentHighBrush" />
 
-			<StaticResource x:Key="TabBarItemForeground"
-							ResourceKey="SystemControlForegroundBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundPointerOver"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundPressed"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundDisabled"
-							ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-			<StaticResource x:Key="TabBarItemForegroundSelected"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundSelectedPointerOver"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-			<StaticResource x:Key="TabBarItemForegroundSelectedPressed"
-							ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+			<StaticResource x:Key="TabBarItemForegroundSelected" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundSelectedPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
+			<StaticResource x:Key="TabBarItemForegroundSelectedPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
 
-			<StaticResource x:Key="TabBarItemBorderBrush"
-							ResourceKey="SystemControlTransparentBrush" />
+			<StaticResource x:Key="TabBarItemBorderBrush" ResourceKey="SystemControlTransparentBrush" />
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
 
@@ -82,8 +54,7 @@
 
 	<Style x:Key="BaseTabBarStyle"
 		   TargetType="utu:TabBar">
-		<Setter Property="IsTabStop"
-				Value="False" />
+		<Setter Property="IsTabStop" Value="False" />
 		<Setter Property="ItemsPanel">
 			<Setter.Value>
 				<ItemsPanelTemplate>
@@ -91,10 +62,8 @@
 				</ItemsPanelTemplate>
 			</Setter.Value>
 		</Setter>
-		<Setter Property="ItemContainerStyle"
-				Value="{StaticResource DefaultTabBarItemStyle}" />
-		<Setter Property="SelectionIndicatorPresenterStyle"
-				Value="{StaticResource DefaultTabBarSelectionIndicatorPresenterStyle}" />
+		<Setter Property="ItemContainerStyle" Value="{StaticResource DefaultTabBarItemStyle}" />
+		<Setter Property="SelectionIndicatorPresenterStyle" Value="{StaticResource DefaultTabBarSelectionIndicatorPresenterStyle}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBar">
@@ -106,18 +75,14 @@
 							<VisualStateGroup x:Name="OrientationStates">
 								<VisualState x:Name="Horizontal">
 									<VisualState.Setters>
-										<Setter Target="SelectionIndicatorPresenter.VerticalContentAlignment"
-												Value="Stretch" />
-										<Setter Target="SelectionIndicatorPresenter.HorizontalContentAlignment"
-												Value="Left" />
+										<Setter Target="SelectionIndicatorPresenter.VerticalContentAlignment" Value="Stretch" />
+										<Setter Target="SelectionIndicatorPresenter.HorizontalContentAlignment" Value="Left" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Vertical">
 									<VisualState.Setters>
-										<Setter Target="SelectionIndicatorPresenter.VerticalContentAlignment"
-												Value="Top" />
-										<Setter Target="SelectionIndicatorPresenter.HorizontalContentAlignment"
-												Value="Stretch" />
+										<Setter Target="SelectionIndicatorPresenter.VerticalContentAlignment" Value="Top" />
+										<Setter Target="SelectionIndicatorPresenter.HorizontalContentAlignment" Value="Stretch" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -174,22 +139,14 @@
 
 	<Style x:Key="DefaultTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
-		<Setter Property="Foreground"
-				Value="{ThemeResource TabBarItemForeground}" />
-		<Setter Property="Background"
-				Value="{ThemeResource TabBarItemBackground}" />
-		<Setter Property="BorderBrush"
-				Value="{ThemeResource TabBarItemBorderBrush}" />
-		<Setter Property="FontFamily"
-				Value="{ThemeResource ContentControlThemeFontFamily}" />
-		<Setter Property="FontWeight"
-				Value="Normal" />
-		<Setter Property="FontSize"
-				Value="{ThemeResource ControlContentThemeFontSize}" />
-		<Setter Property="UseSystemFocusVisuals"
-				Value="True" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Center" />
+		<Setter Property="Foreground" Value="{ThemeResource TabBarItemForeground}" />
+		<Setter Property="Background" Value="{ThemeResource TabBarItemBackground}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource TabBarItemBorderBrush}" />
+		<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+		<Setter Property="FontWeight" Value="Normal" />
+		<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+		<Setter Property="UseSystemFocusVisuals" Value="True" />
+		<Setter Property="HorizontalContentAlignment" Value="Center" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBarItem">
@@ -204,62 +161,42 @@
 								<VisualState x:Name="Normal" />
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource TabBarItemBackgroundPointerOver}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource TabBarItemBackgroundPointerOver}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource TabBarItemForegroundPointerOver}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource TabBarItemForegroundPointerOver}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource TabBarItemBackgroundPointerOver}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource TabBarItemBackgroundPointerOver}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundPointerOver}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundPointerOver}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource TabBarItemBackgroundPressed}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource TabBarItemBackgroundPressed}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource TabBarItemForegroundPressed}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource TabBarItemForegroundPressed}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource TabBarItemBackgroundPressed}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource TabBarItemBackgroundPressed}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundPressed}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundPressed}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Selected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource TabBarItemBackgroundSelected}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource TabBarItemBackgroundSelected}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource TabBarItemForegroundSelected}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource TabBarItemForegroundSelected}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource TabBarItemBackgroundSelected}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource TabBarItemBackgroundSelected}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundSelected}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundSelected}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="PointerOverSelected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource TabBarItemBackgroundSelectedPointerOver}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource TabBarItemBackgroundSelectedPointerOver}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource TabBarItemForegroundSelectedPointerOver}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource TabBarItemForegroundSelectedPointerOver}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource TabBarItemBackgroundSelectedPointerOver}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource TabBarItemBackgroundSelectedPointerOver}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundSelectedPointerOver}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundSelectedPointerOver}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="PressedSelected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource TabBarItemBackgroundSelectedPressed}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource TabBarItemBackgroundSelectedPressed}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource TabBarItemForegroundSelectedPressed}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource TabBarItemForegroundSelectedPressed}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource TabBarItemBackgroundSelectedPressed}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource TabBarItemBackgroundSelectedPressed}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundSelectedPressed}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundSelectedPressed}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -267,10 +204,8 @@
 								<VisualState x:Name="Enabled" />
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource TabBarItemForegroundDisabled}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource TabBarItemForegroundDisabled}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource TabBarItemForegroundDisabled}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabBarItemForegroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -278,22 +213,16 @@
 								<VisualState x:Name="IconOnTop" />
 								<VisualState x:Name="IconOnly">
 									<VisualState.Setters>
-										<Setter Target="PointerRectangle.Visibility"
-												Value="Visible" />
-										<Setter Target="ContentPresenter.Visibility"
-												Value="Collapsed" />
+										<Setter Target="PointerRectangle.Visibility" Value="Visible" />
+										<Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="ContentOnly">
 									<VisualState.Setters>
-										<Setter Target="IconBox.Visibility"
-												Value="Collapsed" />
-										<Setter Target="ContentPresenter.Margin"
-												Value="{StaticResource TabBarItemContentOnlyMargin}" />
-										<Setter Target="IconRow.Height"
-												Value="0" />
-										<Setter Target="ContentRow.Height"
-												Value="*" />
+										<Setter Target="IconBox.Visibility" Value="Collapsed" />
+										<Setter Target="ContentPresenter.Margin" Value="{StaticResource TabBarItemContentOnlyMargin}" />
+										<Setter Target="IconRow.Height" Value="0" />
+										<Setter Target="ContentRow.Height" Value="*" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -343,19 +272,19 @@
 								<VisualState x:Name="Horizontal">
 									<Storyboard x:Name="IndicatorTransitionHorizontalStoryboard">
 										<DoubleAnimation Storyboard.TargetName="IndicatorTransform"
-													 Storyboard.TargetProperty="TranslateX"
-													 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.X}"
-													 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.X}"
-													 Duration="{StaticResource TabBarIndicatorAnimationDuration}" />
+														 Storyboard.TargetProperty="TranslateX"
+														 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.X}"
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.X}"
+														 Duration="{StaticResource TabBarIndicatorAnimationDuration}" />
 									</Storyboard>
 								</VisualState>
 								<VisualState x:Name="Vertical">
 									<Storyboard x:Name="IndicatorTransitionVerticalStoryboard">
 										<DoubleAnimation Storyboard.TargetName="IndicatorTransform"
-													 Storyboard.TargetProperty="TranslateY"
-													 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.Y}"
-													 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.Y}"
-													 Duration="{StaticResource TabBarIndicatorAnimationDuration}" />
+														 Storyboard.TargetProperty="TranslateY"
+														 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.Y}"
+														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.Y}"
+														 Duration="{StaticResource TabBarIndicatorAnimationDuration}" />
 									</Storyboard>
 								</VisualState>
 							</VisualStateGroup>
@@ -379,15 +308,15 @@
 		</Setter>
 	</Style>
 
-	<!-- TabBar -->
+	<!--  TabBar  -->
 	<Style TargetType="utu:TabBar"
 		   BasedOn="{StaticResource DefaultTabBarStyle}" />
 
-	<!-- TabBarItem -->
+	<!--  TabBarItem  -->
 	<Style TargetType="utu:TabBarItem"
 		   BasedOn="{StaticResource DefaultTabBarItemStyle}" />
 
-	<!-- TabBarSelectionIndicatorPresenter -->
+	<!--  TabBarSelectionIndicatorPresenter  -->
 	<Style TargetType="utu:TabBarSelectionIndicatorPresenter"
 		   BasedOn="{StaticResource DefaultTabBarSelectionIndicatorPresenterStyle}" />
 

--- a/src/Uno.Toolkit.UI/Extensions/ItemsControlExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/ItemsControlExtensions.cs
@@ -61,7 +61,14 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Gets the container for the given index.
 		/// </summary>
-		public static T? FindContainerByIndex<T>(this ItemsControl itemsControl, int index) where T : class? => 
-			itemsControl.GetItems()?.OfType<T>().Skip(index).FirstOrDefault();
+		public static T? ContainerFromIndexSafe<T>(this ItemsControl itemsControl, int index) where T : class?
+		{
+			if (index >= 0 && index < itemsControl.Items.Count)
+			{
+				return itemsControl.ContainerFromIndex(index) as T;
+			}
+
+			return null;
+		}
 	}
 }

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
@@ -43,7 +43,7 @@
 	<Thickness x:Key="MaterialNavigationTabBarItemLargeBadgePadding">4,0</Thickness>
 	<CornerRadius x:Key="MaterialNavigationTabBarItemLargeBadgeCornerRadius">8</CornerRadius>
 
-	<!-- WORKAROUND: ControlExtensions must be explicitly referenced as an attribute to avoid a crash on WinAppSDK apps, and not just as a a setter property -->
+	<!--  WORKAROUND: ControlExtensions must be explicitly referenced as an attribute to avoid a crash on WinAppSDK apps, and not just as a a setter property  -->
 	<Style x:Key="WorkaroundTabBarStyle"
 		   TargetType="utu:TabBar">
 		<Setter Property="Template">
@@ -60,24 +60,9 @@
 	<Style x:Key="BaseMaterialTabBarStyle"
 		   BasedOn="{StaticResource DefaultTabBarStyle}"
 		   TargetType="utu:TabBar">
-
-		<Setter Property="um:ControlExtensions.TintedBackground"
-				Value="{x:Null}" />
-		<Setter Property="um:ControlExtensions.IsTintEnabled"
-				Value="True" />
-		<Setter Property="IsTabStop"
-				Value="False" />
-		<Setter Property="ItemsPanel">
-			<Setter.Value>
-				<ItemsPanelTemplate>
-					<utu:TabBarListPanel />
-				</ItemsPanelTemplate>
-			</Setter.Value>
-		</Setter>
-		<Setter Property="ItemContainerStyle"
-				Value="{StaticResource DefaultTabBarItemStyle}" />
-		<Setter Property="SelectionIndicatorPresenterStyle"
-				Value="{StaticResource DefaultTabBarSelectionIndicatorPresenterStyle}" />
+		<Setter Property="um:ControlExtensions.TintedBackground" Value="{x:Null}" />
+		<Setter Property="um:ControlExtensions.IsTintEnabled" Value="True" />
+		<Setter Property="SelectionIndicatorPresenterStyle" Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBar">
@@ -89,22 +74,14 @@
 							<VisualStateGroup x:Name="OrientationStates">
 								<VisualState x:Name="Horizontal">
 									<VisualState.Setters>
-										<Setter Target="TabBarGrid.Height"
-												Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height}" />
-										<Setter Target="SelectionIndicatorPresenter.VerticalContentAlignment"
-												Value="Stretch" />
-										<Setter Target="SelectionIndicatorPresenter.HorizontalContentAlignment"
-												Value="Left" />
+										<Setter Target="SelectionIndicatorPresenter.VerticalContentAlignment" Value="Stretch" />
+										<Setter Target="SelectionIndicatorPresenter.HorizontalContentAlignment" Value="Left" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Vertical">
 									<VisualState.Setters>
-										<Setter Target="TabBarGrid.Width"
-												Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width}" />
-										<Setter Target="SelectionIndicatorPresenter.VerticalContentAlignment"
-												Value="Top" />
-										<Setter Target="SelectionIndicatorPresenter.HorizontalContentAlignment"
-												Value="Stretch" />
+										<Setter Target="SelectionIndicatorPresenter.VerticalContentAlignment" Value="Top" />
+										<Setter Target="SelectionIndicatorPresenter.HorizontalContentAlignment" Value="Stretch" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -119,6 +96,7 @@
 															   Foreground="{TemplateBinding Foreground}"
 															   Owner="{Binding RelativeSource={RelativeSource TemplatedParent}}"
 															   AutomationProperties.AutomationId="SelectionIndicatorPresenter"
+															   Padding="{TemplateBinding Padding}"
 															   Opacity="0" />
 					</Grid>
 				</ControlTemplate>
@@ -127,60 +105,49 @@
 	</Style>
 
 	<Style x:Key="MaterialVerticalTabBarStyle"
-		   BasedOn="{StaticResource BaseVerticalTabBarStyle}"
+		   BasedOn="{StaticResource BaseMaterialTabBarStyle}"
 		   TargetType="utu:TabBar">
-		<Setter Property="um:ControlExtensions.Elevation"
-				Value="1" />
-		<Setter Property="Background"
-				Value="{ThemeResource SurfaceBrush}" />
-		<Setter Property="HorizontalAlignment"
-				Value="Center" />
-		<Setter Property="MinWidth"
-				Value="{StaticResource MaterialNavigationTabBarWidthOrHeight}" />
-		<Setter Property="utu:SafeArea.Insets"
-				Value="VisibleBounds" />
-		<Setter Property="ItemContainerStyle"
-				Value="{StaticResource MaterialVerticalTabBarItemStyle}" />
+		<Setter Property="um:ControlExtensions.Elevation" Value="1" />
+		<Setter Property="Background" Value="{ThemeResource SurfaceBrush}" />
+		<Setter Property="HorizontalAlignment" Value="Center" />
+		<Setter Property="MinWidth" Value="{StaticResource MaterialNavigationTabBarWidthOrHeight}" />
+		<Setter Property="utu:SafeArea.Insets" Value="VisibleBounds" />
+		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialVerticalTabBarItemStyle}" />
+		<Setter Property="Orientation" Value="Vertical" />
+		<Setter Property="ItemsPanel">
+			<Setter.Value>
+				<ItemsPanelTemplate>
+					<utu:TabBarListPanel Orientation="Vertical" />
+				</ItemsPanelTemplate>
+			</Setter.Value>
+		</Setter>
 	</Style>
 
 	<Style x:Key="MaterialBottomTabBarStyle"
-		   BasedOn="{StaticResource BaseHorizontalTabBarStyle}"
+		   BasedOn="{StaticResource BaseMaterialTabBarStyle}"
 		   TargetType="utu:TabBar">
-		<Setter Property="um:ControlExtensions.Elevation"
-				Value="1" />
-		<Setter Property="Background"
-				Value="{ThemeResource SurfaceBrush}" />
-		<Setter Property="VerticalAlignment"
-				Value="Bottom" />
-		<Setter Property="MinHeight"
-				Value="{StaticResource MaterialNavigationTabBarWidthOrHeight}" />
-		<Setter Property="utu:SafeArea.Insets"
-				Value="Bottom" />
-		<Setter Property="ItemContainerStyle"
-				Value="{StaticResource MaterialBottomTabBarItemStyle}" />
+		<Setter Property="um:ControlExtensions.Elevation" Value="1" />
+		<Setter Property="Background" Value="{ThemeResource SurfaceBrush}" />
+		<Setter Property="VerticalAlignment" Value="Bottom" />
+		<Setter Property="MinHeight" Value="{StaticResource MaterialNavigationTabBarWidthOrHeight}" />
+		<Setter Property="utu:SafeArea.Insets" Value="Bottom" />
+		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialBottomTabBarItemStyle}" />
 	</Style>
 
 	<Style x:Key="MaterialTopTabBarStyle"
-		   BasedOn="{StaticResource BaseHorizontalTabBarStyle}"
+		   BasedOn="{StaticResource BaseMaterialTabBarStyle}"
 		   TargetType="utu:TabBar">
-		<Setter Property="Background"
-				Value="{ThemeResource BackgroundBrush}" />
-		<Setter Property="VerticalAlignment"
-				Value="Top" />
-		<Setter Property="MinHeight"
-				Value="{StaticResource MaterialTopTabBarHeight}" />
-		<Setter Property="utu:SafeArea.Insets"
-				Value="Top" />
-		<Setter Property="ItemContainerStyle"
-				Value="{StaticResource MaterialTopTabBarItemStyle}" />
-		<Setter Property="SelectionIndicatorPresenterStyle"
-				Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}" />
+		<Setter Property="Background" Value="{ThemeResource BackgroundBrush}" />
+		<Setter Property="VerticalAlignment" Value="Top" />
+		<Setter Property="MinHeight" Value="{StaticResource MaterialTopTabBarHeight}" />
+		<Setter Property="utu:SafeArea.Insets" Value="Top" />
+		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialTopTabBarItemStyle}" />
 		<Setter Property="SelectionIndicatorContentTemplate">
 			<Setter.Value>
 				<DataTemplate>
 					<Border Height="2"
-							Margin="0,0,0,1"
 							VerticalAlignment="Bottom"
+							Margin="0,0,0,1"
 							Background="{ThemeResource PrimaryBrush}" />
 				</DataTemplate>
 			</Setter.Value>
@@ -188,26 +155,16 @@
 	</Style>
 
 	<Style x:Key="MaterialColoredTopTabBarStyle"
-		   BasedOn="{StaticResource BaseHorizontalTabBarStyle}"
+		   BasedOn="{StaticResource MaterialTopTabBarStyle}"
 		   TargetType="utu:TabBar">
-		<Setter Property="Background"
-				Value="{ThemeResource PrimaryBrush}" />
-		<Setter Property="VerticalAlignment"
-				Value="Top" />
-		<Setter Property="MinHeight"
-				Value="{StaticResource MaterialTopTabBarHeight}" />
-		<Setter Property="utu:SafeArea.Insets"
-				Value="Top" />
-		<Setter Property="ItemContainerStyle"
-				Value="{StaticResource MaterialColoredTopTabBarItemStyle}" />
-		<Setter Property="SelectionIndicatorPresenterStyle"
-				Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}" />
+		<Setter Property="Background" Value="{ThemeResource PrimaryBrush}" />
+		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialColoredTopTabBarItemStyle}" />
 		<Setter Property="SelectionIndicatorContentTemplate">
 			<Setter.Value>
 				<DataTemplate>
 					<Border Height="2"
-							Margin="0,0,0,1"
 							VerticalAlignment="Bottom"
+							Margin="0,0,0,1"
 							Background="{ThemeResource OnPrimaryBrush}" />
 				</DataTemplate>
 			</Setter.Value>
@@ -223,24 +180,15 @@
 	-->
 	<Style x:Key="MaterialBaseNavigationTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
-		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
-		<Setter Property="FontSize"
-				Value="{ThemeResource LabelMediumFontSize}" />
-		<Setter Property="FontWeight"
-				Value="{ThemeResource LabelMediumFontWeight}" />
-		<Setter Property="UseSystemFocusVisuals"
-				Value="True" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Center" />
-		<Setter Property="Background"
-				Value="{ThemeResource SystemControlTransparentBrush}" />
-		<Setter Property="Foreground"
-				Value="{ThemeResource OnSurfaceVariantBrush}" />
-		<Setter Property="BorderBrush"
-				Value="{ThemeResource SystemControlTransparentBrush}" />
-		<Setter Property="Padding"
-				Value="{StaticResource MaterialNavigationTabBarItemPadding}" />
+		<Setter Property="FontFamily" Value="{ThemeResource MaterialMediumFontFamily}" />
+		<Setter Property="FontSize" Value="{ThemeResource LabelMediumFontSize}" />
+		<Setter Property="FontWeight" Value="{ThemeResource LabelMediumFontWeight}" />
+		<Setter Property="UseSystemFocusVisuals" Value="True" />
+		<Setter Property="HorizontalContentAlignment" Value="Center" />
+		<Setter Property="Background" Value="{ThemeResource SystemControlTransparentBrush}" />
+		<Setter Property="Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}" />
+		<Setter Property="Padding" Value="{StaticResource MaterialNavigationTabBarItemPadding}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBarItem">
@@ -257,52 +205,37 @@
 								<VisualState x:Name="Normal" />
 								<not_mobile:VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background"
-												Value="{ThemeResource OnSurfaceVariantHoverBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnSurfaceVariantBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceVariantBrush}" />
+										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource OnSurfaceVariantHoverBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background"
-												Value="{ThemeResource OnSurfaceVariantPressedBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnSurfaceVariantBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceVariantBrush}" />
+										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource OnSurfaceVariantPressedBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Selected">
 									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background"
-												Value="{ThemeResource SecondaryContainerBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnSecondaryContainerBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceBrush}" />
+										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource SecondaryContainerBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSecondaryContainerBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 								<not_mobile:VisualState x:Name="PointerOverSelected">
 									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background"
-												Value="{ThemeResource OnSurfaceHoverBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnSecondaryContainerBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceBrush}" />
+										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource OnSurfaceHoverBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSecondaryContainerBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 								<VisualState x:Name="PressedSelected">
 									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background"
-												Value="{ThemeResource OnSurfacePressedBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnSecondaryContainerBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceBrush}" />
+										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource OnSurfacePressedBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSecondaryContainerBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -310,10 +243,8 @@
 								<VisualState x:Name="Enabled" />
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -321,22 +252,16 @@
 								<VisualState x:Name="IconOnTop" />
 								<VisualState x:Name="IconOnly">
 									<VisualState.Setters>
-										<Setter Target="ContentPresenter.Visibility"
-												Value="Collapsed" />
-										<Setter Target="ContentGrid.RowSpacing"
-												Value="0" />
+										<Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
+										<Setter Target="ContentGrid.RowSpacing" Value="0" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="ContentOnly">
 									<VisualState.Setters>
-										<Setter Target="IconBox.Visibility"
-												Value="Collapsed" />
-										<Setter Target="ContentPresenter.Margin"
-												Value="12,0" />
-										<Setter Target="IconRow.Height"
-												Value="0" />
-										<Setter Target="ContentRow.Height"
-												Value="*" />
+										<Setter Target="IconBox.Visibility" Value="Collapsed" />
+										<Setter Target="ContentPresenter.Margin" Value="12,0" />
+										<Setter Target="IconRow.Height" Value="0" />
+										<Setter Target="ContentRow.Height" Value="*" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -454,22 +379,14 @@
 
 	<Style x:Key="MaterialTopTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
-		<Setter Property="Background"
-				Value="{ThemeResource SystemControlTransparentBrush}" />
-		<Setter Property="Foreground"
-				Value="{ThemeResource OnSurfaceMediumBrush}" />
-		<Setter Property="BorderBrush"
-				Value="{ThemeResource SystemControlTransparentBrush}" />
-		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialRegularFontFamily}" />
-		<Setter Property="FontSize"
-				Value="{ThemeResource TitleSmallFontSize}" />
-		<Setter Property="FontWeight"
-				Value="{ThemeResource TitleSmallFontWeight}" />
-		<Setter Property="UseSystemFocusVisuals"
-				Value="True" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Center" />
+		<Setter Property="Background" Value="{ThemeResource SystemControlTransparentBrush}" />
+		<Setter Property="Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}" />
+		<Setter Property="FontFamily" Value="{ThemeResource MaterialRegularFontFamily}" />
+		<Setter Property="FontSize" Value="{ThemeResource TitleSmallFontSize}" />
+		<Setter Property="FontWeight" Value="{ThemeResource TitleSmallFontWeight}" />
+		<Setter Property="UseSystemFocusVisuals" Value="True" />
+		<Setter Property="HorizontalContentAlignment" Value="Center" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBarItem">
@@ -484,72 +401,50 @@
 								<VisualState x:Name="Normal" />
 								<not_mobile:VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource PrimaryHoverBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource PrimaryHoverBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnSurfaceMediumBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceMediumBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryHoverBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryHoverBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 								<not_mobile:VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource PrimaryPressedBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource PrimaryPressedBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnSurfaceMediumBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceMediumBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryPressedBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryPressedBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 								<VisualState x:Name="Selected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource SystemControlTransparentBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource SystemControlTransparentBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource PrimaryBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource SystemControlTransparentBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource SystemControlTransparentBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource PrimaryBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PrimaryBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 								<not_mobile:VisualState x:Name="PointerOverSelected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource PrimaryHoverBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource PrimaryHoverBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource PrimaryBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryHoverBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryHoverBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource PrimaryBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PrimaryBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 								<not_mobile:VisualState x:Name="PressedSelected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource PrimaryPressedBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource PrimaryPressedBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource PrimaryBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryPressedBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryPressedBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource PrimaryBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PrimaryBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 							</VisualStateGroup>
 							<VisualStateGroup x:Name="FocusStates">
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource PrimaryLowBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource PrimaryLowBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryLowBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="PointerFocused" />
@@ -559,10 +454,8 @@
 								<VisualState x:Name="Enabled" />
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -570,22 +463,16 @@
 								<VisualState x:Name="IconOnTop" />
 								<VisualState x:Name="IconOnly">
 									<VisualState.Setters>
-										<Setter Target="PointerRectangle.Visibility"
-												Value="Visible" />
-										<Setter Target="ContentPresenter.Visibility"
-												Value="Collapsed" />
+										<Setter Target="PointerRectangle.Visibility" Value="Visible" />
+										<Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="ContentOnly">
 									<VisualState.Setters>
-										<Setter Target="IconBox.Visibility"
-												Value="Collapsed" />
-										<Setter Target="ContentPresenter.Margin"
-												Value="12,0" />
-										<Setter Target="IconRow.Width"
-												Value="0" />
-										<Setter Target="ContentRow.Width"
-												Value="*" />
+										<Setter Target="IconBox.Visibility" Value="Collapsed" />
+										<Setter Target="ContentPresenter.Margin" Value="12,0" />
+										<Setter Target="IconRow.Width" Value="0" />
+										<Setter Target="ContentRow.Width" Value="*" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -599,41 +486,41 @@
 								   Feedback="{ThemeResource PrimaryBrush}"
 								   FeedbackOpacity="{StaticResource PressedOpacity}">
 							<um:Ripple.Content>
-							<Grid>
-								<Rectangle x:Name="PointerRectangle"
-										   Fill="Transparent"
-										   Visibility="Collapsed" />
+								<Grid>
+									<Rectangle x:Name="PointerRectangle"
+											   Fill="Transparent"
+											   Visibility="Collapsed" />
 
-								<Grid x:Name="ContentGrid"
-									  ColumnSpacing="8">
-									<Grid.ColumnDefinitions>
-										<ColumnDefinition x:Name="IconRow"
-														  Width="*" />
-										<ColumnDefinition x:Name="ContentRow"
-														  Width="Auto" />
-									</Grid.ColumnDefinitions>
-									<Viewbox x:Name="IconBox"
-											 Width="{StaticResource MaterialTopTabBarItemIconHeight}"
-											 Height="{StaticResource MaterialTopTabBarItemIconHeight}">
-										<ContentPresenter x:Name="Icon"
-														  Content="{TemplateBinding Icon}"
-														  Foreground="{TemplateBinding Foreground}" />
-									</Viewbox>
-									<ContentPresenter x:Name="ContentPresenter"
-													  Grid.Column="1"
-													  Margin="{StaticResource MaterialTopTabBarItemContentMargin}"
-													  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-													  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-													  AutomationProperties.AccessibilityView="Raw"
-													  Content="{TemplateBinding Content}"
-													  ContentTemplate="{TemplateBinding ContentTemplate}"
-													  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-													  ContentTransitions="{TemplateBinding ContentTransitions}"
-													  FontSize="{TemplateBinding FontSize}"
-													  Foreground="{TemplateBinding Foreground}"
-													  TextWrapping="NoWrap" />
+									<Grid x:Name="ContentGrid"
+										  ColumnSpacing="8">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition x:Name="IconRow"
+															  Width="*" />
+											<ColumnDefinition x:Name="ContentRow"
+															  Width="Auto" />
+										</Grid.ColumnDefinitions>
+										<Viewbox x:Name="IconBox"
+												 Width="{StaticResource MaterialTopTabBarItemIconHeight}"
+												 Height="{StaticResource MaterialTopTabBarItemIconHeight}">
+											<ContentPresenter x:Name="Icon"
+															  Content="{TemplateBinding Icon}"
+															  Foreground="{TemplateBinding Foreground}" />
+										</Viewbox>
+										<ContentPresenter x:Name="ContentPresenter"
+														  Grid.Column="1"
+														  Margin="{StaticResource MaterialTopTabBarItemContentMargin}"
+														  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+														  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+														  AutomationProperties.AccessibilityView="Raw"
+														  Content="{TemplateBinding Content}"
+														  ContentTemplate="{TemplateBinding ContentTemplate}"
+														  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+														  ContentTransitions="{TemplateBinding ContentTransitions}"
+														  FontSize="{TemplateBinding FontSize}"
+														  Foreground="{TemplateBinding Foreground}"
+														  TextWrapping="NoWrap" />
+									</Grid>
 								</Grid>
-							</Grid>
 							</um:Ripple.Content>
 						</um:Ripple>
 					</Grid>
@@ -645,8 +532,7 @@
 	<Style x:Key="MaterialColoredTopTabBarItemStyle"
 		   BasedOn="{StaticResource MaterialTopTabBarItemStyle}"
 		   TargetType="utu:TabBarItem">
-		<Setter Property="Foreground"
-				Value="{ThemeResource OnPrimaryMediumBrush}" />
+		<Setter Property="Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBarItem">
@@ -661,72 +547,50 @@
 								<VisualState x:Name="Normal" />
 								<not_mobile:VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource OnPrimaryHoverBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource OnPrimaryHoverBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnPrimaryMediumBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnPrimaryMediumBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryHoverBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryHoverBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 								<not_mobile:VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource OnPrimaryPressedBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource OnPrimaryPressedBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnPrimaryMediumBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnPrimaryMediumBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryPressedBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryPressedBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 								<VisualState x:Name="Selected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource SystemControlTransparentBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource SystemControlTransparentBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnPrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnPrimaryBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource SystemControlTransparentBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource SystemControlTransparentBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 								<not_mobile:VisualState x:Name="PointerOverSelected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource OnPrimaryHoverBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource OnPrimaryHoverBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnPrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnPrimaryBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryHoverBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryHoverBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 								<not_mobile:VisualState x:Name="PressedSelected">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource OnPrimaryPressedBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource OnPrimaryPressedBrush}" />
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource OnPrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnPrimaryBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryPressedBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryPressedBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
 									</VisualState.Setters>
 								</not_mobile:VisualState>
 							</VisualStateGroup>
 							<VisualStateGroup x:Name="FocusStates">
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background"
-												Value="{ThemeResource OnPrimaryLowBrush}" />
-										<Setter Target="PointerRectangle.Fill"
-												Value="{ThemeResource OnPrimaryLowBrush}" />
+										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryLowBrush}" />
+										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="PointerFocused" />
@@ -736,10 +600,8 @@
 								<VisualState x:Name="Enabled" />
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="Icon.Foreground"
-												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+										<Setter Target="Icon.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -747,22 +609,16 @@
 								<VisualState x:Name="IconOnTop" />
 								<VisualState x:Name="IconOnly">
 									<VisualState.Setters>
-										<Setter Target="PointerRectangle.Visibility"
-												Value="Visible" />
-										<Setter Target="ContentPresenter.Visibility"
-												Value="Collapsed" />
+										<Setter Target="PointerRectangle.Visibility" Value="Visible" />
+										<Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="ContentOnly">
 									<VisualState.Setters>
-										<Setter Target="IconBox.Visibility"
-												Value="Collapsed" />
-										<Setter Target="ContentPresenter.Margin"
-												Value="12,0" />
-										<Setter Target="IconRow.Width"
-												Value="0" />
-										<Setter Target="ContentRow.Width"
-												Value="*" />
+										<Setter Target="IconBox.Visibility" Value="Collapsed" />
+										<Setter Target="ContentPresenter.Margin" Value="12,0" />
+										<Setter Target="IconRow.Width" Value="0" />
+										<Setter Target="ContentRow.Width" Value="*" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -823,28 +679,17 @@
 	<!--#region FAB TabBarItem Styles-->
 	<Style x:Key="MaterialBaseFabTabBarItemStyle"
 		   TargetType="utu:TabBarItem">
-		<Setter Property="FontFamily"
-				Value="{ThemeResource MaterialMediumFontFamily}" />
-		<Setter Property="FontSize"
-				Value="{ThemeResource LabelMediumFontSize}" />
-		<Setter Property="FontWeight"
-				Value="{ThemeResource LabelMediumFontWeight}" />
-		<Setter Property="IsSelectable"
-				Value="False" />
-		<Setter Property="UseSystemFocusVisuals"
-				Value="True" />
-		<Setter Property="VerticalContentAlignment"
-				Value="Center" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Center" />
-		<Setter Property="CornerRadius"
-				Value="{StaticResource MaterialFabTabBarItemCornerRadius}" />
-		<Setter Property="Padding"
-				Value="{StaticResource MaterialFabTabBarItemPadding}" />
-		<Setter Property="Background"
-				Value="{ThemeResource PrimaryContainerBrush}" />
-		<Setter Property="Foreground"
-				Value="{ThemeResource OnPrimaryContainerBrush}" />
+		<Setter Property="FontFamily" Value="{ThemeResource MaterialMediumFontFamily}" />
+		<Setter Property="FontSize" Value="{ThemeResource LabelMediumFontSize}" />
+		<Setter Property="FontWeight" Value="{ThemeResource LabelMediumFontWeight}" />
+		<Setter Property="IsSelectable" Value="False" />
+		<Setter Property="UseSystemFocusVisuals" Value="True" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+		<Setter Property="HorizontalContentAlignment" Value="Center" />
+		<Setter Property="CornerRadius" Value="{StaticResource MaterialFabTabBarItemCornerRadius}" />
+		<Setter Property="Padding" Value="{StaticResource MaterialFabTabBarItemPadding}" />
+		<Setter Property="Background" Value="{ThemeResource PrimaryContainerBrush}" />
+		<Setter Property="Foreground" Value="{ThemeResource OnPrimaryContainerBrush}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBarItem">
@@ -911,24 +756,19 @@
 
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="StateOverlay.Background"
-												Value="{ThemeResource OnPrimaryContainerHoverBrush}" />
+										<Setter Target="StateOverlay.Background" Value="{ThemeResource OnPrimaryContainerHoverBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Pressed">
 									<VisualState.Setters>
-										<Setter Target="StateOverlay.Background"
-												Value="{ThemeResource OnPrimaryContainerPressedBrush}" />
+										<Setter Target="StateOverlay.Background" Value="{ThemeResource OnPrimaryContainerPressedBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="IconPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceDisabledBrush}" />
-										<Setter Target="ContentPresenter.Foreground"
-												Value="{ThemeResource OnSurfaceDisabledBrush}" />
-										<Setter Target="StateOverlay.Background"
-												Value="{ThemeResource OnSurfaceDisabledLowBrush}" />
+										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource OnSurfaceDisabledBrush}" />
+										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceDisabledBrush}" />
+										<Setter Target="StateOverlay.Background" Value="{ThemeResource OnSurfaceDisabledLowBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -937,8 +777,7 @@
 
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
-										<Setter Target="StateOverlay.Background"
-												Value="{ThemeResource OnPrimaryContainerFocusedBrush}" />
+										<Setter Target="StateOverlay.Background" Value="{ThemeResource OnPrimaryContainerFocusedBrush}" />
 									</VisualState.Setters>
 								</VisualState>
 


### PR DESCRIPTION
Changes for the MinHeight/MinWidth from https://github.com/unoplatform/uno.toolkit.ui/pull/519 accidentally undid the work for the surface tint on TabBars

General TabBar style cleanup 

## PR Type

What kind of change does this PR introduce?

- Bugfix
