### PR TITLE
fix: Loading appxmanifest.xml and package.appxmanifest from file or embedded resource

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
@@ -319,7 +319,7 @@ namespace Uno.Toolkit.UI
 					}
 					catch (Exception docError)
 					{
-						typeof(ExtendedSplashScreen).Log().LogTrace($"{manifestFile} exists as an embedded resource but not able to load to XDocument [{docError}].");
+						typeof(ExtendedSplashScreen).Log().LogTrace($"The manifest `{manifestFile}` exists as a packaged file but could not be loaded to XDocument: {docError}.");
 					}
 				}
 			}

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
@@ -296,7 +296,7 @@ namespace Uno.Toolkit.UI
 			}
 			catch (Exception docError)
 			{
-				typeof(ExtendedSplashScreen).Log().LogDebug($"{manifestFile} exists as a packaged file but not able to load to XDocument [{docError}].");
+				typeof(ExtendedSplashScreen).Log().LogDebug($"The manifest `{manifestFile}` exists as a packaged file but could not be loaded to XDocument: {docError}.");
 			}
 
 			return default;

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
@@ -286,7 +286,7 @@ namespace Uno.Toolkit.UI
 		{
 			try
 			{
-				typeof(ExtendedSplashScreen).Log().LogTrace($"Attempting to load {manifestFile} from file packaged with application.");
+				typeof(ExtendedSplashScreen).Log().LogTrace($"Attempting to load manifest `{manifestFile}` from file packaged with application.");
 				var filePath = await ApplicationPathFromFileName(entry, manifestFile);
 				if (!string.IsNullOrWhiteSpace(filePath))
 				{

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
@@ -304,7 +304,7 @@ namespace Uno.Toolkit.UI
 
 		private static XDocument? LoadManifestFromEmbeddedFile(Assembly? entry, string manifestFile)
 		{
-			typeof(ExtendedSplashScreen).Log().LogTrace($"Attempting to load {manifestFile} from embedded resource within the {entry?.GetName().Name} assembly.");
+			typeof(ExtendedSplashScreen).Log().LogTrace($"Attempting to load manifest from embedded resource `{manifestFile}` within the {entry?.GetName().Name} assembly.");
 			// Check EndsWith because the file may have a prefix based on the project and folder the file was sourced from
 			var res = entry?.GetManifestResourceNames()?.FirstOrDefault(x => x.ToLower().EndsWith(manifestFile));
 			if (res is not null &&

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
@@ -307,10 +307,9 @@ namespace Uno.Toolkit.UI
 			typeof(ExtendedSplashScreen).Log().LogTrace($"Attempting to load manifest from embedded resource `{manifestFile}` within the {entry?.GetName().Name} assembly.");
 			// Check EndsWith because the file may have a prefix based on the project and folder the file was sourced from
 			var res = entry?.GetManifestResourceNames()?.FirstOrDefault(x => x.ToLower().EndsWith(manifestFile));
-			if (res is not null &&
-				!string.IsNullOrWhiteSpace(res))
+			if (!string.IsNullOrWhiteSpace(res))
 			{
-				var packageStream = entry!.GetManifestResourceStream(res);
+				var packageStream = entry!.GetManifestResourceStream(res!);
 
 				if (packageStream is not null)
 				{

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
@@ -33,6 +33,10 @@ namespace Uno.Toolkit.UI
 {
 	public partial class ExtendedSplashScreen
 	{
+		private const string PackageAppxManifestFileName = "package.appxmanifest";
+		private const string AppxManifestFilename = "AppxManifest.xml";
+		private const string WasmAppManifestFilename = "appmanifest.js";
+
 		public bool SplashIsEnabled =>
 #if WINDOWS_UWP || WINDOWS
 				(Platforms & SplashScreenPlatform.Windows) != 0;
@@ -160,17 +164,16 @@ namespace Uno.Toolkit.UI
 		{
 			try
 			{
-				var manifestFilename = "appmanifest.js";
 				string? manifestString = default;
 				try
 				{
-					var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{manifestFilename}"));
+					var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{WasmAppManifestFilename}"));
 					manifestString = await FileIO.ReadTextAsync(storageFile);
 				}
 				catch
 				{
 					var entry = Assembly.GetEntryAssembly();
-					var res = entry?.GetManifestResourceNames()?.FirstOrDefault(x => x.ToLower().Contains(manifestFilename));
+					var res = entry?.GetManifestResourceNames()?.FirstOrDefault(x => x.ToLower().Contains(WasmAppManifestFilename));
 					if (string.IsNullOrWhiteSpace(res))
 					{
 						return null;
@@ -225,22 +228,9 @@ namespace Uno.Toolkit.UI
 		{
 			try
 			{
-				var manifestFilename = "AppxManifest.xml";
-				XDocument? doc = default;
-				try
-				{
-					var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{manifestFilename}"));
-					doc = XDocument.Load(storageFile.Path, LoadOptions.None);
-				}
-				catch
-				{
-					var entry = Assembly.GetEntryAssembly();
-					var packageStream = entry?.GetManifestResourceStream($"{entry?.GetName().Name}.Package.appxmanifest");
-					if (packageStream is not null)
-					{
-						doc = XDocument.Load(packageStream, LoadOptions.None);
-					}
-				}
+				var entry = Assembly.GetEntryAssembly();
+				var doc = await LoadAppManifest(entry, AppxManifestFilename, PackageAppxManifestFileName);
+
 				if (doc is null)
 				{
 					return null;
@@ -272,6 +262,101 @@ namespace Uno.Toolkit.UI
 			}
 
 			return null;
+		}
+
+		private static async Task<XDocument?> LoadAppManifest(Assembly? entry, params string[] manifestFiles)
+		{
+			foreach (var file in manifestFiles)
+			{
+				var doc = await LoadManifestFromPackageFile(entry, file);
+				if (doc is not null)
+				{
+					return doc;
+				}
+				doc = LoadManifestFromEmbeddedFile(entry, file);
+				if (doc is not null)
+				{
+					return doc;
+				}
+			}
+			return default;
+		}
+
+		private static async Task<XDocument?> LoadManifestFromPackageFile(Assembly? entry, string manifestFile)
+		{
+			try
+			{
+				typeof(ExtendedSplashScreen).Log().LogTrace($"Attempting to load {manifestFile} from file packaged with application.");
+				var filePath = await ApplicationPathFromFileName(entry, manifestFile);
+				if (!string.IsNullOrWhiteSpace(filePath))
+				{
+					typeof(ExtendedSplashScreen).Log().LogTrace($"Full path to {manifestFile} is {filePath}.");
+					return XDocument.Load(filePath, LoadOptions.None);
+				}
+			}
+			catch (Exception docError)
+			{
+				typeof(ExtendedSplashScreen).Log().LogDebug($"{manifestFile} exists as a packaged file but not able to load to XDocument [{docError}].");
+			}
+
+			return default;
+		}
+
+		private static XDocument? LoadManifestFromEmbeddedFile(Assembly? entry, string manifestFile)
+		{
+			typeof(ExtendedSplashScreen).Log().LogTrace($"Attempting to load {manifestFile} from embedded resource within the {entry?.GetName().Name} assembly.");
+			// Check EndsWith because the file may have a prefix based on the project and folder the file was sourced from
+			var res = entry?.GetManifestResourceNames()?.FirstOrDefault(x => x.ToLower().EndsWith(manifestFile));
+			if (res is not null &&
+				!string.IsNullOrWhiteSpace(res))
+			{
+				var packageStream = entry!.GetManifestResourceStream(res);
+
+				if (packageStream is not null)
+				{
+					try
+					{
+						return XDocument.Load(packageStream, LoadOptions.None);
+					}
+					catch (Exception docError)
+					{
+						typeof(ExtendedSplashScreen).Log().LogTrace($"{manifestFile} exists as an embedded resource but not able to load to XDocument [{docError}].");
+					}
+				}
+			}
+
+			return default;
+		}
+
+		private static async Task<string> ApplicationPathFromFileName(Assembly? entry, string fileName)
+		{
+			// Note: We attempt to resolve based on the assembly first because it doesn't throw an exception if the file doesn't exist
+			// whereas StorageFile.GetFileFromApplicationUriAsync will throw an exception if the file doesn't exist.
+			var filePath = string.Empty;
+			var codebase = entry?.GetName().CodeBase;
+			if (codebase is not null)
+			{
+				var manifestPath = Path.Combine(Path.GetDirectoryName(codebase) ?? string.Empty, fileName);
+				if (File.Exists(manifestPath))
+				{
+					filePath = manifestPath;
+				}
+			}
+
+			if (string.IsNullOrWhiteSpace(filePath))
+			{
+				try
+				{
+					var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{fileName}"));
+					filePath = storageFile.Path;
+				}
+				catch
+				{
+					typeof(ExtendedSplashScreen).Log().LogTrace($"Unable to load application StorageFile for {fileName}.");
+				}
+			}
+
+			return filePath;
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #563

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Doesn't load from file system when unpackaged WinUI

## What is the new behavior?

manifest file loaded from file system as fall back from applicationdata

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
