### PR TITLE
fix(test): XamlHelper unable to process xmlns'd attribute

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Helpers/XamlHelper.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Helpers/XamlHelper.cs
@@ -52,7 +52,9 @@ namespace Uno.Toolkit.RuntimeTests.Helpers
 				{
 					var match = xmlns.Key == string.Empty
 						? NonXmlnsTagRegex.IsMatch(xaml)
-						: xaml.Contains($"<{xmlns.Key}:");
+						// naively match the xmlns-prefix regardless if it is quoted,
+						// since false positive doesn't matter.
+						: xaml.Contains($"{xmlns.Key}:");
 					if (match)
 					{
 						xmlnses.Add(xmlns.Key, xmlns.Value);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #572

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
XamlHelper fails to parse input with xmlns'd attribute, like: `<Border x:Name="asd" />`

## What is the new behavior?
^ no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.