### PR TITLE
fix: Ensure NavBar properly displays MainCommand button in all scenarios

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NavigationBarSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/NavigationBarSamplePage.xaml
@@ -74,13 +74,13 @@
 						<Button.Flyout>
 							<Flyout x:Name="M3ModalFlyout"
                                     Opened="M3ModalFlyout_Opened"
-                                    Placement="Bottom">
+                                    Placement="Full">
 								<Flyout.FlyoutPresenterStyle>
 									<Style TargetType="FlyoutPresenter">
-										<Setter Property="MinWidth"
-                                                Value="200" />
+										<Setter Property="Width"
+                                                Value="900" />
 										<Setter Property="MinHeight"
-                                                Value="200" />
+                                                Value="600" />
 									</Style>
 								</Flyout.FlyoutPresenterStyle>
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/M3MaterialNavigationBarSample_ModalPage1.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/M3MaterialNavigationBarSample_ModalPage1.xaml.cs
@@ -37,7 +37,7 @@ namespace Uno.Toolkit.Samples.Content.NestedSamples
 			this.InitializeComponent();
 		}
 
-		private void NavigateToNextPage(object sender, RoutedEventArgs e) => Frame.Navigate(typeof(MaterialNavigationBarSample_ModalPage2));
+		private void NavigateToNextPage(object sender, RoutedEventArgs e) => Frame.Navigate(typeof(M3MaterialNavigationBarSample_ModalPage2));
 
 		private void NavigateBack(object sender, RoutedEventArgs e) => Shell.GetForCurrentView().BackNavigateFromNestedSample();
 	}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/M3MaterialNavigationBarSample_ModalPage2.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/M3MaterialNavigationBarSample_ModalPage2.xaml
@@ -19,10 +19,9 @@
                            AutomationProperties.AutomationId="M3Page2NavBar"
 						   MainCommandMode="Back">
             <utu:NavigationBar.MainCommand>
-                <AppBarButton Click="NavigateBack"
-                              Label="Back">
-                </AppBarButton>
-            </utu:NavigationBar.MainCommand>
+				<AppBarButton Click="NavigateBack"
+							  Label="Return" />
+			</utu:NavigationBar.MainCommand>
             <utu:NavigationBar.PrimaryCommands>
                 <AppBarButton Style="{StaticResource MaterialAppBarButtonStyle}"
 							  Label="More" />

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
@@ -121,6 +121,10 @@ namespace Uno.Toolkit.UI
 			var native = Native;
 			var element = Element ?? throw new InvalidOperationException("Element is null.");
 
+			native.Image = null;
+			native.ClearCustomView();
+			native.Title = element.Content is string content ? content : element.Label;
+
 			if (element.Icon != null)
 			{
 				switch (element.Icon)
@@ -128,7 +132,6 @@ namespace Uno.Toolkit.UI
 					case BitmapIcon bitmap:
 						native.Image = ImageHelper.FromUri(bitmap.UriSource);
 						native.ClearCustomView();
-						native.Title = null;
 						break;
 
 					case FontIcon font: // not supported
@@ -140,49 +143,24 @@ namespace Uno.Toolkit.UI
 						native.ClearCustomView();
 						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
 						// We default to an empty string to ensure it is added.
-						native.Title = string.Empty;
+						native.Title ??= string.Empty;
 						break;
 				}
 			}
-			else if (element.Content != null)
+			else if (element.Content is FrameworkElement fe)
 			{
-				switch (element.Content)
-				{
-					case string text:
-						native.Image = null;
-						native.ClearCustomView();
-						native.Title = text;
-						break;
+				var currentParent = element.Parent;
+				_appBarButtonWrapper.Child = element;
 
-					case FrameworkElement fe:
-						var currentParent = element.Parent;
-						_appBarButtonWrapper.Child = element;
-
-						//Restore the original parent if any, as we
-						//want the DataContext to flow properly from the
-						//NavigationBar.
-						element.SetParent(currentParent);
-						native.Image = null;
-						native.CustomView = fe.Visibility == Visibility.Visible ? _appBarButtonWrapper : null;
-						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
-						// We default to an empty string to ensure it is added, in order to support late-bound Content.
-						native.Title = string.Empty;
-						break;
-
-					default:
-						native.Image = null;
-						native.ClearCustomView();
-						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
-						// We default to an empty string to ensure it is added.
-						native.Title = element.Label ?? string.Empty;
-						break;
-				}
-			}
-			else
-			{
+				//Restore the original parent if any, as we
+				//want the DataContext to flow properly from the
+				//NavigationBar.
+				element.SetParent(currentParent);
 				native.Image = null;
-				native.ClearCustomView();
-				native.Title = element.Label;
+				native.CustomView = fe.Visibility == Visibility.Visible ? _appBarButtonWrapper : null;
+				// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
+				// We default to an empty string to ensure it is added, in order to support late-bound Content.
+				native.Title ??= string.Empty;
 			}
 
 			// Foreground

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
@@ -876,18 +876,13 @@ namespace Uno.Toolkit.UI
 			{
 				base.PushViewController(viewController, animated);
 
-				// If navigating from ViewController A to ViewController B, B's back button text is determined by A's NavigationBar.MainCommand.Label.
 				if (viewController is PageViewController pvc)
 				{
 					var pushedNavBar = pvc.GetNavigationBar();
-					if (pushedNavBar?.MainCommandMode == MainCommandMode.Back
-						&& pushedNavBar?.MainCommand?.Label is string backButtonTitle
-						&& LowerController?.NavigationItem is { } previousNavItem)
-					{
-						previousNavItem.BackButtonTitle = backButtonTitle;
-					}
+
+					var renderer = pushedNavBar?.GetRenderer(() => (NavigationBarNavigationItemRenderer?)null);
+					renderer?.SetBackItem(LowerController?.NavigationItem);
 				}
-				
 			}
 		}
 


### PR DESCRIPTION
related to https://github.com/unoplatform/uno.chefs/issues/128

## PR Type

What kind of change does this PR introduce?
- Bugfix

For cases where the NavBar's MainCommand should still be visible even if the BackStack is empty (such as modal pages where the MainCommand should be visible in order to close the flyout), we should be able to define the MainCommand.Icon and have the button visible in the NavBar like below:
![image](https://user-images.githubusercontent.com/4793020/230213454-349d9882-0254-4401-90e2-174078180ad8.png)

We should also now be able to properly display the proper text on the NavBar's MainCommand using its Content or Label property

`<MainCommand Label="Return" />` should give:
![image](https://user-images.githubusercontent.com/4793020/230214548-62233100-3696-4024-8b07-d991a0d943f4.png)

