### PR TITLE
fix(NavigationBar): Ensure proper iOS back button behavior

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/RuntimeTestRunner.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/RuntimeTestRunner.xaml
@@ -5,7 +5,6 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:rtt="using:Uno.UI.RuntimeTests"
-	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/RuntimeTestRunner.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/RuntimeTestRunner.xaml
@@ -9,5 +9,5 @@
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<rtt:UnitTestsControl utu:SafeArea.Insets="VisibleBounds" />
+	<rtt:UnitTestsControl />
 </Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/RuntimeTestRunner.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/RuntimeTestRunner.xaml
@@ -5,8 +5,9 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:rtt="using:Uno.UI.RuntimeTests"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<rtt:UnitTestsControl />
+	<rtt:UnitTestsControl utu:SafeArea.Insets="VisibleBounds" />
 </Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml
@@ -11,16 +11,13 @@
 			 xmlns:xamarin="http://uno.ui/xamarin"
 			 mc:Ignorable="wasm xamarin">
 
-	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-		  utu:SafeArea.Insets="VisibleBounds">
-
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<Grid.RowDefinitions>
 			<RowDefinition x:Name="TopPaddingRow"
 						   Height="0" />
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
-
 
 		<!-- We set CompactModeThresholdWidth to a very high value so that it never happens. We don't want to use the compact mode. -->
 		<muxc:NavigationView Grid.Row="2"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml
@@ -3,7 +3,6 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:local="using:Uno.Toolkit.Samples"
-			 xmlns:utu="using:Uno.Toolkit.UI"
 			 xmlns:not_wasm="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Shell.xaml
@@ -3,6 +3,7 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:local="using:Uno.Toolkit.Samples"
+			 xmlns:utu="using:Uno.Toolkit.UI"
 			 xmlns:not_wasm="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -10,7 +11,8 @@
 			 xmlns:xamarin="http://uno.ui/xamarin"
 			 mc:Ignorable="wasm xamarin">
 
-	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+		  utu:SafeArea.Insets="VisibleBounds">
 
 		<Grid.RowDefinitions>
 			<RowDefinition x:Name="TopPaddingRow"

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/NavBarAutoLayoutPage2.xaml
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/NavBarAutoLayoutPage2.xaml
@@ -1,0 +1,18 @@
+﻿<Page x:Class="Uno.Toolkit.RuntimeTests.Tests.TestPages.NavBarAutoLayoutPage2"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.RuntimeTests.Tests.TestPages"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<utu:AutoLayout>
+		<utu:NavigationBar Content="Testing 2">
+			<utu:NavigationBar.MainCommand>
+				<AppBarButton Label="Hello" />
+			</utu:NavigationBar.MainCommand>
+		</utu:NavigationBar>
+	</utu:AutoLayout>
+</Page>

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/NavBarAutoLayoutPage2.xaml.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/NavBarAutoLayoutPage2.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Uno.Toolkit.UI;
+
+#if IS_WINUI
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+#else
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests.TestPages
+{
+	public sealed partial class NavBarAutoLayoutPage2 : Page
+	{
+		public NavBarAutoLayoutPage2()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -44,9 +44,18 @@ namespace Uno.Toolkit.UI
 		private bool _isInOverflow;
 		private DependencyObject? _elementParent;
 
-		public AppBarButtonRenderer(AppBarButton element, bool isInOverflow = false) : base(element)
+		public bool IsInOverflow
 		{
-			_isInOverflow = isInOverflow;
+			get => _isInOverflow;
+			set
+			{
+				_isInOverflow = value;
+				Invalidate();
+			}
+		}
+
+		public AppBarButtonRenderer(AppBarButton element) : base(element)
+		{
 			element.ViewAttachedToWindow += OnElementAttachedToWindow;
 		}
 

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
@@ -124,7 +124,6 @@ namespace Uno.Toolkit.UI
 			native.Image = null;
 			native.ClearCustomView();
 			native.Title = element.Content is string content ? content : element.Label;
-
 			if (element.Icon != null)
 			{
 				switch (element.Icon)

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
@@ -861,8 +861,7 @@ namespace Uno.Toolkit.UI
 			public override UIViewController PopViewController(bool animated)
 			{
 				var lowerNavigationBar = LowerController?.GetNavigationBar();
-				var renderer = lowerNavigationBar?.GetRenderer(() => (NavigationBarRenderer?)null);
-				if (renderer != null)
+				if (lowerNavigationBar?.TryGetRenderer<NavigationBar, NavigationBarRenderer>() is { } renderer)
 				{
 					// Set navigation bar properties for page about to become visible. This gives a nice animation and works around bug on 
 					// iOS 11.2 where TitleTextAttributes aren't updated properly (https://openradar.appspot.com/37567828)
@@ -878,10 +877,11 @@ namespace Uno.Toolkit.UI
 
 				if (viewController is PageViewController pvc)
 				{
-					var pushedNavBar = pvc.GetNavigationBar();
-
-					var renderer = pushedNavBar?.GetRenderer(() => (NavigationBarNavigationItemRenderer?)null);
-					renderer?.SetBackItem(LowerController?.NavigationItem);
+					var pushedNavBar = pvc.View?.FindTopNavigationBar();
+					if (pushedNavBar?.TryGetRenderer<NavigationBar, NavigationBarNavigationItemRenderer>() is { } renderer)
+					{
+						renderer.BackItem = LowerController?.NavigationItem;
+					}
 				}
 			}
 		}

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.Android.cs
@@ -51,7 +51,7 @@ namespace Uno.Toolkit.UI
 			var navBar = TemplatedParent as NavigationBar;
 			if (navBar is { })
 			{
-				Content = navBar.GetOrAddRenderer(nb => new NavigationBarRenderer(nb)).Native;
+				Content = navBar.GetOrAddDefaultRenderer().Native;
 				navBar.MainCommand.Click += OnMainCommandClicked;
 				_mainCommandClickHandler.Disposable = null;
 				_mainCommandClickHandler.Disposable = Disposable.Create(() => navBar.MainCommand.Click -= OnMainCommandClicked);

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.Android.cs
@@ -51,7 +51,7 @@ namespace Uno.Toolkit.UI
 			var navBar = TemplatedParent as NavigationBar;
 			if (navBar is { })
 			{
-				Content = navBar.GetRenderer(() => new NavigationBarRenderer(navBar)).Native;
+				Content = navBar.GetOrAddRenderer(nb => new NavigationBarRenderer(nb)).Native;
 				navBar.MainCommand.Click += OnMainCommandClicked;
 				_mainCommandClickHandler.Disposable = null;
 				_mainCommandClickHandler.Disposable = Disposable.Create(() => navBar.MainCommand.Click -= OnMainCommandClicked);

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
@@ -73,7 +73,7 @@ namespace Uno.Toolkit.UI
 				_navBarRef = new WeakReference<NavigationBar?>(navBar);
 			}
 
-			_navigationBar = navBar?.GetOrAddRenderer(nb => new NavigationBarRenderer(nb)).Native;
+			_navigationBar = navBar?.GetOrAddDefaultRenderer().Native;
 
 			if (navBar is { })
 			{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
@@ -71,14 +71,9 @@ namespace Uno.Toolkit.UI
 			{
 				navBar = TemplatedParent as NavigationBar;
 				_navBarRef = new WeakReference<NavigationBar?>(navBar);
-
-				_navigationBar = navBar?.GetRenderer(RendererFactory).Native;
-
 			}
-			else
-			{
-				_navigationBar = navBar?.ResetRenderer(RendererFactory).Native;
-			}
+
+			_navigationBar = navBar?.GetOrAddRenderer(nb => new NavigationBarRenderer(nb)).Native;
 
 			if (navBar is { })
 			{
@@ -131,15 +126,6 @@ namespace Uno.Toolkit.UI
 			{
 				navBar?.TryPerformMainCommand();
 			}
-		}
-
-		NavigationBarRenderer RendererFactory()
-		{
-			NavigationBar? navBar = null;
-
-			_navBarRef?.TryGetTarget(out navBar);
-
-			return new NavigationBarRenderer(navBar!);
 		}
 
 		protected override Size MeasureOverride(Size size)

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationAppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationAppBarButtonRenderer.Android.cs
@@ -39,12 +39,18 @@ namespace Uno.Toolkit.UI
 {
 	internal class NavigationAppBarButtonRenderer : Renderer<AppBarButton, Toolbar>
 	{
-		private readonly MainCommandMode _mode;
-
-		public NavigationAppBarButtonRenderer(AppBarButton element, MainCommandMode mode) : base(element) 
+		private MainCommandMode _mode;
+		public MainCommandMode Mode
 		{
-			_mode = mode;
+			get => _mode;
+			set
+			{
+				_mode = value;
+				Invalidate();
+			}
 		}
+
+		public NavigationAppBarButtonRenderer(AppBarButton element) : base(element) { }
 
 		protected override Toolbar CreateNativeInstance() => throw new NotSupportedException("The Native instance must be provided.");
 

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarHelper.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarHelper.iOS.cs
@@ -19,12 +19,16 @@ namespace Uno.Toolkit.UI
 	{
 		internal static void SetNavigationBar(NavigationBar navigationBar, UIKit.UINavigationBar? uiNavigationBar)
 		{
-			navigationBar.GetOrAddRenderer(navBar => new NavigationBarRenderer(navBar)).Native = uiNavigationBar;
+			navigationBar.AddOrUpdateRenderer(
+				onCreate: navBar => new NavigationBarRenderer(navBar) { Native = uiNavigationBar },
+				onUpdate: (navBar, renderer) => renderer.Native = uiNavigationBar);
 		}
 
 		internal static void SetNavigationItem(NavigationBar navigationBar, UIKit.UINavigationItem? navigationItem)
 		{
-			navigationBar.GetOrAddRenderer(navBar => new NavigationBarNavigationItemRenderer(navBar)).Native = navigationItem;
+			navigationBar.AddOrUpdateRenderer(
+				onCreate: navBar => new NavigationBarNavigationItemRenderer(navBar) { Native = navigationItem },
+				onUpdate: (navBar, renderer) => renderer.Native = navigationItem);
 		}
 
 		/// <summary>

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
@@ -138,7 +138,7 @@ namespace Uno.Toolkit.UI
 			{
 				btn.SetParent(Element);
 
-				if (btn.GetOrAddRenderer(appBarBtn => new AppBarButtonRenderer(appBarBtn)).Native is { } uiBarButton)
+				if (btn.GetOrAddDefaultRenderer().Native is { } uiBarButton)
 				{
 					rightBarButtons.Add(uiBarButton);
 				}
@@ -156,7 +156,7 @@ namespace Uno.Toolkit.UI
 				if (mode == MainCommandMode.Action ||
 					(mode == MainCommandMode.Back && _backItem == null))
 				{
-					native.LeftBarButtonItem = mainCommand.GetOrAddRenderer(mainBtn => new AppBarButtonRenderer(mainBtn)).Native;
+					native.LeftBarButtonItem = mainCommand.GetOrAddDefaultRenderer().Native;
 				}
 				else
 				{
@@ -175,7 +175,7 @@ namespace Uno.Toolkit.UI
 
 					if (mainCommandIcon is { } icon && string.IsNullOrEmpty(_backItem?.BackButtonTitle))
 					{
-						native.LeftBarButtonItem = mainCommand.GetOrAddRenderer(mainBtn => new AppBarButtonRenderer(mainBtn)).Native;
+						native.LeftBarButtonItem = mainCommand.GetOrAddDefaultRenderer().Native;
 					}
 					else
 					{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.Android.cs
@@ -245,8 +245,9 @@ namespace Uno.Toolkit.UI
 					{
 						// This ensures that Behaviors expecting this button to be in the logical tree work.
 						primaryCommand.SetParent(Element);
-						var renderer = primaryCommand.GetOrAddRenderer(btn => new AppBarButtonRenderer(btn));
-						renderer.Native = menuItem;
+						primaryCommand.AddOrUpdateRenderer(
+							onCreate: btn => new AppBarButtonRenderer(btn) { Native = menuItem },
+							onUpdate: (btn, renderer) => renderer.Native = menuItem);
 
 						
 					}
@@ -260,23 +261,23 @@ namespace Uno.Toolkit.UI
 					{
 						// This ensures that Behaviors expecting this button to be in the logical tree work. 
 						secondaryCommand.SetParent(Element);
-						var renderer = secondaryCommand.GetOrAddRenderer(btn => new AppBarButtonRenderer(btn, isInOverflow: true));
-						renderer.Native = menuItem;
-
-						
+						secondaryCommand.AddOrUpdateRenderer(
+							onCreate: btn => new AppBarButtonRenderer(btn) { Native = menuItem, IsInOverflow = true },
+							onUpdate: (btn, renderer) => renderer.Native = menuItem);
 					}
 				}
 			}
 
-			var MainCommand = element.GetValue(NavigationBar.MainCommandProperty) as AppBarButton;
-			var MainCommandMode = (MainCommandMode)element.GetValue(NavigationBar.MainCommandModeProperty);
+			var mainCommand = element.GetValue(NavigationBar.MainCommandProperty) as AppBarButton;
+			var mainCommandMode = (MainCommandMode)element.GetValue(NavigationBar.MainCommandModeProperty);
 
-			if (MainCommand is { } mainCommand)
+			if (mainCommand is { })
 			{
 				// This ensures that Behaviors expecting this button to be in the logical tree work. 
 				mainCommand.SetParent(Element);
-				var renderer = mainCommand.GetOrAddRenderer(mainBtn => new NavigationAppBarButtonRenderer(mainBtn, MainCommandMode));
-				renderer.Native = native;
+				mainCommand.AddOrUpdateRenderer(
+							onCreate: btn => new NavigationAppBarButtonRenderer(btn) { Native = native, Mode = mainCommandMode },
+							onUpdate: (btn, renderer) => renderer.Native = native);
 			}
 			else
 			{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.Android.cs
@@ -245,7 +245,7 @@ namespace Uno.Toolkit.UI
 					{
 						// This ensures that Behaviors expecting this button to be in the logical tree work.
 						primaryCommand.SetParent(Element);
-						var renderer = primaryCommand.GetRenderer(() => new AppBarButtonRenderer(primaryCommand));
+						var renderer = primaryCommand.GetOrAddRenderer(btn => new AppBarButtonRenderer(btn));
 						renderer.Native = menuItem;
 
 						
@@ -260,7 +260,7 @@ namespace Uno.Toolkit.UI
 					{
 						// This ensures that Behaviors expecting this button to be in the logical tree work. 
 						secondaryCommand.SetParent(Element);
-						var renderer = secondaryCommand.GetRenderer(() => new AppBarButtonRenderer(secondaryCommand, isInOverflow: true));
+						var renderer = secondaryCommand.GetOrAddRenderer(btn => new AppBarButtonRenderer(btn, isInOverflow: true));
 						renderer.Native = menuItem;
 
 						
@@ -275,7 +275,7 @@ namespace Uno.Toolkit.UI
 			{
 				// This ensures that Behaviors expecting this button to be in the logical tree work. 
 				mainCommand.SetParent(Element);
-				var renderer = mainCommand.GetRenderer(() => new NavigationAppBarButtonRenderer(mainCommand, MainCommandMode));
+				var renderer = mainCommand.GetOrAddRenderer(mainBtn => new NavigationAppBarButtonRenderer(mainBtn, MainCommandMode));
 				renderer.Native = native;
 			}
 			else

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
@@ -41,8 +41,8 @@ namespace Uno.Toolkit.UI
 			var navigationBar = new UINavigationBar();
 			if (Element is { } element)
 			{
-				var navigationItem = element.GetRenderer(() => new NavigationBarNavigationItemRenderer(element)).Native;
-				navigationBar.PushNavigationItem(navigationItem!, false);
+				var renderer = element.GetOrAddRenderer(navBar => new NavigationBarNavigationItemRenderer(navBar));
+				navigationBar.PushNavigationItem(renderer.Native, false);
 			}
 
 			return navigationBar;
@@ -217,7 +217,7 @@ namespace Uno.Toolkit.UI
 			if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
 			{
 				var backButtonAppearance = new UIBarButtonItemAppearance(UIBarButtonItemStyle.Plain);
-
+				var backImage = mainCommandIcon ?? appearance.BackIndicatorImage;
 				if (mainForeground is { } foreground)
 				{
 					var titleTextAttributes = new UIStringAttributes
@@ -229,24 +229,13 @@ namespace Uno.Toolkit.UI
 
 					backButtonAppearance.Normal.TitleTextAttributes = attributes;
 					backButtonAppearance.Highlighted.TitleTextAttributes = attributes;
-					
-					if (mainCommandIcon is { } image)
-					{
-						var tintedImage = image.ApplyTintColor(foreground);
-						appearance.SetBackIndicatorImage(tintedImage, tintedImage);
-					}
-					else if (appearance.BackIndicatorImage is { } backImage)
-					{
-						var tintedBack = backImage.ApplyTintColor(foreground);
-						appearance.SetBackIndicatorImage(tintedBack, tintedBack);
-					}
+
+					backImage = backImage?.ApplyTintColor(foreground);
 				}
-				else
+
+				if (backImage is { })
 				{
-					if (mainCommandIcon is { } image)
-					{
-						appearance.SetBackIndicatorImage(image, image);
-					}
+					appearance.SetBackIndicatorImage(backImage, backImage);
 				}
 
 				appearance.BackButtonAppearance = backButtonAppearance;

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
@@ -184,5 +184,13 @@ namespace Uno.Toolkit.UI
 
 			return existingRenderer;
 		}
+
+#if __IOS__ || __ANDROID__
+		public static AppBarButtonRenderer GetOrAddDefaultRenderer(this AppBarButton appBarButton)
+			=> GetOrAddRenderer(appBarButton, elt => new AppBarButtonRenderer(elt));
+
+		public static NavigationBarRenderer GetOrAddDefaultRenderer(this NavigationBar navBar)
+			=> GetOrAddRenderer(navBar, elt => new NavigationBarRenderer(elt));
+#endif
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
@@ -139,16 +139,50 @@ namespace Uno.Toolkit.UI
 	{
 		private static readonly WeakAttachedDictionary<DependencyObject, Type> _renderers = new WeakAttachedDictionary<DependencyObject, Type>();
 
-		public static TRenderer GetRenderer<TElement, TRenderer>(this TElement element, Func<TRenderer>? rendererFactory)
+		public static TRenderer? TryGetRenderer<TElement, TRenderer>(this TElement element)
 			where TElement : DependencyObject
+			where TRenderer : class
 		{
-			return _renderers.GetValue(element, typeof(TRenderer), rendererFactory);
+			TRenderer? renderer = null;
+			if (_renderers.GetValue<TRenderer>(element, typeof(TRenderer)) is { } existingRenderer)
+			{
+				renderer = existingRenderer;
+			}
+
+			return renderer;
 		}
 
-		public static TRenderer ResetRenderer<TElement, TRenderer>(this TElement element, Func<TRenderer>? rendererFactory)
+		public static void SetRenderer<TElement, TRenderer>(this TElement element, TRenderer? renderer)
 			where TElement : DependencyObject
 		{
-			return _renderers.GetValue(element, typeof(TRenderer), rendererFactory);
+			_renderers.SetValue(element, typeof(TRenderer), renderer);
+		}
+
+		public static void AddOrUpdateRenderer<TElement, TRenderer>(this TElement element, Func<TElement, TRenderer> onCreate, Action<TElement, TRenderer>? onUpdate = null)
+			where TElement : DependencyObject
+			where TRenderer : class
+		{
+			if (_renderers.GetValue<TRenderer>(element, typeof(TRenderer)) is { } renderer)
+			{
+				onUpdate?.Invoke(element, renderer);
+			}
+			else
+			{
+				element.SetRenderer(onCreate(element));
+			}
+		}
+
+		public static TRenderer GetOrAddRenderer<TElement, TRenderer>(this TElement element, Func<TElement, TRenderer> rendererFactory)
+			where TElement : DependencyObject
+			where TRenderer : class
+		{
+			if (_renderers.GetValue<TRenderer>(element, typeof(TRenderer)) is not { } existingRenderer)
+			{
+				existingRenderer = rendererFactory(element);
+				element.SetRenderer(existingRenderer);
+			}
+
+			return existingRenderer;
 		}
 	}
 }


### PR DESCRIPTION
NavigationBars wrapped in an AutoLayout on iOS can result in a missing Back button icon/label. 

We need to ensure that we are rendering the Page's NavigationBar with the proper instance of the previous ViewController's UINavigationItem