### PR TITLE
fix: align CardContentControl with material guidance

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardContentControlSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CardContentControlSamplePage.xaml
@@ -27,7 +27,7 @@
 										<RowDefinition Height="Auto" />
 									</Grid.RowDefinitions>
 
-									<!--  Media part  -->
+									<!-- Media part -->
 									<Image Source="ms-appx:///Assets/Media/LargeMedia.png"
 										   Stretch="Uniform"
 										   MaxHeight="194" />
@@ -35,22 +35,22 @@
 									<StackPanel Grid.Row="1"
 												Margin="16,14">
 
-										<!--  Header part  -->
+										<!-- Header part -->
 										<TextBlock Text="Elevated card"
 												   MaxLines="1"
 												   Style="{StaticResource MaterialHeadline6}" />
 
-										<!--  SubHeader part  -->
+										<!-- SubHeader part -->
 										<TextBlock Text="With media, supporting text and action buttons"
 												   Margin="0,4,0,12"
 												   MaxLines="2"
 												   Style="{StaticResource MaterialSubtitle1}" />
 
-										<!--  Supporting content part  -->
+										<!-- Supporting content part -->
 										<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."
 												   Style="{StaticResource MaterialBody2}" />
 
-										<!--  Action buttons part  -->
+										<!-- Action buttons part -->
 										<StackPanel Margin="0,12,0,0"
 													Spacing="6"
 													Orientation="Horizontal">
@@ -81,7 +81,7 @@
 										<RowDefinition Height="Auto" />
 									</Grid.RowDefinitions>
 
-									<!--  Media part  -->
+									<!-- Media part -->
 									<Image Source="ms-appx:///Assets/Media/LargeMedia.png"
 										   Stretch="Uniform"
 										   MaxHeight="194" />
@@ -89,22 +89,22 @@
 									<StackPanel Grid.Row="1"
 												Margin="16,14">
 
-										<!--  Header part  -->
+										<!-- Header part -->
 										<TextBlock Text="Elevated card"
 												   MaxLines="1"
 												   Style="{StaticResource MaterialHeadline6}" />
 
-										<!--  SubHeader part  -->
+										<!-- SubHeader part -->
 										<TextBlock Text="With media, supporting text and action buttons"
 												   Margin="0,4,0,12"
 												   MaxLines="2"
 												   Style="{StaticResource MaterialSubtitle1}" />
 
-										<!--  Supporting content part  -->
+										<!-- Supporting content part -->
 										<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."
 												   Style="{StaticResource MaterialBody2}" />
 
-										<!--  Action buttons part  -->
+										<!-- Action buttons part -->
 										<StackPanel Margin="0,12,0,0"
 													Spacing="6"
 													Orientation="Horizontal">
@@ -125,14 +125,15 @@
 			</DataTemplate>
 		</sample:SamplePageLayout.MaterialTemplate>
 		<sample:SamplePageLayout.M3MaterialTemplate>
-		<DataTemplate>
+			<DataTemplate>
 				<StackPanel Padding="0,20"
 							Spacing="20">
 					<!-- Material M3 Outlined CardContentControl Style -->
 					<TextBlock Text="Outlined CardContentControl Style"
 							   Style="{StaticResource TitleLarge}" />
 
-					<utu:CardContentControl Style="{StaticResource OutlinedCardContentControlStyle}">
+					<utu:CardContentControl MaxWidth="400"
+											Style="{StaticResource OutlinedCardContentControlStyle}">
 						<utu:CardContentControl.ContentTemplate>
 							<DataTemplate>
 								<Grid>
@@ -141,32 +142,31 @@
 										<RowDefinition Height="Auto" />
 									</Grid.RowDefinitions>
 
-									<!--  Media part  -->
+									<!-- Media part -->
 									<Image Source="ms-appx:///Assets/Media/LargeMedia.png"
-										   Stretch="Uniform"
-										   MaxHeight="194" />
+										   Stretch="Uniform" />
 
 									<StackPanel Grid.Row="1"
 												Margin="16">
 
-										<!--  Header part  -->
+										<!-- Header part -->
 										<TextBlock Text="Outlined card"
 												   MaxLines="1"
 												   Style="{StaticResource TitleMedium}" />
 
-										<!--  SubHeader part  -->
+										<!-- SubHeader part -->
 										<TextBlock Text="With media, supporting text and action buttons"
 												   MaxLines="2"
 												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
 												   Style="{StaticResource LabelSmall}" />
 
-										<!--  Supporting content part  -->
+										<!-- Supporting content part -->
 										<TextBlock Margin="0,16"
 												   Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."
 												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
-						   						   Style="{ThemeResource BodyMedium}" />
+												   Style="{ThemeResource BodyMedium}" />
 
-										<!--  Action buttons part  -->
+										<!-- Action buttons part -->
 										<StackPanel Spacing="8"
 													Orientation="Horizontal">
 											<Button Content="ACTION 1"
@@ -185,7 +185,9 @@
 					<TextBlock Text="Filled CardContentControl Style"
 							   Style="{StaticResource TitleLarge}" />
 
-					<utu:CardContentControl Style="{StaticResource FilledCardContentControlStyle}">
+
+					<utu:CardContentControl MaxWidth="400"
+											Style="{StaticResource FilledCardContentControlStyle}">
 						<utu:CardContentControl.ContentTemplate>
 							<DataTemplate>
 								<Grid>
@@ -194,32 +196,32 @@
 										<RowDefinition Height="Auto" />
 									</Grid.RowDefinitions>
 
-									<!--  Media part  -->
+									<!-- Media part -->
 									<Image Source="ms-appx:///Assets/Media/LargeMedia.png"
-										   Stretch="Uniform"
-										   MaxHeight="194" />
+										   Stretch="Uniform" />
 
 									<StackPanel Grid.Row="1"
 												Margin="16">
 
-										<!--  Header part  -->
+										<!-- Header part -->
 										<TextBlock Text="Filled card"
 												   MaxLines="1"
 												   Style="{StaticResource TitleMedium}" />
 
-										<!--  SubHeader part  -->
+										<!-- SubHeader part -->
 										<TextBlock Text="With media, supporting text and action buttons"
 												   MaxLines="2"
 												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
 												   Style="{StaticResource LabelSmall}" />
 
-										<!--  Supporting content part  -->
+										<!-- Supporting content part -->
 										<TextBlock Margin="0,16"
+												   TextWrapping="WrapWholeWords"
 												   Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."
 												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
-						   						   Style="{ThemeResource BodyMedium}" />
+												   Style="{ThemeResource BodyMedium}" />
 
-										<!--  Action buttons part  -->
+										<!-- Action buttons part -->
 										<StackPanel Spacing="8"
 													Orientation="Horizontal">
 											<Button Content="ACTION 1"
@@ -238,7 +240,8 @@
 					<TextBlock Text="Elevated CardContentControl Style"
 							   Style="{StaticResource TitleLarge}" />
 
-					<utu:CardContentControl Style="{StaticResource ElevatedCardContentControlStyle}">
+					<utu:CardContentControl MaxWidth="400"
+											Style="{StaticResource ElevatedCardContentControlStyle}">
 						<utu:CardContentControl.ContentTemplate>
 							<DataTemplate>
 								<Grid>
@@ -247,32 +250,31 @@
 										<RowDefinition Height="Auto" />
 									</Grid.RowDefinitions>
 
-									<!--  Media part  -->
+									<!-- Media part -->
 									<Image Source="ms-appx:///Assets/Media/LargeMedia.png"
-										   Stretch="Uniform"
-										   MaxHeight="194" />
+										   Stretch="Uniform" />
 
 									<StackPanel Grid.Row="1"
 												Margin="16">
 
-										<!--  Header part  -->
+										<!-- Header part -->
 										<TextBlock Text="Elevated card"
 												   MaxLines="1"
 												   Style="{StaticResource TitleMedium}" />
 
-										<!--  SubHeader part  -->
+										<!-- SubHeader part -->
 										<TextBlock Text="With media, supporting text and action buttons"
 												   MaxLines="2"
 												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
 												   Style="{StaticResource LabelSmall}" />
 
-										<!--  Supporting content part  -->
+										<!-- Supporting content part -->
 										<TextBlock Margin="0,16"
 												   Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."
 												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
-						   						   Style="{ThemeResource BodyMedium}" />
+												   Style="{ThemeResource BodyMedium}" />
 
-										<!--  Action buttons part  -->
+										<!-- Action buttons part -->
 										<StackPanel Spacing="8"
 													Orientation="Horizontal">
 											<Button Content="ACTION 1"

--- a/src/Uno.Toolkit.RuntimeTests/Tests/CardContentControlTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/CardContentControlTests.cs
@@ -38,7 +38,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		public async Task Should_Hug_Content()
 		{
 			var rootGrid = XamlHelper.LoadXaml<Grid>("""
-				<Grid xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Width="500" Height="500">
+				<Grid Width="500" Height="500">
 					<utu:CardContentControl Padding="0" x:Name="MyCard" Style="{StaticResource FilledCardContentControlStyle}">
 						<Grid Background="Red" Height="200" Width="200" />
 					</utu:CardContentControl>
@@ -61,7 +61,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		public async Task Only_Elevated_Has_Margin(string cardStyle)
 		{
 			var rootGrid = XamlHelper.LoadXaml<Grid>($$"""
-				<Grid xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+				<Grid>
 					<utu:CardContentControl Padding="0" x:Name="MyCard" Style="{StaticResource {{cardStyle}}}">
 						<Grid Background="Red" Height="200" Width="200" />
 					</utu:CardContentControl>

--- a/src/Uno.Toolkit.RuntimeTests/Tests/CardContentControlTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/CardContentControlTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Extensions;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+using Uno.UI.Extensions;
+using Windows.Foundation;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation.Metadata;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+#else
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests
+{
+	[TestClass]
+	[RunsOnUIThread]
+	internal class CardContentControlTests
+	{
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task Should_Hug_Content()
+		{
+			var rootGrid = XamlHelper.LoadXaml<Grid>("""
+				<Grid xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Width="500" Height="500">
+					<utu:CardContentControl Padding="0" x:Name="MyCard" Style="{StaticResource FilledCardContentControlStyle}">
+						<Grid Background="Red" Height="200" Width="200" />
+					</utu:CardContentControl>
+				</Grid>
+			""");
+
+
+			var card = (CardContentControl)rootGrid.FindName("MyCard");
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(rootGrid);
+
+			Assert.AreEqual(200d, card.ActualWidth);
+			Assert.AreEqual(200d, card.ActualHeight);
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		[DataRow("FilledCardContentControlStyle")]
+		[DataRow("OutlinedCardContentControlStyle")]
+		public async Task Only_Elevated_Has_Margin(string cardStyle)
+		{
+			var rootGrid = XamlHelper.LoadXaml<Grid>($$"""
+				<Grid xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					<utu:CardContentControl Padding="0" x:Name="MyCard" Style="{StaticResource {{cardStyle}}}">
+						<Grid Background="Red" Height="200" Width="200" />
+					</utu:CardContentControl>
+				</Grid>
+			""");
+
+			var card = (CardContentControl)rootGrid.FindName("MyCard");
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(rootGrid);
+
+			Assert.AreEqual(default, card.Margin);
+		}
+	}
+}

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/CardContentControl.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/CardContentControl.xaml
@@ -1,335 +1,306 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                      xmlns:um="using:Uno.Material"
-                                      xmlns:utu="using:Uno.Toolkit.UI"
-                                      xmlns:toolkit="using:Uno.UI.Toolkit">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:um="using:Uno.Material"
+					xmlns:utu="using:Uno.Toolkit.UI"
+					xmlns:toolkit="using:Uno.UI.Toolkit">
 
-    <!--  CardContentControl Base Style  -->
-    <Style x:Key="MaterialBaseCardContentControlStyle"
-           TargetType="utu:CardContentControl">
-        <Setter Property="MinHeight"
-                Value="{StaticResource MaterialCardMinHeight}" />
-        <Setter Property="MaxWidth"
-                Value="{StaticResource MaterialCardMaxWidth}" />
-        <Setter Property="Margin"
-                Value="{StaticResource MaterialCardElevationMargin}" />
-        <Setter Property="CornerRadius"
-                Value="{StaticResource MaterialCardCornerRadius}" />
-        <Setter Property="HorizontalAlignment"
-                Value="Stretch" />
-        <Setter Property="HorizontalContentAlignment"
-                Value="Stretch" />
-        <Setter Property="VerticalAlignment"
-                Value="Stretch" />
-        <Setter Property="VerticalContentAlignment"
-                Value="Stretch" />
-    </Style>
+	<!-- CardContentControl Base Style -->
+	<Style x:Key="MaterialBaseCardContentControlStyle"
+		   TargetType="utu:CardContentControl">
+		<Setter Property="CornerRadius" Value="{StaticResource MaterialCardCornerRadius}" />
+		<Setter Property="HorizontalAlignment" Value="Center" />
+		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
+		<Setter Property="VerticalAlignment" Value="Center" />
+		<Setter Property="VerticalContentAlignment" Value="Stretch" />
+	</Style>
 
-        <!-- Filled -->
-    <Style x:Key="MaterialFilledCardContentControlStyle"
-           BasedOn="{StaticResource MaterialBaseCardContentControlStyle}"
-           TargetType="utu:CardContentControl">
-        <Setter Property="Background"
-                Value="{StaticResource MaterialFilledCardBackground}" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="utu:CardContentControl">
-                    <Grid x:Name="GridRoot"
-                          MinWidth="{TemplateBinding MinWidth}"
-                          MinHeight="{TemplateBinding MinHeight}"
-                          MaxWidth="{TemplateBinding MaxWidth}"
-                          MaxHeight="{TemplateBinding MaxHeight}"
-                          Background="{TemplateBinding Background}"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          CornerRadius="{TemplateBinding CornerRadius}"
-                          BorderThickness="{TemplateBinding BorderThickness}"
-                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal">
-                                    <VisualState.Setters>
-                                        <Setter Target="HoverOverlay.Opacity"
-                                                Value="0" />
-                                        <Setter Target="FocusedOverlay.Opacity"
-                                                Value="0" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="PointerOver">
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="HoverOverlay"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         Duration="{StaticResource MaterialDelayedBeginTime}"
-                                                         From="0"
-                                                         To="1">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseIn" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                    </Storyboard>
-                                </VisualState>
+	<!-- Filled -->
+	<Style x:Key="MaterialFilledCardContentControlStyle"
+		   BasedOn="{StaticResource MaterialBaseCardContentControlStyle}"
+		   TargetType="utu:CardContentControl">
+		<Setter Property="Background" Value="{StaticResource MaterialFilledCardBackground}" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:CardContentControl">
+					<Grid x:Name="GridRoot"
+						  MinWidth="{TemplateBinding MinWidth}"
+						  MinHeight="{TemplateBinding MinHeight}"
+						  MaxWidth="{TemplateBinding MaxWidth}"
+						  MaxHeight="{TemplateBinding MaxHeight}"
+						  Background="{TemplateBinding Background}"
+						  BorderBrush="{TemplateBinding BorderBrush}"
+						  CornerRadius="{TemplateBinding CornerRadius}"
+						  BorderThickness="{TemplateBinding BorderThickness}"
+						  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+						  VerticalAlignment="{TemplateBinding VerticalAlignment}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity" Value="0" />
+										<Setter Target="FocusedOverlay.Opacity" Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialDelayedBeginTime}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
 
-                                <VisualState x:Name="Pressed">
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="HoverPressed"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         Duration="{StaticResource MaterialDelayedBeginTime}"
-                                                         From="0"
-                                                         To="1">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseIn" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverPressed"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialDelayedBeginTime}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
 
-                                        <DoubleAnimation Storyboard.TargetName="HoverOverlay"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         Duration="{StaticResource MaterialDelayedBeginTime}"
-                                                         To="0">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseIn" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialDelayedBeginTime}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
 
-                                        <DoubleAnimation Storyboard.TargetName="FocusedOverlay"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         Duration="{StaticResource MaterialDelayedBeginTime}"
-                                                         To="0">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseIn" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                    </Storyboard>
-                                </VisualState>
+										<DoubleAnimation Storyboard.TargetName="FocusedOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialDelayedBeginTime}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
 
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="HoverOverlay.Opacity"
-                                                Value="0" />
-                                        <Setter Target="FocusedOverlay.Opacity"
-                                                Value="0" />
-                                        <Setter Target="GridRoot.Opacity"
-                                                Value="0.38" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="FocusStates">
-                                <VisualState x:Name="Focused">
-                                    <VisualState.Setters>
-                                        <Setter Target="FocusedOverlay.Opacity"
-                                                Value="1" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="PointerFocused" />
-                                <VisualState x:Name="Unfocused">
-                                    <VisualState.Setters>
-                                        <Setter Target="FocusedOverlay.Opacity"
-                                                Value="0" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity" Value="0" />
+										<Setter Target="FocusedOverlay.Opacity" Value="0" />
+										<Setter Target="GridRoot.Opacity" Value="0.38" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity" Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerFocused" />
+								<VisualState x:Name="Unfocused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity" Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
 
-                        <!--  Ripple effect  -->
-                        <!-- Will add the ripple effect later on when this issue is taken care of: -->
-                        <!-- https://github.com/unoplatform/uno.ui.toolkit/issues/88 -->
-                        <!--<um:Ripple Feedback="{ThemeResource OnSurfaceFocusedBrush}"
+						<!-- Ripple effect -->
+						<!-- Will add the ripple effect later on when this issue is taken care of: -->
+						<!-- https://github.com/unoplatform/uno.ui.toolkit/issues/88 -->
+						<!--<um:Ripple Feedback="{ThemeResource OnSurfaceFocusedBrush}"
 										 BorderBrush="{TemplateBinding BorderBrush}"
 										 BorderThickness="{TemplateBinding BorderThickness}"
 										 CornerRadius="{StaticResource MaterialCardCornerRadius}"
 										 Padding="{TemplateBinding Padding}"
 										 AutomationProperties.AccessibilityView="Raw" />-->
 
-                        <!--  Main ContentPresenter  -->
-                        <ContentPresenter x:Name="ContentPresenter"
-                                          Padding="{TemplateBinding Padding}"
-                                          Content="{TemplateBinding Content}"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          AutomationProperties.AccessibilityView="Raw" />
+						<!-- Main ContentPresenter -->
+						<ContentPresenter x:Name="ContentPresenter"
+										  Padding="{TemplateBinding Padding}"
+										  Content="{TemplateBinding Content}"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw" />
 
-                        <!--  Border for Pressed State  -->
-                        <Border x:Name="HoverPressed"
-                                Background="{ThemeResource OnSurfacePressedBrush}"
-                                IsHitTestVisible="False"
-                                Opacity="0" />
+						<!-- Border for Pressed State -->
+						<Border x:Name="HoverPressed"
+								Background="{ThemeResource OnSurfacePressedBrush}"
+								IsHitTestVisible="False"
+								Opacity="0" />
 
-                        <!--  Border for PointerOver State  -->
-                        <Border x:Name="HoverOverlay"
-                                Background="{ThemeResource OnSurfaceHoverBrush}"
-                                IsHitTestVisible="False"
-                                Opacity="0" />
+						<!-- Border for PointerOver State -->
+						<Border x:Name="HoverOverlay"
+								Background="{ThemeResource OnSurfaceHoverBrush}"
+								IsHitTestVisible="False"
+								Opacity="0" />
 
-                        <!--  Border for Focused State  -->
-                        <Border x:Name="FocusedOverlay"
-                                Background="{ThemeResource OnSurfaceFocusedBrush}"
-                                IsHitTestVisible="False"
-                                Opacity="0" />
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+						<!-- Border for Focused State -->
+						<Border x:Name="FocusedOverlay"
+								Background="{ThemeResource OnSurfaceFocusedBrush}"
+								IsHitTestVisible="False"
+								Opacity="0" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
 
-    <!-- Outlined -->
-    <Style x:Key="MaterialOutlinedCardContentControlStyle"
-           BasedOn="{StaticResource MaterialFilledCardContentControlStyle}"
-           TargetType="utu:CardContentControl">
-        <Setter Property="Background"
-                Value="{StaticResource MaterialOutlinedCardBackground}" />
-        <Setter Property="BorderBrush"
-                Value="{ThemeResource MaterialOutlinedCardBorderBrush}" />
-        <Setter Property="BorderThickness"
-                Value="{StaticResource MaterialCardBorderThickness}" />
-    </Style>
+	<!-- Outlined -->
+	<Style x:Key="MaterialOutlinedCardContentControlStyle"
+		   BasedOn="{StaticResource MaterialFilledCardContentControlStyle}"
+		   TargetType="utu:CardContentControl">
+		<Setter Property="Background" Value="{StaticResource MaterialOutlinedCardBackground}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource MaterialOutlinedCardBorderBrush}" />
+		<Setter Property="BorderThickness" Value="{StaticResource MaterialCardBorderThickness}" />
+	</Style>
 
-    <!-- Elevated -->
-    <Style x:Key="MaterialElevatedCardContentControlStyle"
-           BasedOn="{StaticResource MaterialBaseCardContentControlStyle}"
-           TargetType="utu:CardContentControl">
-        <Setter Property="Background"
-                Value="{StaticResource MaterialElevatedCardBackground}" />
-        <Setter Property="Elevation"
-                Value="{StaticResource MaterialCardElevation}" />
+	<!-- Elevated -->
+	<Style x:Key="MaterialElevatedCardContentControlStyle"
+		   BasedOn="{StaticResource MaterialBaseCardContentControlStyle}"
+		   TargetType="utu:CardContentControl">
+		<Setter Property="Background" Value="{StaticResource MaterialElevatedCardBackground}" />
+		<Setter Property="Elevation" Value="{StaticResource MaterialCardElevation}" />
 
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="utu:CardContentControl">
-                    <!--  Elevated View  -->
-                    <toolkit:ElevatedView x:Name="ElevatedRoot"
-                                          MinWidth="{TemplateBinding MinWidth}"
-                                          MinHeight="{TemplateBinding MinHeight}"
-                                          MaxWidth="{TemplateBinding MaxWidth}"
-                                          MaxHeight="{TemplateBinding MaxHeight}"
-                                          Background="{TemplateBinding Background}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                                          CornerRadius="{TemplateBinding CornerRadius}"
-                                          Elevation="{TemplateBinding Elevation}"
-                                          ShadowColor="{TemplateBinding ShadowColor}">
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal">
-                                    <VisualState.Setters>
-                                        <Setter Target="HoverOverlay.Opacity"
-                                                Value="0" />
-                                        <Setter Target="FocusedOverlay.Opacity"
-                                                Value="0" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="PointerOver">
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="HoverOverlay"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         Duration="{StaticResource MaterialDelayedBeginTime}"
-                                                         From="0"
-                                                         To="1">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseIn" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Pressed">
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="HoverPressed"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         Duration="{StaticResource MaterialDelayedBeginTime}"
-                                                         From="0"
-                                                         To="1">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseIn" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:CardContentControl">
+					<!-- Elevated View -->
+					<toolkit:ElevatedView x:Name="ElevatedRoot"
+										  MinWidth="{TemplateBinding MinWidth}"
+										  MinHeight="{TemplateBinding MinHeight}"
+										  MaxWidth="{TemplateBinding MaxWidth}"
+										  MaxHeight="{TemplateBinding MaxHeight}"
+										  Background="{TemplateBinding Background}"
+										  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalAlignment}"
+										  CornerRadius="{TemplateBinding CornerRadius}"
+										  Elevation="{TemplateBinding Elevation}"
+										  Margin="{StaticResource MaterialCardElevationMargin}"
+										  ShadowColor="{TemplateBinding ShadowColor}">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity" Value="0" />
+										<Setter Target="FocusedOverlay.Opacity" Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialDelayedBeginTime}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="HoverPressed"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialDelayedBeginTime}"
+														 From="0"
+														 To="1">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
 
-                                        <DoubleAnimation Storyboard.TargetName="HoverOverlay"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         Duration="{StaticResource MaterialDelayedBeginTime}"
-                                                         To="0">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseIn" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
+										<DoubleAnimation Storyboard.TargetName="HoverOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialDelayedBeginTime}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
 
-                                        <DoubleAnimation Storyboard.TargetName="FocusedOverlay"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         Duration="{StaticResource MaterialDelayedBeginTime}"
-                                                         To="0">
-                                            <DoubleAnimation.EasingFunction>
-                                                <CubicEase EasingMode="EaseIn" />
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="HoverOverlay.Opacity"
-                                                Value="0" />
-                                        <Setter Target="FocusedOverlay.Opacity"
-                                                Value="0" />
-                                        <Setter Target="GridRoot.Opacity"
-                                                Value="0.38" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="FocusStates">
-                                <VisualState x:Name="Focused">
-                                    <VisualState.Setters>
-                                        <Setter Target="FocusedOverlay.Opacity"
-                                                Value="1" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="PointerFocused" />
-                                <VisualState x:Name="Unfocused">
-                                    <VisualState.Setters>
-                                        <Setter Target="FocusedOverlay.Opacity"
-                                                Value="0" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
+										<DoubleAnimation Storyboard.TargetName="FocusedOverlay"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="{StaticResource MaterialDelayedBeginTime}"
+														 To="0">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseIn" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="HoverOverlay.Opacity" Value="0" />
+										<Setter Target="FocusedOverlay.Opacity" Value="0" />
+										<Setter Target="GridRoot.Opacity" Value="0.38" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity" Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="PointerFocused" />
+								<VisualState x:Name="Unfocused">
+									<VisualState.Setters>
+										<Setter Target="FocusedOverlay.Opacity" Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
 
-                        <Grid x:Name="GridRoot"
-                              CornerRadius="{TemplateBinding CornerRadius}">
+						<Grid x:Name="GridRoot"
+							  CornerRadius="{TemplateBinding CornerRadius}">
 
-                            <!--  Ripple effect  -->
-                            <!-- Will add the ripple effect later on when this issue is taken care of: -->
-                            <!-- https://github.com/unoplatform/uno.ui.toolkit/issues/88 -->
-                            <!--<um:Ripple Feedback="{ThemeResource OnSurfaceFocusedBrush}"
+							<!-- Ripple effect -->
+							<!-- Will add the ripple effect later on when this issue is taken care of: -->
+							<!-- https://github.com/unoplatform/uno.ui.toolkit/issues/88 -->
+							<!--<um:Ripple Feedback="{ThemeResource OnSurfaceFocusedBrush}"
 											 CornerRadius="{StaticResource MaterialCardCornerRadius}"
 											 Padding="{TemplateBinding Padding}"
 											 AutomationProperties.AccessibilityView="Raw" />-->
 
-                            <!--  Main ContentPresenter  -->
-                            <ContentPresenter x:Name="ContentPresenter"
-                                              Padding="{TemplateBinding Padding}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              AutomationProperties.AccessibilityView="Raw" />
+							<!-- Main ContentPresenter -->
+							<ContentPresenter x:Name="ContentPresenter"
+											  Padding="{TemplateBinding Padding}"
+											  Content="{TemplateBinding Content}"
+											  ContentTemplate="{TemplateBinding ContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  AutomationProperties.AccessibilityView="Raw" />
 
-                            <!--  Border for Pressed State  -->
-                            <Border x:Name="HoverPressed"
-                                    Background="{ThemeResource OnSurfacePressedBrush}"
-                                    IsHitTestVisible="False"
-                                    Opacity="0" />
+							<!-- Border for Pressed State -->
+							<Border x:Name="HoverPressed"
+									Background="{ThemeResource OnSurfacePressedBrush}"
+									IsHitTestVisible="False"
+									Opacity="0" />
 
-                            <!--  Border for PointerOver State  -->
-                            <Border x:Name="HoverOverlay"
-                                    Background="{ThemeResource OnSurfaceHoverBrush}"
-                                    IsHitTestVisible="False"
-                                    Opacity="0" />
+							<!-- Border for PointerOver State -->
+							<Border x:Name="HoverOverlay"
+									Background="{ThemeResource OnSurfaceHoverBrush}"
+									IsHitTestVisible="False"
+									Opacity="0" />
 
-                            <!--  Border for Focused State  -->
-                            <Border x:Name="FocusedOverlay"
-                                    Background="{ThemeResource OnSurfaceFocusedBrush}"
-                                    IsHitTestVisible="False"
-                                    Opacity="0" />
-                        </Grid>
-                    </toolkit:ElevatedView>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+							<!-- Border for Focused State -->
+							<Border x:Name="FocusedOverlay"
+									Background="{ThemeResource OnSurfaceFocusedBrush}"
+									IsHitTestVisible="False"
+									Opacity="0" />
+						</Grid>
+					</toolkit:ElevatedView>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.Figma/issues/675
closes https://github.com/unoplatform/Uno.Figma/issues/1226
closes https://github.com/unoplatform/Uno.Figma/issues/1443
closes https://github.com/unoplatform/Uno.Figma/issues/1401

Aligning CardContentControl with Material Guidance


## PR Type

What kind of change does this PR introduce?

- Bugfix
