### PR TITLE
fix: SpaceBetween causing wrong size

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -89,7 +89,6 @@ internal class AutoLayoutTest
 	[DataRow(true, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 110, 10, 0, 0 }, 10, 10, 110, 12, 185)]
 	[DataRow(true, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 110, 10, 0, 0 }, -30, 10, 110, 12, 165)]
 	[DataRow(true, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 10, 10, 0, 0 }, 10, 10, 10, 12, 105)]
-	[DataRow(true, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 10, 10, 0, 0 }, 10, 10, 10, 12, 105)]
 	[DataRow(true, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 10, 10, 0, 0 }, -30, 10, 10, 12, 85)]
 	[DataRow(false, Orientation.Vertical, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 110, 10, 0, 0 }, 10, 10, 110, 138, 248)]
 	[DataRow(false, Orientation.Horizontal, VerticalAlignment.Top, HorizontalAlignment.Left, new[] { 10, 10, 10, 10 }, new[] { 110, 10, 0, 0 }, 10, 10, 110, 78, 138)]
@@ -335,5 +334,79 @@ internal class AutoLayoutTest
 			Assert.AreEqual(expected2, border3Transform!.X);
 			Assert.AreEqual(expected3, border4Transform!.X);
 		}
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task When_Fixed_Dimensions_Padding_And_SpaceBetween_Horizontal()
+	{
+		var SUT = new AutoLayout()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)),
+			Padding = new Thickness(26, 42, 26, 26),
+			Justify = AutoLayoutJustify.SpaceBetween,
+			Width = 200,
+			Orientation = Orientation.Horizontal,
+			VerticalAlignment = VerticalAlignment.Top,
+		};
+
+		var border1 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 40,
+			Height = 40,
+		};
+
+		var border2 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 40,
+			Height = 40,
+		};
+
+		SUT.Children.Add(border1);
+		SUT.Children.Add(border2);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		Assert.AreEqual(108, SUT.ActualHeight);
+		Assert.AreEqual(200, SUT.ActualWidth);
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task When_Fixed_Dimensions_Padding_And_SpaceBetween_Vertical()
+	{
+		var SUT = new AutoLayout()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)),
+			Padding = new Thickness(56, 26, 26, 26),
+			Justify = AutoLayoutJustify.SpaceBetween,
+			Height = 160,
+			Orientation = Orientation.Vertical,
+			HorizontalAlignment = HorizontalAlignment.Left,
+		};
+
+		var border1 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 40,
+			Height = 40,
+		};
+
+		var border2 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 40,
+			Height = 40,
+		};
+
+		SUT.Children.Add(border1);
+		SUT.Children.Add(border2);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		Assert.AreEqual(160, SUT.ActualHeight);
+		Assert.AreEqual(122, SUT.ActualWidth);
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Arrange.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Arrange.cs
@@ -195,8 +195,8 @@ partial class AutoLayout
 			var haveCounterEndPadding = counterAlignment is AutoLayoutAlignment.Stretch or AutoLayoutAlignment.End;
 			var counterEndPadding = haveCounterEndPadding ? (isHorizontal ? padding.Bottom : padding.Right) : 0;
 
-			var test = borderThickness.GetCounterLength(orientation);
-			var availableCounterLength = finalSize.GetCounterLength(orientation) - (counterStartPadding + counterEndPadding + test);
+			var counterBorderLength = borderThickness.GetCounterLength(orientation);
+			var availableCounterLength = finalSize.GetCounterLength(orientation) - (counterStartPadding + counterEndPadding + counterBorderLength);
 
 			EnsureZeroFloor(ref availableCounterLength);
 

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Measure.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Measure.cs
@@ -83,8 +83,8 @@ partial class AutoLayout
 			// and the final spacing will be calculated in the arrange pass.
 			desiredSize = orientation switch
 			{
-				Orientation.Horizontal => new Size(availableSize.Width, desiredCounterSize),
-				Orientation.Vertical => new Size(desiredCounterSize, availableSize.Height),
+				Orientation.Horizontal => new Size(availableSize.Width, desiredCounterSize + Padding.GetCounterLength(orientation)),
+				Orientation.Vertical => new Size(desiredCounterSize + Padding.GetCounterLength(orientation), availableSize.Height),
 				_ => throw new ArgumentOutOfRangeException(),
 			};
 		}


### PR DESCRIPTION
GitHub Issue: Fixes #588

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In very specific cases, having SpaceBetween set, one fixed dimension parent and fixed size children, calculated parent dimension was been generated smaller then expected.

## What is the new behavior?

Now, parent size is been calculated as expected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
