### PR TITLE
ci: continue-on-error with Azure Static WebApps

### DIFF
--- a/.github/workflows/azure-static-webapp.yml
+++ b/.github/workflows/azure-static-webapp.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Publish to Azure Static WebApps
         id: builddeploy_uno
+        continue-on-error: true
         uses: Azure/static-web-apps-deploy@v0.0.1-preview
         with:
           skip_deploy_on_missing_secrets: true


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
Azure Static WebApps failing the pr checks with:
> Reason: This Static Web App already has the maximum number of staging environments (10). Please remove one and try again.

## What is the new behavior?
Failure to deploy doesn't fail the check.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error