### PR TITLE
fix: Fixes Material Card themed backgrounds

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Card.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Card.xaml
@@ -3,24 +3,46 @@
                     xmlns:utu="using:Uno.Toolkit.UI"
                     xmlns:um="using:Uno.Material"
                     xmlns:toolkit="using:Uno.UI.Toolkit">
+	<ResourceDictionary.ThemeDictionaries>
+		<!-- Card Brushes Theme Resources -->
+		<ResourceDictionary x:Key="Default">
+			<!-- Filled -->
+			<StaticResource x:Key="MaterialFilledCardBackground"
+							ResourceKey="SurfaceBrush" />
 
-    <!-- Card Brushes Resources -->
-    <!-- Elevated -->
-    <StaticResource x:Key="MaterialElevatedCardBackground"
-	                ResourceKey="SurfaceBrush" />
+			<!-- Outlined -->
+			<StaticResource x:Key="MaterialOutlinedCardBackground"
+							ResourceKey="SurfaceBrush" />
 
-    <!-- Filled -->
-    <StaticResource x:Key="MaterialFilledCardBackground"
-	                ResourceKey="SurfaceVariantBrush" />
-    
-    <!-- Outlined -->
-    <StaticResource x:Key="MaterialOutlinedCardBackground"
-	                ResourceKey="SurfaceBrush" />
-    <StaticResource x:Key="MaterialOutlinedCardBorderBrush"
-	                ResourceKey="OutlineBrush" />
+			<!-- Elevated -->
+			<StaticResource x:Key="MaterialElevatedCardBackground"
+							ResourceKey="SurfaceBrush" />
 
-    <!--  Card Other Resources  -->
-    <!-- Double -->
+			<!--  Card Other Resources  -->
+			<StaticResource x:Key="MaterialOutlinedCardBorderBrush"
+							ResourceKey="OutlineBrush" />
+		</ResourceDictionary>
+
+		<ResourceDictionary x:Key="Light">
+			<!-- Filled -->
+			<StaticResource x:Key="MaterialFilledCardBackground"
+							ResourceKey="SurfaceBrush" />
+
+			<!-- Outlined -->
+			<StaticResource x:Key="MaterialOutlinedCardBackground"
+							ResourceKey="SurfaceBrush" />
+
+			<!-- Elevated -->
+			<StaticResource x:Key="MaterialElevatedCardBackground"
+							ResourceKey="SurfaceBrush" />
+
+			<!--  Card Other Resources  -->
+			<StaticResource x:Key="MaterialOutlinedCardBorderBrush"
+							ResourceKey="OutlineBrush" />
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+
+	<!-- Double -->
     <x:Double x:Key="MaterialCardMinHeight">72</x:Double>
     <x:Double x:Key="MaterialCardMaxWidth">344</x:Double>
 
@@ -154,7 +176,7 @@
            TargetType="utu:Card"
            BasedOn="{StaticResource MaterialBaseCardStyle}">
         <Setter Property="Background"
-                Value="{StaticResource MaterialFilledCardBackground}" />
+                Value="{ThemeResource MaterialFilledCardBackground}" />
         <Setter Property="VerticalAlignment"
                 Value="Stretch" />
         <Setter Property="VerticalContentAlignment"
@@ -337,7 +359,7 @@
            BasedOn="{StaticResource MaterialFilledCardStyle}">
 
         <Setter Property="Background"
-                Value="{StaticResource MaterialOutlinedCardBackground}" />
+                Value="{ThemeResource MaterialOutlinedCardBackground}" />
         <Setter Property="BorderBrush"
                 Value="{ThemeResource MaterialOutlinedCardBorderBrush}" />
         <Setter Property="BorderThickness"
@@ -348,7 +370,7 @@
            BasedOn="{StaticResource MaterialBaseCardStyle}"
            TargetType="utu:Card">
         <Setter Property="Background"
-                Value="{StaticResource MaterialElevatedCardBackground}" />
+                Value="{ThemeResource MaterialElevatedCardBackground}" />
         <Setter Property="VerticalAlignment"
                 Value="Stretch" />
         <Setter Property="VerticalContentAlignment"
@@ -534,7 +556,7 @@
            TargetType="utu:Card">
 
         <Setter Property="Background"
-                Value="{StaticResource MaterialFilledCardBackground}" />
+                Value="{ThemeResource MaterialFilledCardBackground}" />
 
         <Setter Property="Template">
             <Setter.Value>
@@ -733,7 +755,7 @@
            TargetType="utu:Card">
 
         <Setter Property="Background"
-                Value="{StaticResource MaterialOutlinedCardBackground}" />
+                Value="{ThemeResource MaterialOutlinedCardBackground}" />
         <Setter Property="BorderBrush"
                 Value="{ThemeResource MaterialOutlinedCardBorderBrush}" />
         <Setter Property="BorderThickness"
@@ -745,7 +767,7 @@
            TargetType="utu:Card">
 
         <Setter Property="Background"
-                Value="{StaticResource MaterialElevatedCardBackground}" />
+                Value="{ThemeResource MaterialElevatedCardBackground}" />
         <Setter Property="Elevation"
                 Value="{StaticResource MaterialCardElevation}" />
 
@@ -949,7 +971,7 @@
            TargetType="utu:Card">
 
         <Setter Property="Background"
-                Value="{StaticResource MaterialFilledCardBackground}" />
+                Value="{ThemeResource MaterialFilledCardBackground}" />
 
         <Setter Property="Template">
             <Setter.Value>
@@ -1137,7 +1159,7 @@
         <Setter Property="Padding"
                 Value="0" />
         <Setter Property="Background"
-                Value="{StaticResource MaterialOutlinedCardBackground}" />
+                Value="{ThemeResource MaterialOutlinedCardBackground}" />
         <Setter Property="BorderBrush"
                 Value="{ThemeResource MaterialOutlinedCardBorderBrush}" />
         <Setter Property="BorderThickness"
@@ -1149,7 +1171,7 @@
            TargetType="utu:Card">
 
         <Setter Property="Background"
-                Value="{StaticResource MaterialElevatedCardBackground}" />
+                Value="{ThemeResource MaterialElevatedCardBackground}" />
         <Setter Property="Elevation"
                 Value="{StaticResource MaterialCardElevation}" />
 


### PR DESCRIPTION
GitHub Issue (If applicable): [[Gallery]Card- when changing theme Cards are not getting properly refreshed.](https://github.com/unoplatform/uno/issues/12104)


<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] ~~[Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated~~
- [ ] ~~[Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)~~
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
