### PR TITLE
docs: fix broken link

### DIFF
--- a/doc/controls-styles.md
+++ b/doc/controls-styles.md
@@ -4,25 +4,25 @@ uid: Toolkit.ControlsHelpersStyles
 # Uno Toolkit Controls
 The `Uno.Toolkit.UI` library adds the following controls:
 - `AutoLayout`: A custom panel used by the [Figma plugin](https://platform.uno/unofigma/) to bridge the gap between Figma and UWP layout implementation.
-- [`Card` and `CardContentControl`](controls\CardAndCardContentControl.md): \[Material control\] Cards contain content and actions that relate information about a subject.
-- [`Chip` and `ChipGroup`](controls\ChipAndChipGroup.md): \[Material control\] Chips are compact elements that represent an input, attribute, or action.
+- [`Card` and `CardContentControl`](controls/CardAndCardContentControl.md): \[Material control\] Cards contain content and actions that relate information about a subject.
+- [`Chip` and `ChipGroup`](controls/ChipAndChipGroup.md): \[Material control\] Chips are compact elements that represent an input, attribute, or action.
 - `Divider`: \[Material control\] A divider is a thin line that groups content in lists and layouts.
-- [`DrawerControl`](controls\DrawerControl.md): A container to display additional content, in a hidden pane that can be revealed using a swipe gesture, like a drawer.
-- [`DrawerFlyoutPresenter`](controls\DrawerFlyoutPresenter.md): A specialized `ContentPresenter` to be used in the template of a `FlyoutPresenter` to enable gesture support.
-- [`LoadingView`](controls\LoadingView.md): A control that indicates that the UI is waiting on a task to complete.
-- [`TabBar` and `TabBarItem`](controls\TabBarAndTabBarItem.md): A list of selectable items that can be used to facilitate lateral navigation within an application.
-- [`NavigationBar`](controls\NavigationBar.md): A custom control that helps implement navigation logic for your application.
+- [`DrawerControl`](controls/DrawerControl.md): A container to display additional content, in a hidden pane that can be revealed using a swipe gesture, like a drawer.
+- [`DrawerFlyoutPresenter`](controls/DrawerFlyoutPresenter.md): A specialized `ContentPresenter` to be used in the template of a `FlyoutPresenter` to enable gesture support.
+- [`LoadingView`](controls/LoadingView.md): A control that indicates that the UI is waiting on a task to complete.
+- [`TabBar` and `TabBarItem`](controls/TabBarAndTabBarItem.md): A list of selectable items that can be used to facilitate lateral navigation within an application.
+- [`NavigationBar`](controls/NavigationBar.md): A custom control that helps implement navigation logic for your application.
 
 ## Helpers
 The `Uno.Toolkit.UI` library adds the following helper classes:
 - `SystemThemeHelper`: Provides a set of helper methods to check the current operating system theme, and manipulate the application dark/light theme.
-- [`AncestorBinding` and `ItemsControlBinding`](helpers\ancestor-itemscontrol-binding.md): These markup extensions provides relative binding based on ancestor type. If you are familiar with WPF, they are very similar to `{RelativeSource Mode=FindAncestor}`.
-- [`CommandExtensions`](helpers\command-extensions.md): Provides Command/CommandParameter attached properties for common scenarios.
-- [`InputExtensions`](helpers\input-extensions.md): Provides various attached properties for _input controls_, such as `TextBox` and `PasswordBox`.
-- [`ItemsRepeaterExtensions`](helpers\itemsrepeater-extensions.md): Provides selection support for ItemsRepeater.
-- [`StatusBar`](helpers\StatusBar-extensions.md): Provides two attached properties on `Page` to controls the visual of the status bar on mobile platforms.
-- [`TabBarItemExtensions`](helpers\TabBarItem-extensions.md): Provides additional features for `TabBarItem`.
-- [`VisualStateManagerExtensions`](helpers\VisualStateManager-extensions.md): Provides a way of manipulating the visual states of Control with attached property.
+- [`AncestorBinding` and `ItemsControlBinding`](helpers/ancestor-itemscontrol-binding.md): These markup extensions provides relative binding based on ancestor type. If you are familiar with WPF, they are very similar to `{RelativeSource Mode=FindAncestor}`.
+- [`CommandExtensions`](helpers/command-extensions.md): Provides Command/CommandParameter attached properties for common scenarios.
+- [`InputExtensions`](helpers/input-extensions.md): Provides various attached properties for _input controls_, such as `TextBox` and `PasswordBox`.
+- [`ItemsRepeaterExtensions`](helpers/itemsrepeater-extensions.md): Provides selection support for ItemsRepeater.
+- [`StatusBar`](helpers/StatusBar-extensions.md): Provides two attached properties on `Page` to controls the visual of the status bar on mobile platforms.
+- [`TabBarItemExtensions`](helpers/TabBarItem-extensions.md): Provides additional features for `TabBarItem`.
+- [`VisualStateManagerExtensions`](helpers/VisualStateManager-extensions.md): Provides a way of manipulating the visual states of Control with attached property.
 
 
 Exposes visual states as attachable properties that lets you bind a string on a `Control` to set its `VisualState`s.


### PR DESCRIPTION
GitHub Issue (If applicable): closes #456

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Documentation content changes

## What is the new behavior?
fixed broken links in `doc\controls-styles.md` page

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.