### PR TITLE
fix: NavBar Icon fixes

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml.Navigation.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml.Navigation.cs
@@ -87,7 +87,7 @@ namespace Uno.Toolkit.Samples
 			AddNavigationItems(nv);
 
 			// landing navigation
-			ShellNavigateTo<RuntimeTestRunner>(
+			ShellNavigateTo<NavigationBarSamplePage>(
 #if WINDOWS_UWP
 				// note: on uwp, NavigationView.SelectedItem MUST be set on launch to avoid entering compact-mode
 				trySynchronizeCurrentItem: true

--- a/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarTests.cs
@@ -244,6 +244,36 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 				};
 			}
 		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		[DataRow(typeof(FontIconPage), DisplayName = nameof(FontIconPage))]
+		[DataRow(typeof(PathIconPage), DisplayName = nameof(PathIconPage))]
+		[DataRow(typeof(SymbolIconPage), DisplayName = nameof(SymbolIconPage))]
+		public async Task NavigationBar_Renders_With_Invalid_AppBarButton_IconElement(Type pageType)
+		{
+			var frame = new Frame { Width = 200, Height = 200 };
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(frame);
+
+			var navBar = await frame.NavigateAndGetNavBar(pageType);
+			AssertNavigationBar(frame);
+		}
+
+
+#if __ANDROID__
+		private static void AssertNavigationBar(Frame frame)
+		{
+			var page = frame.Content as Page;
+			var navBar = page?.FindChild<NavigationBar>();
+
+			var renderedNativeNavBar = navBar.GetNativeNavBar();
+
+			Assert.IsNotNull(renderedNativeNavBar);
+
+			Assert.IsTrue(renderedNativeNavBar!.Height > 0, "Native toolbar height is not greater than 0");
+			Assert.IsTrue(renderedNativeNavBar!.Width > 0, "Native toolbar width is not greater than 0");
+		}
 #endif
 
 #if __IOS__
@@ -372,6 +402,9 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 
 			Assert.AreSame(renderedNativeNavItem, presenter.NavigationController.TopViewController.NavigationItem);
 			Assert.AreSame(renderedNativeNavBar, presenter.NavigationController.NavigationBar);
+
+			Assert.IsTrue(renderedNativeNavBar!.Bounds.Height > 0, "Native toolbar height is not greater than 0");
+			Assert.IsTrue(renderedNativeNavBar!.Bounds.Width > 0, "Native toolbar width is not greater than 0");
 		}
 
 
@@ -428,6 +461,72 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 				Content = PageContent;
 			}
 		}
+
+		private sealed partial class FontIconPage : Page
+		{
+			public FontIconPage()
+			{
+				var navBar = new NavigationBar
+				{
+					Content = "FontIconPage"
+				};
+
+				navBar.PrimaryCommands.Add(
+					new AppBarButton
+					{
+						Icon = new FontIcon
+						{
+							Glyph = "&#xE113;",
+						}
+					}
+				);
+
+				Content = navBar;
+			}
+		}
+
+		private sealed partial class SymbolIconPage : Page
+		{
+			public SymbolIconPage()
+			{
+				var navBar = new NavigationBar
+				{
+					Content = "SymbolIconPage"
+				};
+
+				navBar.PrimaryCommands.Add(
+					new AppBarButton
+					{
+						Icon = new SymbolIcon
+						{
+							Symbol = Symbol.Home,
+						}
+					}
+				);
+
+				Content = navBar;
+			}
+		}
+
+		private sealed partial class PathIconPage : Page
+		{
+			public PathIconPage()
+			{
+				var navBar = new NavigationBar
+				{
+					Content = "PathIconPage"
+				};
+
+				navBar.PrimaryCommands.Add(
+					new AppBarButton
+					{
+						Icon = new PathIcon(),
+					}
+				);
+
+				Content = navBar;
+			}
+		}
 #endif
 	}
 
@@ -442,13 +541,23 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		public static UINavigationItem? GetNativeNavItem(this NavigationBar? navBar) => navBar
 			?.TryGetRenderer<NavigationBar, NavigationBarNavigationItemRenderer>()
 			?.Native;
+
+#elif __ANDROID__
+		public static AndroidX.AppCompat.Widget.Toolbar? GetNativeNavBar(this NavigationBar? navBar) => navBar
+			?.TryGetRenderer<NavigationBar, NavigationBarRenderer>()
+			?.Native;
 #endif
-		public static async Task<NavigationBar?> NavigateAndGetNavBar<TPage>(this Frame frame) where TPage : Page
+		public static Task<NavigationBar?> NavigateAndGetNavBar<TPage>(this Frame frame) where TPage : Page
 		{
-			frame.Navigate(typeof(TPage));
+			return frame.NavigateAndGetNavBar(typeof(TPage));
+		}
+
+		public static async Task<NavigationBar?> NavigateAndGetNavBar(this Frame frame, Type pageType)
+		{
+			frame.Navigate(pageType);
 			await UnitTestsUIContentHelper.WaitForIdle();
 
-			var page = frame.Content as TPage;
+			var page = frame.Content as Page;
 			await UnitTestsUIContentHelper.WaitForLoaded(page!);
 			return page?.FindChild<NavigationBar>();
 		}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarTests.cs
@@ -406,8 +406,8 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			Assert.IsTrue(renderedNativeNavBar!.Bounds.Height > 0, "Native toolbar height is not greater than 0");
 			Assert.IsTrue(renderedNativeNavBar!.Bounds.Width > 0, "Native toolbar width is not greater than 0");
 		}
-
-
+#endif
+#endif
 
 		private sealed partial class FirstPage : Page
 		{
@@ -527,7 +527,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 				Content = navBar;
 			}
 		}
-#endif
 	}
 
 #if __IOS__ || __ANDROID__

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
@@ -124,20 +124,20 @@ namespace Uno.Toolkit.UI
 			native.Image = null;
 			native.ClearCustomView();
 			native.Title = element.Content is string content ? content : element.Label;
-			if (element.Icon != null)
+			if (element.Icon is { } icon)
 			{
-				switch (element.Icon)
+				switch (icon)
 				{
 					case BitmapIcon bitmap:
 						native.Image = ImageHelper.FromUri(bitmap.UriSource);
 						native.ClearCustomView();
 						break;
 
-					case FontIcon font: // not supported
-					case PathIcon path: // not supported
-					case SymbolIcon symbol: // not supported
+					case FontIcon: // not supported
+					case PathIcon: // not supported
+					case SymbolIcon: // not supported
 					default:
-						this.Log().WarnIfEnabled(() => $"{GetType().Name ?? "FontIcon, PathIcon and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
+						this.Log().WarnIfEnabled(() => $"{icon.GetType().Name ?? "FontIcon, PathIcon and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
 						native.Image = null;
 						native.ClearCustomView();
 						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
@@ -163,15 +163,16 @@ namespace Uno.Toolkit.UI
 			}
 
 			// Foreground
-			if (ColorHelper.TryGetColorWithOpacity(element.Foreground, out var foreground))
+			if (element.TryGetIconColor(out var iconColor))
 			{
-				var color = (UIColor)foreground;
+				var color = (UIColor)iconColor;
 				native.TintColor = color.ColorWithAlpha((nfloat)element.Opacity);
 			}
 			else
 			{
-				native.TintColor = default(UIColor); // TODO .Clear;
+				native.TintColor = default; // TODO .Clear;
 			}
+
 
 			// IsEnabled
 			native.Enabled = element.IsEnabled;

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationAppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationAppBarButtonRenderer.Android.cs
@@ -125,25 +125,27 @@ namespace Uno.Toolkit.UI
 
 			bool TrySetIcon()
 			{
-				if (element.Icon is { } icon)
+				if (element.Icon is not { } icon)
 				{
-					if (icon is BitmapIcon bitmap)
-					{
-						if (bitmap.UriSource is { } uriSource)
-						{
-							native.NavigationIcon = DrawableHelper.FromUri(uriSource);
-							if (hasIconColor)
-							{
-								DrawableCompat.SetTint(native.NavigationIcon, (Android.Graphics.Color)foregroundColor);
-							}
-						}
+					return false;
+				}
 
-						return true;
-					}
-					else
+				if (icon is BitmapIcon bitmap)
+				{
+					if (bitmap.UriSource is { } uriSource)
 					{
-						this.Log().WarnIfEnabled(() => $"{icon.GetType().Name ?? "FontIcon, PathIcon and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
+						native.NavigationIcon = DrawableHelper.FromUri(uriSource);
+						if (hasIconColor)
+						{
+							DrawableCompat.SetTint(native.NavigationIcon, (Android.Graphics.Color)foregroundColor);
+						}
 					}
+
+					return true;
+				}
+				else
+				{
+					this.Log().WarnIfEnabled(() => $"{icon.GetType().Name ?? "FontIcon, PathIcon and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
 				}
 
 				return false;

--- a/src/Uno.Toolkit.UI/Extensions/AppBarButtonExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/AppBarButtonExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.UI;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -34,6 +35,26 @@ namespace Uno.Toolkit.UI
 		{
 			var peer = button?.GetAutomationPeer() as ButtonAutomationPeer;
 			peer?.Invoke();
+		}
+
+		public static bool TryGetIconColor(this AppBarButton appBarButton, out Color iconColor)
+		{
+			iconColor = default;
+
+			if (appBarButton.Icon?.ReadLocalValue(IconElement.ForegroundProperty) != DependencyProperty.UnsetValue &&
+				ColorHelper.TryGetColorWithOpacity(appBarButton.Icon?.Foreground, out var iconForeground))
+			{
+				iconColor = iconForeground;
+				return true;
+			}
+
+			if (ColorHelper.TryGetColorWithOpacity(appBarButton.Foreground, out var buttonForeground))
+			{
+				iconColor = buttonForeground;
+				return true;
+			}
+
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
related https://github.com/unoplatform/nventive-private/issues/487
related https://github.com/unoplatform/uno/issues/8996
fixes https://github.com/unoplatform/uno.toolkit.ui/issues/586

Fix error when using non-supported appbarbutton iconelement

## What is the current behavior?

Setting the Foreground property of a BitmapIcon has no effect when being used within the native renderers for CommandBar on iOS/Android

## What is the new behavior?

Foreground on BitmapIcon is respected and takes precedence over the Foreground of the AppBarButton
