### PR TITLE
feat: Adding ability to disable animations

### DIFF
--- a/doc/controls/LoadingView.md
+++ b/doc/controls/LoadingView.md
@@ -11,6 +11,7 @@ Source|ILoadable|Gets and sets the source `ILoadable` associated with this contr
 LoadingContent|object|Gets or sets the content to be displayed during loading/waiting.
 LoadingContentTemplate|DataTemplate|Gets or sets the template to be used to display the LoadingContent during loading/waiting.
 LoadingContentTemplateSelector|DataTemplateSelector|Gets or sets the template selector to be used to display the LoadingContent during loading/waiting.
+DisableAnimantions|bool|Gets and sets whether animations will run when transitioning between states.
 
 ## ILoadable
 Describes if this instance is currently in a busy state and notifies subscribers that said state when has changed.

--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.cs
@@ -26,6 +26,25 @@ namespace Uno.Toolkit.UI
 			public const string Loaded = nameof(Loaded);
 		}
 
+		#region DependencyProperty: DisableAnimations
+
+		public static DependencyProperty DisableAnimationsProperty { get; } = DependencyProperty.Register(
+			nameof(DisableAnimations),
+			typeof(bool),
+			typeof(LoadingView),
+			new PropertyMetadata(false));
+
+		/// <summary>
+		/// Gets and sets the whether animations will play when transitioning to Loaded state.
+		/// </summary>
+		public bool DisableAnimations
+		{
+			get => (bool)GetValue(DisableAnimationsProperty);
+			set => SetValue(DisableAnimationsProperty, value);
+		}
+
+		#endregion
+
 		#region DependencyProperty: Source
 
 		public static DependencyProperty SourceProperty { get; } = DependencyProperty.Register(
@@ -131,7 +150,7 @@ namespace Uno.Toolkit.UI
 				? VisualStateNames.Loading
 				: VisualStateNames.Loaded;
 
-			VisualStateManager.GoToState(this, loadingState, IsLoaded);
+			VisualStateManager.GoToState(this, loadingState, IsLoaded && !DisableAnimations);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #552

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

LoadingView will always show a flicker of the loading state if transition has occurred before rendered (eg loading task completes before app activation). 

## What is the new behavior?

Disabling animations will prevent the loading state from being shown

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
