### PR TITLE
fix: Fixes text truncation in TabBarItem

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
@@ -382,7 +382,7 @@
 														  FontFamily="{TemplateBinding FontFamily}"
 														  FontWeight="{TemplateBinding FontWeight}"
 														  Foreground="{TemplateBinding Foreground}"
-														  TextWrapping="NoWrap" />
+														  TextWrapping="WrapWholeWords" />
 									</Grid>
 								</Grid>
 							</um:Ripple.Content>
@@ -542,7 +542,7 @@
 														  ContentTransitions="{TemplateBinding ContentTransitions}"
 														  FontSize="{TemplateBinding FontSize}"
 														  Foreground="{TemplateBinding Foreground}"
-														  TextWrapping="NoWrap" />
+														  TextWrapping="WrapWholeWords" />
 									</Grid>
 								</Grid>
 							</um:Ripple.Content>
@@ -688,7 +688,7 @@
 														  ContentTransitions="{TemplateBinding ContentTransitions}"
 														  FontSize="{TemplateBinding FontSize}"
 														  Foreground="{TemplateBinding Foreground}"
-														  TextWrapping="NoWrap" />
+														  TextWrapping="WrapWholeWords" />
 									</Grid>
 								</Grid>
 							</um:Ripple.Content>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno#8228

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
As reported in Gallery app, TabBarItem's text is truncated when there's not enough space

## What is the new behavior?
TabBarItem's text is wrapped across multiple lines when horizontal space is not enough

## PR Checklist
Please check if your PR fulfills the following requirements:
- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] ~~[Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated~~
- [ ] ~~[Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)~~
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->
