### PR TITLE
refactor(tabbar): Add lightweight styling to tab bar style

### DIFF
--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
@@ -1,893 +1,1297 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:mobile="http://uno.ui/mobile"
-					xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:todo="what should be done"
-					xmlns:toolkit="using:Uno.UI.Toolkit"
-					xmlns:not_win="http://uno.ui/not_win"
-					xmlns:um="using:Uno.Material"
-					xmlns:utu="using:Uno.Toolkit.UI"
-					mc:Ignorable="d mobile todo not_win">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mobile="http://uno.ui/mobile"
+    xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:not_win="http://uno.ui/not_win"
+    xmlns:todo="what should be done"
+    xmlns:toolkit="using:Uno.UI.Toolkit"
+    xmlns:um="using:Uno.Material"
+    xmlns:utu="using:Uno.Toolkit.UI"
+    mc:Ignorable="d mobile todo not_win">
 
-	<!--  Base Navigation-style TabBar Resources  -->
-	<x:Double x:Key="MaterialNavigationTabBarWidthOrHeight">80</x:Double>
-	<x:Double x:Key="MaterialNavigationTabBarItemIconHeight">18</x:Double>
-	<x:Double x:Key="MaterialNavigationTabBarItemActiveIndicatorWidth">64</x:Double>
-	<x:Double x:Key="MaterialNavigationTabBarItemActiveIndicatorHeight">32</x:Double>
-	<Thickness x:Key="MaterialNavigationTabBarItemPadding">0,12,0,16</Thickness>
-	<CornerRadius x:Key="MaterialNavigationTabBarItemActiveIndicatorCornerRadius">16</CornerRadius>
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <!--  Base Navigation-style TabBar Resources  -->
+            <x:Double x:Key="NavigationTabBarWidthOrHeight">80</x:Double>
+            <x:Double x:Key="NavigationTabBarItemIconHeight">18</x:Double>
+            <x:Double x:Key="NavigationTabBarItemActiveIndicatorWidth">64</x:Double>
+            <x:Double x:Key="NavigationTabBarItemActiveIndicatorHeight">32</x:Double>
+            <Thickness x:Key="NavigationTabBarItemPadding">0,12,0,16</Thickness>
+            <CornerRadius x:Key="NavigationTabBarItemActiveIndicatorCornerRadius">16</CornerRadius>
 
-	<!--  Top TabBar Resources  -->
-	<x:Double x:Key="MaterialTopTabBarHeight">48</x:Double>
-	<x:Double x:Key="MaterialTopTabBarItemIconHeight">20</x:Double>
-	<Thickness x:Key="MaterialTopTabBarItemContentMargin">0,0,0,0</Thickness>
+            <!--  Top TabBar Resources  -->
+            <x:Double x:Key="TopTabBarHeight">48</x:Double>
+            <x:Double x:Key="TopTabBarItemIconHeight">20</x:Double>
+            <Thickness x:Key="TopTabBarItemContentMargin">0,0,0,0</Thickness>
 
-	<!--  FAB Resources  -->
-	<x:Double x:Key="MaterialFabTabBarItemOffset">-32</x:Double>
-	<x:Double x:Key="MaterialFabTabBarItemContentWidthOrHeight">16</x:Double>
-	<x:Double x:Key="MaterialFabTabBarItemIconTextPadding">12</x:Double>
-	<CornerRadius x:Key="MaterialFabTabBarItemCornerRadius">16</CornerRadius>
-	<Thickness x:Key="MaterialFabTabBarItemPadding">20</Thickness>
+            <!--  FAB Resources  -->
+            <x:Double x:Key="FabTabBarItemOffset">-32</x:Double>
+            <x:Double x:Key="FabTabBarItemContentWidthOrHeight">16</x:Double>
+            <x:Double x:Key="FabTabBarItemIconTextPadding">12</x:Double>
+            <CornerRadius x:Key="FabTabBarItemCornerRadius">16</CornerRadius>
+            <Thickness x:Key="FabTabBarItemPadding">20</Thickness>
 
-	<!--  Small Badge  -->
-	<x:Double x:Key="MaterialNavigationTabBarItemSmallBadgeHeight">6</x:Double>
-	<x:Double x:Key="MaterialNavigationTabBarItemSmallBadgeWidth">6</x:Double>
-	<Thickness x:Key="MaterialNavigationTabBarItemSmallBadgeMargin">0,4,20,0</Thickness>
+            <!--  Small Badge  -->
+            <x:Double x:Key="NavigationTabBarItemSmallBadgeHeight">6</x:Double>
+            <x:Double x:Key="NavigationTabBarItemSmallBadgeWidth">6</x:Double>
+            <Thickness x:Key="NavigationTabBarItemSmallBadgeMargin">0,4,20,0</Thickness>
 
-	<!--  Large Badge  -->
-	<x:Double x:Key="MaterialNavigationTabBarItemLargeBadgeHeight">16</x:Double>
-	<x:Double x:Key="MaterialNavigationTabBarItemLargeBadgeMinWidth">16</x:Double>
-	<Thickness x:Key="MaterialNavigationTabBarItemLargeBadgeMargin">32,2,0,0</Thickness>
-	<Thickness x:Key="MaterialNavigationTabBarItemLargeBadgePadding">4,0</Thickness>
-	<CornerRadius x:Key="MaterialNavigationTabBarItemLargeBadgeCornerRadius">8</CornerRadius>
+            <!--  Large Badge  -->
+            <x:Double x:Key="NavigationTabBarItemLargeBadgeHeight">16</x:Double>
+            <x:Double x:Key="NavigationTabBarItemLargeBadgeMinWidth">16</x:Double>
+            <Thickness x:Key="NavigationTabBarItemLargeBadgeMargin">32,2,0,0</Thickness>
+            <Thickness x:Key="NavigationTabBarItemLargeBadgePadding">4,0</Thickness>
+            <CornerRadius x:Key="NavigationTabBarItemLargeBadgeCornerRadius">8</CornerRadius>
 
-	<!--  WORKAROUND: ControlExtensions must be explicitly referenced as an attribute to avoid a crash on WinAppSDK apps, and not just as a a setter property  -->
-	<Style x:Key="WorkaroundTabBarStyle"
-		   TargetType="utu:TabBar">
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBar">
-					<Grid um:ControlExtensions.IsTintEnabled="False" />
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+            <!--  Brushes  -->
+            <StaticResource x:Key="VerticalTabBarBackground" ResourceKey="SurfaceBrush" />
 
-	<!--#region TabBar Styles-->
+            <StaticResource x:Key="BottomTabBarBackground" ResourceKey="SurfaceBrush" />
 
-	<Style x:Key="BaseMaterialTabBarStyle"
-		   BasedOn="{StaticResource DefaultTabBarStyle}"
-		   TargetType="utu:TabBar">
-		<Setter Property="um:ControlExtensions.TintedBackground" Value="{x:Null}" />
-		<Setter Property="um:ControlExtensions.IsTintEnabled" Value="True" />
-		<Setter Property="SelectionIndicatorPresenterStyle" Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBar">
-					<Grid x:Name="TabBarGrid"
-						  Background="{Binding Path=(um:ControlExtensions.TintedBackground), RelativeSource={RelativeSource TemplatedParent}}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}">
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="OrientationStates">
-								<VisualState x:Name="Horizontal">
-									<VisualState.Setters>
-										<Setter Target="BelowSelectionIndicatorPresenter.VerticalContentAlignment" Value="Stretch" />
-										<Setter Target="BelowSelectionIndicatorPresenter.HorizontalContentAlignment" Value="Left" />
-										<Setter Target="AboveSelectionIndicatorPresenter.VerticalContentAlignment" Value="Stretch" />
-										<Setter Target="AboveSelectionIndicatorPresenter.HorizontalContentAlignment" Value="Left" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="Vertical">
-									<VisualState.Setters>
-										<Setter Target="BelowSelectionIndicatorPresenter.VerticalContentAlignment" Value="Top" />
-										<Setter Target="BelowSelectionIndicatorPresenter.HorizontalContentAlignment" Value="Stretch" />
-										<Setter Target="AboveSelectionIndicatorPresenter.VerticalContentAlignment" Value="Top" />
-										<Setter Target="AboveSelectionIndicatorPresenter.HorizontalContentAlignment" Value="Stretch" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="IndicatorPlacementStates">
-								<VisualState x:Name="Above" />
-								<VisualState x:Name="Below">
-									<VisualState.Setters>
-										<Setter Target="BelowSelectionIndicatorPresenter.Visibility" Value="Visible" />
-										<Setter Target="AboveSelectionIndicatorPresenter.Visibility" Value="Collapsed" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-						<utu:TabBarSelectionIndicatorPresenter x:Name="BelowSelectionIndicatorPresenter"
-															   Content="{TemplateBinding SelectionIndicatorContent}"
-															   ContentTemplate="{TemplateBinding SelectionIndicatorContentTemplate}"
-															   Style="{TemplateBinding SelectionIndicatorPresenterStyle}"
-															   IndicatorTransitionMode="{TemplateBinding SelectionIndicatorTransitionMode}"
-															   Foreground="{TemplateBinding Foreground}"
-															   Owner="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-															   AutomationProperties.AutomationId="BelowSelectionIndicatorPresenter"
-															   Padding="{TemplateBinding Padding}"
-															   Opacity="0"
-															   Visibility="Collapsed" />
-						<ItemsPresenter x:Name="TabBarItemsPresenter"
-										Padding="{TemplateBinding Padding}" />
-						<utu:TabBarSelectionIndicatorPresenter x:Name="AboveSelectionIndicatorPresenter"
-															   Content="{TemplateBinding SelectionIndicatorContent}"
-															   ContentTemplate="{TemplateBinding SelectionIndicatorContentTemplate}"
-															   Style="{TemplateBinding SelectionIndicatorPresenterStyle}"
-															   IndicatorTransitionMode="{TemplateBinding SelectionIndicatorTransitionMode}"
-															   Foreground="{TemplateBinding Foreground}"
-															   Owner="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-															   AutomationProperties.AutomationId="AboveSelectionIndicatorPresenter"
-															   Padding="{TemplateBinding Padding}"
-															   Opacity="0" />
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+            <StaticResource x:Key="TopTabBarBackground" ResourceKey="BackgroundBrush" />
+            <StaticResource x:Key="TopTabBarBottomBorderBrush" ResourceKey="PrimaryBrush" />
 
-	<Style x:Key="MaterialVerticalTabBarStyle"
-		   BasedOn="{StaticResource BaseMaterialTabBarStyle}"
-		   TargetType="utu:TabBar">
-		<Setter Property="um:ControlExtensions.Elevation" Value="1" />
-		<Setter Property="Background" Value="{ThemeResource SurfaceBrush}" />
-		<Setter Property="HorizontalAlignment" Value="Center" />
-		<Setter Property="MinWidth" Value="{StaticResource MaterialNavigationTabBarWidthOrHeight}" />
-		<Setter Property="utu:SafeArea.Insets" Value="VisibleBounds" />
-		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialVerticalTabBarItemStyle}" />
-		<Setter Property="Orientation" Value="Vertical" />
-		<Setter Property="ItemsPanel">
-			<Setter.Value>
-				<ItemsPanelTemplate>
-					<utu:TabBarListPanel Orientation="Vertical" />
-				</ItemsPanelTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+            <StaticResource x:Key="ColoredTopTabBarBackground" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarBottomBorderBrush" ResourceKey="OnPrimaryBrush" />
 
-	<Style x:Key="MaterialBottomTabBarStyle"
-		   BasedOn="{StaticResource BaseMaterialTabBarStyle}"
-		   TargetType="utu:TabBar">
-		<Setter Property="um:ControlExtensions.Elevation" Value="1" />
-		<Setter Property="Background" Value="{ThemeResource SurfaceBrush}" />
-		<Setter Property="VerticalAlignment" Value="Bottom" />
-		<Setter Property="MinHeight" Value="{StaticResource MaterialNavigationTabBarWidthOrHeight}" />
-		<Setter Property="utu:SafeArea.Insets" Value="Bottom" />
-		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialBottomTabBarItemStyle}" />
-	</Style>
+            <StaticResource x:Key="ColoredTopTabBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundPointerOver" ResourceKey="OnPrimaryHoverBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundFocused" ResourceKey="OnPrimaryLowBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundPressed" ResourceKey="OnPrimaryPressedBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundSelectedPointerOver" ResourceKey="OnPrimaryHoverBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundSelectedPressed" ResourceKey="OnPrimaryPressedBrush" />
 
-	<Style x:Key="MaterialTopTabBarStyle"
-		   BasedOn="{StaticResource BaseMaterialTabBarStyle}"
-		   TargetType="utu:TabBar">
-		<Setter Property="Background" Value="{ThemeResource BackgroundBrush}" />
-		<Setter Property="VerticalAlignment" Value="Top" />
-		<Setter Property="MinHeight" Value="{StaticResource MaterialTopTabBarHeight}" />
-		<Setter Property="utu:SafeArea.Insets" Value="Top" />
-		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialTopTabBarItemStyle}" />
-		<Setter Property="SelectionIndicatorContentTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<Border Height="2"
-							VerticalAlignment="Bottom"
-							Margin="0,0,0,1"
-							Background="{ThemeResource PrimaryBrush}" />
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+            <StaticResource x:Key="ColoredTopTabBarItemForeground" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundPointerOver" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundFocused" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundPressed" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundSelected" ResourceKey="OnPrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundSelectedPointerOver" ResourceKey="OnPrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundSelectedPressed" ResourceKey="OnPrimaryBrush" />
 
-	<Style x:Key="MaterialColoredTopTabBarStyle"
-		   BasedOn="{StaticResource MaterialTopTabBarStyle}"
-		   TargetType="utu:TabBar">
-		<Setter Property="Background" Value="{ThemeResource PrimaryBrush}" />
-		<Setter Property="ItemContainerStyle" Value="{StaticResource MaterialColoredTopTabBarItemStyle}" />
-		<Setter Property="SelectionIndicatorContentTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<Border Height="2"
-							VerticalAlignment="Bottom"
-							Margin="0,0,0,1"
-							Background="{ThemeResource OnPrimaryBrush}" />
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
-	<!--#endregion-->
+            <StaticResource x:Key="ColoredTopTabBarItemIconForeground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundPointerOver" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundPressed" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundSelected" ResourceKey="OnPrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundSelectedPointerOver" ResourceKey="OnPrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundSelectedPressed" ResourceKey="OnPrimaryBrush" />
 
-	<!--#region TabBarItem Styles-->
-	<!--
-		"Navigation" Base TabBarItem Style defines commonalities between:
-		- VerticalTabBar (known as Navigation Rail in Material Design 3: https://m3.material.io/components/navigation-rail/overview) and,
-		- BottomTabBar (known as NavigationBar in Material Design 3: https://m3.material.io/components/navigation-bar/overview)
-	-->
-	<Style x:Key="MaterialBaseNavigationTabBarItemStyle"
-		   TargetType="utu:TabBarItem">
-		<Setter Property="FontFamily" Value="{ThemeResource MaterialMediumFontFamily}" />
-		<Setter Property="FontSize" Value="{ThemeResource LabelMediumFontSize}" />
-		<Setter Property="FontWeight" Value="{ThemeResource LabelMediumFontWeight}" />
-		<Setter Property="UseSystemFocusVisuals" Value="True" />
-		<Setter Property="HorizontalContentAlignment" Value="Center" />
-		<Setter Property="Background" Value="{ThemeResource SystemControlTransparentBrush}" />
-		<Setter Property="Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
-		<Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}" />
-		<Setter Property="Padding" Value="{StaticResource MaterialNavigationTabBarItemPadding}" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBarItem">
-					<Grid x:Name="LayoutRoot"
-						  Background="{TemplateBinding Background}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}"
-						  VerticalAlignment="{TemplateBinding VerticalAlignment}"
-						  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-						  Control.IsTemplateFocusTarget="True">
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrush" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushPointerOver" ResourceKey="OnPrimaryHoverBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushFocused" ResourceKey="OnPrimaryLowBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushPressed" ResourceKey="OnPrimaryPressedBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushSelectedPointerOver" ResourceKey="OnPrimaryHoverBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushSelectedPressed" ResourceKey="OnPrimaryPressedBrush" />
 
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="PointerStates">
-								<VisualState x:Name="Normal" />
-								<not_mobile:VisualState x:Name="PointerOver">
-									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource OnSurfaceVariantHoverBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-								<VisualState x:Name="Pressed">
-									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource OnSurfaceVariantPressedBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceVariantBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="Selected">
-									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource SecondaryContainerBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSecondaryContainerBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-								<not_mobile:VisualState x:Name="PointerOverSelected">
-									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource OnSurfaceHoverBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSecondaryContainerBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-								<VisualState x:Name="PressedSelected">
-									<VisualState.Setters>
-										<Setter Target="ActiveIndicator.Background" Value="{ThemeResource OnSurfacePressedBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSecondaryContainerBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="DisabledStates">
-								<VisualState x:Name="Enabled" />
-								<VisualState x:Name="Disabled">
-									<VisualState.Setters>
-										<Setter Target="Icon.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="TabBarIconPositionStates">
-								<VisualState x:Name="IconOnTop" />
-								<VisualState x:Name="IconOnly">
-									<VisualState.Setters>
-										<Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
-										<Setter Target="ContentGrid.RowSpacing" Value="0" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="ContentOnly">
-									<VisualState.Setters>
-										<Setter Target="IconBox.Visibility" Value="Collapsed" />
-										<Setter Target="ContentPresenter.Margin" Value="12,0" />
-										<Setter Target="IconRow.Height" Value="0" />
-										<Setter Target="ContentRow.Height" Value="*" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-						<um:Ripple x:Name="RippleControl"
-								   Padding="{TemplateBinding Padding}"
-								   AutomationProperties.AccessibilityView="Raw"
-								   BorderBrush="{TemplateBinding BorderBrush}"
-								   BorderThickness="{TemplateBinding BorderThickness}"
-								   CornerRadius="{TemplateBinding CornerRadius}"
-								   Feedback="{ThemeResource OnSurfaceBrush}"
-								   FeedbackOpacity="{StaticResource PressedOpacity}">
-							<um:Ripple.Content>
-								<Grid>
-									<Rectangle x:Name="PointerRectangle"
-											   Fill="Transparent"
-											   Visibility="Collapsed" />
+            <StaticResource x:Key="ColoredTopTabBarItemRippleFeedback" ResourceKey="PrimaryBrush" />
 
-									<Grid x:Name="ContentGrid"
-										  RowSpacing="4">
-										<Grid.RowDefinitions>
-											<RowDefinition x:Name="IconRow"
-														   Height="*" />
-											<RowDefinition x:Name="ContentRow"
-														   Height="Auto" />
-										</Grid.RowDefinitions>
+            <StaticResource x:Key="FabTabBarItemBackground" ResourceKey="PrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundPointerOver" ResourceKey="OnPrimaryContainerHoverBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundFocused" ResourceKey="OnPrimaryContainerFocusedBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundPressed" ResourceKey="OnPrimaryContainerPressedBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
 
-										<Grid x:Name="ActiveIndicator"
-											  Background="{ThemeResource SystemControlTransparentBrush}"
-											  VerticalAlignment="Center"
-											  HorizontalAlignment="Center"
-											  Height="{StaticResource MaterialNavigationTabBarItemActiveIndicatorHeight}"
-											  Width="{StaticResource MaterialNavigationTabBarItemActiveIndicatorWidth}"
-											  CornerRadius="{StaticResource MaterialNavigationTabBarItemActiveIndicatorCornerRadius}">
-											<Border Width="{StaticResource MaterialNavigationTabBarItemIconHeight}"
-													Height="{StaticResource MaterialNavigationTabBarItemIconHeight}"
-													VerticalAlignment="Center"
-													HorizontalAlignment="Center">
-												<Viewbox x:Name="IconBox"
-														 HorizontalAlignment="Center">
-													<ContentPresenter x:Name="Icon"
-																	  Content="{TemplateBinding Icon}"
-																	  Foreground="{TemplateBinding Foreground}" />
-												</Viewbox>
-											</Border>
+            <StaticResource x:Key="FabTabBarItemForeground" ResourceKey="OnPrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundPointerOver" ResourceKey="OnPrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundFocused" ResourceKey="OnPrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundPressed" ResourceKey="OnPrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
 
-											<!--  BADGE  -->
-											<!--  This part can be replaced when InfoBadge will be available in WinUI3  -->
-											<!--  See this commit for the implementation: c935919b2c390014dd8509cc50e16b1549511ffa  -->
-											<!--  (Related Branch: dev/agzi/I274-InfoBadgeImplementationForTBI)  -->
+            <StaticResource x:Key="FabTabBarItemIconForeground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
 
-											<Grid Visibility="{TemplateBinding BadgeVisibility}">
-												<!--  Small Badge  -->
-												<Ellipse Height="{StaticResource MaterialNavigationTabBarItemSmallBadgeHeight}"
-														 Width="{StaticResource MaterialNavigationTabBarItemSmallBadgeWidth}"
-														 Margin="{StaticResource MaterialNavigationTabBarItemSmallBadgeMargin}"
-														 HorizontalAlignment="Right"
-														 VerticalAlignment="Top"
-														 Fill="{ThemeResource ErrorBrush}"
-														 Visibility="{Binding BadgeValue, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToVisible}}" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundPointerOver" ResourceKey="OnSurfaceVariantHoverBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundPressed" ResourceKey="OnSurfaceVariantPressedBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundSelected" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundSelectedPointerOver" ResourceKey="OnSurfaceHoverBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundSelectedPressed" ResourceKey="OnSurfacePressedBrush" />
 
-												<!--  Large Badge  -->
-												<Border Height="{StaticResource MaterialNavigationTabBarItemLargeBadgeHeight}"
-														MinWidth="{StaticResource MaterialNavigationTabBarItemLargeBadgeMinWidth}"
-														Padding="{StaticResource MaterialNavigationTabBarItemLargeBadgePadding}"
-														Margin="{StaticResource MaterialNavigationTabBarItemLargeBadgeMargin}"
-														HorizontalAlignment="Left"
-														VerticalAlignment="Top"
-														CornerRadius="{StaticResource MaterialNavigationTabBarItemLargeBadgeCornerRadius}"
-														Background="{ThemeResource ErrorBrush}"
-														Visibility="{Binding BadgeValue, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}">
-													<TextBlock Text="{TemplateBinding BadgeValue}"
-															   MaxLines="1"
-															   TextAlignment="Center"
-															   VerticalAlignment="Center"
-															   HorizontalAlignment="Center"
-															   Foreground="{ThemeResource OnErrorBrush}"
-															   Style="{StaticResource LabelExtraSmall}" />
-												</Border>
-											</Grid>
+            <StaticResource x:Key="NavigationTabBarItemIconForeground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundPointerOver" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundPressed" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundSelected" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundSelectedPointerOver" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundSelectedPressed" ResourceKey="OnSecondaryContainerBrush" />
 
-										</Grid>
+            <StaticResource x:Key="NavigationTabBarItemErrorBrush" ResourceKey="ErrorBrush" />
+            <StaticResource x:Key="NavigationTabBarItemOnErrorBrush" ResourceKey="OnErrorBrush" />
 
-										<ContentPresenter x:Name="ContentPresenter"
-														  Grid.Row="1"
-														  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-														  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-														  AutomationProperties.AccessibilityView="Raw"
-														  Content="{TemplateBinding Content}"
-														  ContentTemplate="{TemplateBinding ContentTemplate}"
-														  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-														  ContentTransitions="{TemplateBinding ContentTransitions}"
-														  FontSize="{TemplateBinding FontSize}"
-														  FontFamily="{TemplateBinding FontFamily}"
-														  FontWeight="{TemplateBinding FontWeight}"
-														  Foreground="{TemplateBinding Foreground}"
-														  TextWrapping="WrapWholeWords" />
-									</Grid>
-								</Grid>
-							</um:Ripple.Content>
-						</um:Ripple>
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+            <StaticResource x:Key="NavigationTabBarItemPointerFillBrush" ResourceKey="SystemControlTransparentBrush" />
 
-	<Style x:Key="MaterialVerticalTabBarItemStyle"
-		   BasedOn="{StaticResource MaterialBaseNavigationTabBarItemStyle}"
-		   TargetType="utu:TabBarItem" />
+            <StaticResource x:Key="NavigationTabBarItemRippleFeedback" ResourceKey="OnSurfaceBrush" />
 
-	<Style x:Key="MaterialBottomTabBarItemStyle"
-		   BasedOn="{StaticResource MaterialBaseNavigationTabBarItemStyle}"
-		   TargetType="utu:TabBarItem" />
+            <StaticResource x:Key="TopTabBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundFocused" ResourceKey="PrimaryLowBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundPressed" ResourceKey="PrimaryPressedBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundSelectedPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundSelectedPressed" ResourceKey="PrimaryPressedBrush" />
 
-	<Style x:Key="MaterialTopTabBarItemStyle"
-		   TargetType="utu:TabBarItem">
-		<Setter Property="Background" Value="{ThemeResource SystemControlTransparentBrush}" />
-		<Setter Property="Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
-		<Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}" />
-		<Setter Property="FontFamily" Value="{ThemeResource MaterialRegularFontFamily}" />
-		<Setter Property="FontSize" Value="{ThemeResource LabelLargeFontSize}" />
-		<Setter Property="FontWeight" Value="{ThemeResource LabelLargeFontWeight}" />
-		<Setter Property="UseSystemFocusVisuals" Value="True" />
-		<Setter Property="HorizontalContentAlignment" Value="Center" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBarItem">
-					<Grid x:Name="LayoutRoot"
-						  Background="{TemplateBinding Background}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}"
-						  Control.IsTemplateFocusTarget="True">
+            <StaticResource x:Key="TopTabBarItemForeground" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundPointerOver" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundFocused" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundPressed" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundSelected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundSelectedPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundSelectedPressed" ResourceKey="PrimaryBrush" />
 
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal" />
-								<not_mobile:VisualState x:Name="PointerOver">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryHoverBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryHoverBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-								<not_mobile:VisualState x:Name="Pressed">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryPressedBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryPressedBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceMediumBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-								<VisualState x:Name="Selected">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource SystemControlTransparentBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource SystemControlTransparentBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PrimaryBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-								<not_mobile:VisualState x:Name="PointerOverSelected">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryHoverBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryHoverBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PrimaryBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-								<not_mobile:VisualState x:Name="PressedSelected">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryPressedBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryPressedBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource PrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PrimaryBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="FocusStates">
-								<VisualState x:Name="Focused">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource PrimaryLowBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource PrimaryLowBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="PointerFocused" />
-								<VisualState x:Name="Unfocused" />
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="DisabledStates">
-								<VisualState x:Name="Enabled" />
-								<VisualState x:Name="Disabled">
-									<VisualState.Setters>
-										<Setter Target="Icon.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="TabBarIconPositionStates">
-								<VisualState x:Name="IconOnTop" />
-								<VisualState x:Name="IconOnly">
-									<VisualState.Setters>
-										<Setter Target="PointerRectangle.Visibility" Value="Visible" />
-										<Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="ContentOnly">
-									<VisualState.Setters>
-										<Setter Target="IconBox.Visibility" Value="Collapsed" />
-										<Setter Target="ContentPresenter.Margin" Value="12,0" />
-										<Setter Target="IconRow.Width" Value="0" />
-										<Setter Target="ContentRow.Width" Value="*" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-						<um:Ripple x:Name="RippleControl"
-								   Padding="{TemplateBinding Padding}"
-								   AutomationProperties.AccessibilityView="Raw"
-								   BorderBrush="{TemplateBinding BorderBrush}"
-								   BorderThickness="{TemplateBinding BorderThickness}"
-								   CornerRadius="{TemplateBinding CornerRadius}"
-								   Feedback="{ThemeResource PrimaryBrush}"
-								   FeedbackOpacity="{StaticResource PressedOpacity}">
-							<um:Ripple.Content>
-								<Grid>
-									<Rectangle x:Name="PointerRectangle"
-											   Fill="Transparent"
-											   Visibility="Collapsed" />
+            <StaticResource x:Key="TopTabBarItemBorderBrush" ResourceKey="SystemControlTransparentBrush" />
 
-									<Grid x:Name="ContentGrid"
-										  ColumnSpacing="8">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition x:Name="IconRow"
-															  Width="*" />
-											<ColumnDefinition x:Name="ContentRow"
-															  Width="Auto" />
-										</Grid.ColumnDefinitions>
-										<Viewbox x:Name="IconBox"
-												 Width="{StaticResource MaterialTopTabBarItemIconHeight}"
-												 Height="{StaticResource MaterialTopTabBarItemIconHeight}">
-											<ContentPresenter x:Name="Icon"
-															  Content="{TemplateBinding Icon}"
-															  Foreground="{TemplateBinding Foreground}" />
-										</Viewbox>
-										<ContentPresenter x:Name="ContentPresenter"
-														  Grid.Column="1"
-														  Margin="{StaticResource MaterialTopTabBarItemContentMargin}"
-														  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-														  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-														  AutomationProperties.AccessibilityView="Raw"
-														  Content="{TemplateBinding Content}"
-														  ContentTemplate="{TemplateBinding ContentTemplate}"
-														  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-														  ContentTransitions="{TemplateBinding ContentTransitions}"
-														  FontSize="{TemplateBinding FontSize}"
-														  Foreground="{TemplateBinding Foreground}"
-														  TextWrapping="WrapWholeWords" />
-									</Grid>
-								</Grid>
-							</um:Ripple.Content>
-						</um:Ripple>
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+            <StaticResource x:Key="TopTabBarItemIconForeground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundPointerOver" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundPressed" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundSelected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundSelectedPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundSelectedPressed" ResourceKey="PrimaryBrush" />
 
-	<Style x:Key="MaterialColoredTopTabBarItemStyle"
-		   BasedOn="{StaticResource MaterialTopTabBarItemStyle}"
-		   TargetType="utu:TabBarItem">
-		<Setter Property="Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBarItem">
-					<Grid x:Name="LayoutRoot"
-						  Background="{TemplateBinding Background}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}"
-						  Control.IsTemplateFocusTarget="True">
+            <StaticResource x:Key="TopTabBarItemPointerFillBrush" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushFocused" ResourceKey="PrimaryLowBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushPressed" ResourceKey="PrimaryPressedBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushSelectedPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushSelectedPressed" ResourceKey="PrimaryPressedBrush" />
 
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal" />
-								<not_mobile:VisualState x:Name="PointerOver">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryHoverBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryHoverBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-								<not_mobile:VisualState x:Name="Pressed">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryPressedBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryPressedBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryMediumBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-								<VisualState x:Name="Selected">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource SystemControlTransparentBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource SystemControlTransparentBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-								<not_mobile:VisualState x:Name="PointerOverSelected">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryHoverBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryHoverBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-								<not_mobile:VisualState x:Name="PressedSelected">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryPressedBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryPressedBrush}" />
-										<Setter Target="Icon.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnPrimaryBrush}" />
-									</VisualState.Setters>
-								</not_mobile:VisualState>
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="FocusStates">
-								<VisualState x:Name="Focused">
-									<VisualState.Setters>
-										<Setter Target="LayoutRoot.Background" Value="{ThemeResource OnPrimaryLowBrush}" />
-										<Setter Target="PointerRectangle.Fill" Value="{ThemeResource OnPrimaryLowBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="PointerFocused" />
-								<VisualState x:Name="Unfocused" />
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="DisabledStates">
-								<VisualState x:Name="Enabled" />
-								<VisualState x:Name="Disabled">
-									<VisualState.Setters>
-										<Setter Target="Icon.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="TabBarIconPositionStates">
-								<VisualState x:Name="IconOnTop" />
-								<VisualState x:Name="IconOnly">
-									<VisualState.Setters>
-										<Setter Target="PointerRectangle.Visibility" Value="Visible" />
-										<Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="ContentOnly">
-									<VisualState.Setters>
-										<Setter Target="IconBox.Visibility" Value="Collapsed" />
-										<Setter Target="ContentPresenter.Margin" Value="12,0" />
-										<Setter Target="IconRow.Width" Value="0" />
-										<Setter Target="ContentRow.Width" Value="*" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-						<um:Ripple x:Name="RippleControl"
-								   Padding="{TemplateBinding Padding}"
-								   AutomationProperties.AccessibilityView="Raw"
-								   BorderBrush="{TemplateBinding BorderBrush}"
-								   BorderThickness="{TemplateBinding BorderThickness}"
-								   CornerRadius="{TemplateBinding CornerRadius}"
-								   Feedback="{ThemeResource PrimaryBrush}"
-								   FeedbackOpacity="{StaticResource PressedOpacity}">
-							<um:Ripple.Content>
-								<Grid>
-									<Rectangle x:Name="PointerRectangle"
-											   Fill="Transparent"
-											   Visibility="Collapsed" />
+            <StaticResource x:Key="TopTabBarItemRippleFeedback" ResourceKey="PrimaryBrush" />
 
-									<Grid x:Name="ContentGrid"
-										  ColumnSpacing="8">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition x:Name="IconRow"
-															  Width="*" />
-											<ColumnDefinition x:Name="ContentRow"
-															  Width="Auto" />
-										</Grid.ColumnDefinitions>
-										<Viewbox x:Name="IconBox"
-												 Width="{StaticResource MaterialTopTabBarItemIconHeight}"
-												 Height="{StaticResource MaterialTopTabBarItemIconHeight}">
-											<ContentPresenter x:Name="Icon"
-															  Content="{TemplateBinding Icon}"
-															  Foreground="{TemplateBinding Foreground}" />
-										</Viewbox>
-										<ContentPresenter x:Name="ContentPresenter"
-														  Grid.Column="1"
-														  Margin="{StaticResource MaterialTopTabBarItemContentMargin}"
-														  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-														  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-														  AutomationProperties.AccessibilityView="Raw"
-														  Content="{TemplateBinding Content}"
-														  ContentTemplate="{TemplateBinding ContentTemplate}"
-														  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-														  ContentTransitions="{TemplateBinding ContentTransitions}"
-														  FontSize="{TemplateBinding FontSize}"
-														  Foreground="{TemplateBinding Foreground}"
-														  TextWrapping="WrapWholeWords" />
-									</Grid>
-								</Grid>
-							</um:Ripple.Content>
-						</um:Ripple>
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
-	<!--#endregion-->
+            <!--  Base Navigation Brushes  -->
+            <StaticResource x:Key="NavigationTabBarBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
 
-	<!--#region FAB TabBarItem Styles-->
-	<Style x:Key="MaterialBaseFabTabBarItemStyle"
-		   TargetType="utu:TabBarItem">
-		<Setter Property="FontFamily" Value="{ThemeResource MaterialMediumFontFamily}" />
-		<Setter Property="FontSize" Value="{ThemeResource LabelMediumFontSize}" />
-		<Setter Property="FontWeight" Value="{ThemeResource LabelMediumFontWeight}" />
-		<Setter Property="IsSelectable" Value="False" />
-		<Setter Property="UseSystemFocusVisuals" Value="True" />
-		<Setter Property="VerticalContentAlignment" Value="Center" />
-		<Setter Property="HorizontalContentAlignment" Value="Center" />
-		<Setter Property="CornerRadius" Value="{StaticResource MaterialFabTabBarItemCornerRadius}" />
-		<Setter Property="Padding" Value="{StaticResource MaterialFabTabBarItemPadding}" />
-		<Setter Property="Background" Value="{ThemeResource PrimaryContainerBrush}" />
-		<Setter Property="Foreground" Value="{ThemeResource OnPrimaryContainerBrush}" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBarItem">
-					<Grid VerticalAlignment="{TemplateBinding VerticalAlignment}"
-						  HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
-						<toolkit:ElevatedView x:Name="ElevatedView"
-											  HorizontalAlignment="Center"
-											  VerticalAlignment="Center"
-											  Background="Transparent"
-											  CornerRadius="{TemplateBinding CornerRadius}"
-											  Elevation="6">
+            <StaticResource x:Key="NavigationTabBarForeground" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundPointerOver" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundPressed" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundSelected" ResourceKey="OnSurfaceBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundSelectedPointerOver" ResourceKey="OnSurfaceBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundSelectedPressed" ResourceKey="OnSurfaceBrush" />
 
-							<um:Ripple x:Name="Ripple"
-									   CornerRadius="{TemplateBinding CornerRadius}"
-									   Feedback="{TemplateBinding Foreground}"
-									   FeedbackOpacity="{StaticResource PressedOpacity}">
-								<Grid CornerRadius="{TemplateBinding CornerRadius}">
-									<Grid x:Name="Root"
-										  Background="{TemplateBinding Background}">
-										<StackPanel x:Name="ContentPanel"
-													Margin="{TemplateBinding Padding}"
-													Orientation="Horizontal">
+            <StaticResource x:Key="NavigationTabBarBorderBrush" ResourceKey="SystemControlTransparentBrush" />
 
-											<!--  Icon  -->
-											<Viewbox Width="{StaticResource MaterialFabTabBarItemContentWidthOrHeight}"
-													 Height="{StaticResource MaterialFabTabBarItemContentWidthOrHeight}"
-													 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-													 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-													 Visibility="{Binding Path=Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
-												<ContentPresenter x:Name="IconPresenter"
-																  Content="{TemplateBinding Icon}"
-																  Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource TemplatedParent}}" />
-											</Viewbox>
+        </ResourceDictionary>
 
-											<!--  Icon/Content spacing  -->
-											<Border Visibility="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyToCollapsed}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
-												<Border Width="{StaticResource MaterialFabTabBarItemIconTextPadding}"
-														Visibility="{Binding Path=Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
-											</Border>
+        <ResourceDictionary x:Key="Light">
+            <!--  Base Navigation-style TabBar Resources  -->
+            <x:Double x:Key="NavigationTabBarWidthOrHeight">80</x:Double>
+            <x:Double x:Key="NavigationTabBarItemIconHeight">18</x:Double>
+            <x:Double x:Key="NavigationTabBarItemActiveIndicatorWidth">64</x:Double>
+            <x:Double x:Key="NavigationTabBarItemActiveIndicatorHeight">32</x:Double>
+            <Thickness x:Key="NavigationTabBarItemPadding">0,12,0,16</Thickness>
+            <CornerRadius x:Key="NavigationTabBarItemActiveIndicatorCornerRadius">16</CornerRadius>
 
-											<!--  Content  -->
-											<ContentPresenter x:Name="ContentPresenter"
-															  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-															  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-															  Content="{TemplateBinding Content}"
-															  ContentTemplate="{TemplateBinding ContentTemplate}"
-															  ContentTransitions="{TemplateBinding ContentTransitions}"
-															  FontFamily="{TemplateBinding FontFamily}"
-															  FontWeight="{TemplateBinding FontWeight}"
-															  FontSize="{TemplateBinding FontSize}" />
-										</StackPanel>
-									</Grid>
-									<Border x:Name="StateOverlay"
-											Background="Transparent"
-											CornerRadius="{TemplateBinding CornerRadius}" />
-								</Grid>
-							</um:Ripple>
-						</toolkit:ElevatedView>
+            <!--  Top TabBar Resources  -->
+            <x:Double x:Key="TopTabBarHeight">48</x:Double>
+            <x:Double x:Key="TopTabBarItemIconHeight">20</x:Double>
+            <Thickness x:Key="TopTabBarItemContentMargin">0,0,0,0</Thickness>
 
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="CommonStates">
+            <!--  FAB Resources  -->
+            <x:Double x:Key="FabTabBarItemOffset">-32</x:Double>
+            <x:Double x:Key="FabTabBarItemContentWidthOrHeight">16</x:Double>
+            <x:Double x:Key="FabTabBarItemIconTextPadding">12</x:Double>
+            <CornerRadius x:Key="FabTabBarItemCornerRadius">16</CornerRadius>
+            <Thickness x:Key="FabTabBarItemPadding">20</Thickness>
 
-								<VisualState x:Name="Normal" />
+            <!--  Small Badge  -->
+            <x:Double x:Key="NavigationTabBarItemSmallBadgeHeight">6</x:Double>
+            <x:Double x:Key="NavigationTabBarItemSmallBadgeWidth">6</x:Double>
+            <Thickness x:Key="NavigationTabBarItemSmallBadgeMargin">0,4,20,0</Thickness>
 
-								<VisualState x:Name="PointerOver">
-									<VisualState.Setters>
-										<Setter Target="StateOverlay.Background" Value="{ThemeResource OnPrimaryContainerHoverBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="Pressed">
-									<VisualState.Setters>
-										<Setter Target="StateOverlay.Background" Value="{ThemeResource OnPrimaryContainerPressedBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-								<VisualState x:Name="Disabled">
-									<VisualState.Setters>
-										<Setter Target="IconPresenter.Foreground" Value="{ThemeResource OnSurfaceDisabledBrush}" />
-										<Setter Target="ContentPresenter.Foreground" Value="{ThemeResource OnSurfaceDisabledBrush}" />
-										<Setter Target="StateOverlay.Background" Value="{ThemeResource OnSurfaceDisabledLowBrush}" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
+            <!--  Large Badge  -->
+            <x:Double x:Key="NavigationTabBarItemLargeBadgeHeight">16</x:Double>
+            <x:Double x:Key="NavigationTabBarItemLargeBadgeMinWidth">16</x:Double>
+            <Thickness x:Key="NavigationTabBarItemLargeBadgeMargin">32,2,0,0</Thickness>
+            <Thickness x:Key="NavigationTabBarItemLargeBadgePadding">4,0</Thickness>
+            <CornerRadius x:Key="NavigationTabBarItemLargeBadgeCornerRadius">8</CornerRadius>
 
-							<VisualStateGroup x:Name="FocusStates">
+            <!--  Brushes  -->
+            <StaticResource x:Key="VerticalTabBarBackground" ResourceKey="SurfaceBrush" />
 
-								<VisualState x:Name="Focused">
-									<VisualState.Setters>
-										<Setter Target="StateOverlay.Background" Value="{ThemeResource OnPrimaryContainerFocusedBrush}" />
-									</VisualState.Setters>
-								</VisualState>
+            <StaticResource x:Key="BottomTabBarBackground" ResourceKey="SurfaceBrush" />
 
-								<VisualState x:Name="PointerFocused" />
+            <StaticResource x:Key="TopTabBarBackground" ResourceKey="BackgroundBrush" />
+            <StaticResource x:Key="TopTabBarBottomBorderBrush" ResourceKey="PrimaryBrush" />
 
-								<VisualState x:Name="Unfocused" />
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+            <StaticResource x:Key="ColoredTopTabBarBackground" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarBottomBorderBrush" ResourceKey="OnPrimaryBrush" />
 
-	<Style x:Key="MaterialVerticalFabTabBarItemStyle"
-		   BasedOn="{StaticResource MaterialBaseFabTabBarItemStyle}"
-		   TargetType="utu:TabBarItem" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundPointerOver" ResourceKey="OnPrimaryHoverBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundFocused" ResourceKey="OnPrimaryLowBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundPressed" ResourceKey="OnPrimaryPressedBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundSelectedPointerOver" ResourceKey="OnPrimaryHoverBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemBackgroundSelectedPressed" ResourceKey="OnPrimaryPressedBrush" />
 
-	<Style x:Key="MaterialBottomFabTabBarItemStyle"
-		   BasedOn="{StaticResource MaterialBaseFabTabBarItemStyle}"
-		   TargetType="utu:TabBarItem">
-		<!--  KNOWN ISSUE: The part of the FAB that is translated outside of the TabBar bounds is not clickable  -->
-		<!--  https://github.com/unoplatform/uno/issues/7393  -->
-		<Setter Property="RenderTransform">
-			<Setter.Value>
-				<TranslateTransform Y="{StaticResource MaterialFabTabBarItemOffset}" />
-			</Setter.Value>
-		</Setter>
+            <StaticResource x:Key="ColoredTopTabBarItemForeground" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundPointerOver" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundFocused" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundPressed" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundSelected" ResourceKey="OnPrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundSelectedPointerOver" ResourceKey="OnPrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemForegroundSelectedPressed" ResourceKey="OnPrimaryBrush" />
 
-	</Style>
-	<!--#endregion-->
+            <StaticResource x:Key="ColoredTopTabBarItemIconForeground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundPointerOver" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundPressed" ResourceKey="OnPrimaryMediumBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundSelected" ResourceKey="OnPrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundSelectedPointerOver" ResourceKey="OnPrimaryBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemIconForegroundSelectedPressed" ResourceKey="OnPrimaryBrush" />
 
-	<!--#region SelectionIndicator-->
-	<Style x:Key="MaterialTabBarSelectionIndicatorPresenterStyle"
-		   TargetType="utu:TabBarSelectionIndicatorPresenter">
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBarSelectionIndicatorPresenter">
-					<Grid x:Name="Root"
-						  Background="{TemplateBinding Background}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}">
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="IndicatorTransitionStates">
-								<VisualState x:Name="Horizontal">
-									<Storyboard x:Name="IndicatorTransitionHorizontalStoryboard">
-										<DoubleAnimation Storyboard.TargetName="IndicatorTransform"
-														 Storyboard.TargetProperty="TranslateX"
-														 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.X}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.X}"
-														 Duration="00:00:00.200" />
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="Vertical">
-									<Storyboard x:Name="IndicatorTransitionVerticalStoryboard">
-										<DoubleAnimation Storyboard.TargetName="IndicatorTransform"
-														 Storyboard.TargetProperty="TranslateY"
-														 From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.Y}"
-														 To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.Y}"
-														 Duration="00:00:00.200" />
-									</Storyboard>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-						<ContentPresenter x:Name="IndicatorPresenter"
-										  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-										  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-										  Content="{TemplateBinding Content}"
-										  ContentTemplate="{TemplateBinding ContentTemplate}"
-										  RenderTransformOrigin=".5,.5"
-										  Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorMaxSize.Height}"
-										  Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorMaxSize.Width}">
-							<ContentPresenter.RenderTransform>
-								<CompositeTransform x:Name="IndicatorTransform" />
-							</ContentPresenter.RenderTransform>
-						</ContentPresenter>
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
-	<!--#endregion-->
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrush" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushPointerOver" ResourceKey="OnPrimaryHoverBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushFocused" ResourceKey="OnPrimaryLowBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushPressed" ResourceKey="OnPrimaryPressedBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushSelectedPointerOver" ResourceKey="OnPrimaryHoverBrush" />
+            <StaticResource x:Key="ColoredTopTabBarItemPointerFillBrushSelectedPressed" ResourceKey="OnPrimaryPressedBrush" />
 
-	<!--#region Default AppBar style-->
-	<Style x:Key="MaterialDefaultMainCommandStyle"
-		   TargetType="AppBarButton"
-		   BasedOn="{StaticResource MaterialMainCommandStyle}" />
-	<!--#endregion-->
+            <StaticResource x:Key="ColoredTopTabBarItemRippleFeedback" ResourceKey="PrimaryBrush" />
+
+            <StaticResource x:Key="FabTabBarItemBackground" ResourceKey="PrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundPointerOver" ResourceKey="OnPrimaryContainerHoverBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundFocused" ResourceKey="OnPrimaryContainerFocusedBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundPressed" ResourceKey="OnPrimaryContainerPressedBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemBackgroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="FabTabBarItemForeground" ResourceKey="OnPrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundPointerOver" ResourceKey="OnPrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundFocused" ResourceKey="OnPrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundPressed" ResourceKey="OnPrimaryContainerBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemForegroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="FabTabBarItemIconForeground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="FabTabBarItemIconForegroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundPointerOver" ResourceKey="OnSurfaceVariantHoverBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundPressed" ResourceKey="OnSurfaceVariantPressedBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundSelected" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundSelectedPointerOver" ResourceKey="OnSurfaceHoverBrush" />
+            <StaticResource x:Key="NavigationTabBarItemActiveIndicatorBackgroundSelectedPressed" ResourceKey="OnSurfacePressedBrush" />
+
+            <StaticResource x:Key="NavigationTabBarItemIconForeground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundPointerOver" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundPressed" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundSelected" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundSelectedPointerOver" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="NavigationTabBarItemIconForegroundSelectedPressed" ResourceKey="OnSecondaryContainerBrush" />
+
+            <StaticResource x:Key="NavigationTabBarItemErrorBrush" ResourceKey="ErrorBrush" />
+            <StaticResource x:Key="NavigationTabBarItemOnErrorBrush" ResourceKey="OnErrorBrush" />
+
+            <StaticResource x:Key="NavigationTabBarItemPointerFillBrush" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="NavigationTabBarItemRippleFeedback" ResourceKey="OnSurfaceBrush" />
+
+            <StaticResource x:Key="TopTabBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundFocused" ResourceKey="PrimaryLowBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundPressed" ResourceKey="PrimaryPressedBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundSelectedPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="TopTabBarItemBackgroundSelectedPressed" ResourceKey="PrimaryPressedBrush" />
+
+            <StaticResource x:Key="TopTabBarItemForeground" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundPointerOver" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundFocused" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundPressed" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundSelected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundSelectedPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="TopTabBarItemForegroundSelectedPressed" ResourceKey="PrimaryBrush" />
+
+            <StaticResource x:Key="TopTabBarItemBorderBrush" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="TopTabBarItemIconForeground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundPointerOver" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundPressed" ResourceKey="OnSurfaceMediumBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundSelected" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundSelectedPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="TopTabBarItemIconForegroundSelectedPressed" ResourceKey="PrimaryBrush" />
+
+            <StaticResource x:Key="TopTabBarItemPointerFillBrush" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushFocused" ResourceKey="PrimaryLowBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushPressed" ResourceKey="PrimaryPressedBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushSelectedPointerOver" ResourceKey="PrimaryHoverBrush" />
+            <StaticResource x:Key="TopTabBarItemPointerFillBrushSelectedPressed" ResourceKey="PrimaryPressedBrush" />
+
+            <StaticResource x:Key="TopTabBarItemRippleFeedback" ResourceKey="PrimaryBrush" />
+
+            <!--  Base Navigation Brushes  -->
+            <StaticResource x:Key="NavigationTabBarBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="NavigationTabBarBackgroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="NavigationTabBarForeground" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundPointerOver" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundPressed" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundSelected" ResourceKey="OnSurfaceBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundSelectedPointerOver" ResourceKey="OnSurfaceBrush" />
+            <StaticResource x:Key="NavigationTabBarForegroundSelectedPressed" ResourceKey="OnSurfaceBrush" />
+
+            <StaticResource x:Key="NavigationTabBarBorderBrush" ResourceKey="SystemControlTransparentBrush" />
+
+        </ResourceDictionary>
+
+    </ResourceDictionary.ThemeDictionaries>
+
+    <!--  WORKAROUND: ControlExtensions must be explicitly referenced as an attribute to avoid a crash on WinAppSDK apps, and not just as a a setter property  -->
+    <Style x:Key="WorkaroundTabBarStyle" TargetType="utu:TabBar">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="utu:TabBar">
+                    <Grid um:ControlExtensions.IsTintEnabled="False" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!--#region TabBar Styles-->
+
+    <Style
+        x:Key="BaseMaterialTabBarStyle"
+        BasedOn="{StaticResource DefaultTabBarStyle}"
+        TargetType="utu:TabBar">
+        <Setter Property="um:ControlExtensions.TintedBackground" Value="{x:Null}" />
+        <Setter Property="um:ControlExtensions.IsTintEnabled" Value="True" />
+        <Setter Property="SelectionIndicatorPresenterStyle" Value="{StaticResource MaterialTabBarSelectionIndicatorPresenterStyle}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="utu:TabBar">
+                    <Grid
+                        x:Name="TabBarGrid"
+                        Background="{Binding Path=(um:ControlExtensions.TintedBackground), RelativeSource={RelativeSource TemplatedParent}}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
+                        <utu:TabBarSelectionIndicatorPresenter
+                            x:Name="BelowSelectionIndicatorPresenter"
+                            Padding="{TemplateBinding Padding}"
+                            AutomationProperties.AutomationId="BelowSelectionIndicatorPresenter"
+                            Content="{TemplateBinding SelectionIndicatorContent}"
+                            ContentTemplate="{TemplateBinding SelectionIndicatorContentTemplate}"
+                            Foreground="{TemplateBinding Foreground}"
+                            IndicatorTransitionMode="{TemplateBinding SelectionIndicatorTransitionMode}"
+                            Opacity="0"
+                            Owner="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                            Style="{TemplateBinding SelectionIndicatorPresenterStyle}"
+                            Visibility="Collapsed" />
+                        <ItemsPresenter x:Name="TabBarItemsPresenter" Padding="{TemplateBinding Padding}" />
+                        <utu:TabBarSelectionIndicatorPresenter
+                            x:Name="AboveSelectionIndicatorPresenter"
+                            Padding="{TemplateBinding Padding}"
+                            AutomationProperties.AutomationId="AboveSelectionIndicatorPresenter"
+                            Content="{TemplateBinding SelectionIndicatorContent}"
+                            ContentTemplate="{TemplateBinding SelectionIndicatorContentTemplate}"
+                            Foreground="{TemplateBinding Foreground}"
+                            IndicatorTransitionMode="{TemplateBinding SelectionIndicatorTransitionMode}"
+                            Opacity="0"
+                            Owner="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                            Style="{TemplateBinding SelectionIndicatorPresenterStyle}" />
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="OrientationStates">
+                                <VisualState x:Name="Horizontal">
+                                    <VisualState.Setters>
+                                        <Setter Target="BelowSelectionIndicatorPresenter.VerticalContentAlignment" Value="Stretch" />
+                                        <Setter Target="BelowSelectionIndicatorPresenter.HorizontalContentAlignment" Value="Left" />
+                                        <Setter Target="AboveSelectionIndicatorPresenter.VerticalContentAlignment" Value="Stretch" />
+                                        <Setter Target="AboveSelectionIndicatorPresenter.HorizontalContentAlignment" Value="Left" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Vertical">
+                                    <VisualState.Setters>
+                                        <Setter Target="BelowSelectionIndicatorPresenter.VerticalContentAlignment" Value="Top" />
+                                        <Setter Target="BelowSelectionIndicatorPresenter.HorizontalContentAlignment" Value="Stretch" />
+                                        <Setter Target="AboveSelectionIndicatorPresenter.VerticalContentAlignment" Value="Top" />
+                                        <Setter Target="AboveSelectionIndicatorPresenter.HorizontalContentAlignment" Value="Stretch" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="IndicatorPlacementStates">
+                                <VisualState x:Name="Above" />
+                                <VisualState x:Name="Below">
+                                    <VisualState.Setters>
+                                        <Setter Target="BelowSelectionIndicatorPresenter.Visibility" Value="Visible" />
+                                        <Setter Target="AboveSelectionIndicatorPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style
+        x:Key="MaterialVerticalTabBarStyle"
+        BasedOn="{StaticResource BaseMaterialTabBarStyle}"
+        TargetType="utu:TabBar">
+        <Setter Property="um:ControlExtensions.Elevation" Value="1" />
+        <Setter Property="Background" Value="{ThemeResource VerticalTabBarBackground}" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="MinWidth" Value="{ThemeResource NavigationTabBarWidthOrHeight}" />
+        <Setter Property="utu:SafeArea.Insets" Value="VisibleBounds" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialVerticalTabBarItemStyle}" />
+        <Setter Property="Orientation" Value="Vertical" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <utu:TabBarListPanel Orientation="Vertical" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style
+        x:Key="MaterialBottomTabBarStyle"
+        BasedOn="{StaticResource BaseMaterialTabBarStyle}"
+        TargetType="utu:TabBar">
+        <Setter Property="um:ControlExtensions.Elevation" Value="1" />
+        <Setter Property="Background" Value="{ThemeResource BottomTabBarBackground}" />
+        <Setter Property="VerticalAlignment" Value="Bottom" />
+        <Setter Property="MinHeight" Value="{ThemeResource NavigationTabBarWidthOrHeight}" />
+        <Setter Property="utu:SafeArea.Insets" Value="Bottom" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialBottomTabBarItemStyle}" />
+    </Style>
+
+    <Style
+        x:Key="MaterialTopTabBarStyle"
+        BasedOn="{StaticResource BaseMaterialTabBarStyle}"
+        TargetType="utu:TabBar">
+        <Setter Property="Background" Value="{ThemeResource TopTabBarBackground}" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="MinHeight" Value="{ThemeResource TopTabBarHeight}" />
+        <Setter Property="utu:SafeArea.Insets" Value="Top" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialTopTabBarItemStyle}" />
+        <Setter Property="SelectionIndicatorContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <Border
+                        Height="2"
+                        Margin="0,0,0,1"
+                        VerticalAlignment="Bottom"
+                        Background="{ThemeResource TopTabBarBottomBorderBrush}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style
+        x:Key="MaterialColoredTopTabBarStyle"
+        BasedOn="{StaticResource MaterialTopTabBarStyle}"
+        TargetType="utu:TabBar">
+        <Setter Property="Background" Value="{ThemeResource ColoredTopTabBarBackground}" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialColoredTopTabBarItemStyle}" />
+        <Setter Property="SelectionIndicatorContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <Border
+                        Height="2"
+                        Margin="0,0,0,1"
+                        VerticalAlignment="Bottom"
+                        Background="{ThemeResource ColoredTopTabBarBottomBorderBrush}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <!--#endregion-->
+
+    <!--#region TabBarItem Styles-->
+    <!--
+        "Navigation" Base TabBarItem Style defines commonalities between:
+        - VerticalTabBar (known as Navigation Rail in Material Design 3: https://m3.material.io/components/navigation-rail/overview) and,
+        - BottomTabBar (known as NavigationBar in Material Design 3: https://m3.material.io/components/navigation-bar/overview)
+    -->
+    <Style x:Key="MaterialBaseNavigationTabBarItemStyle" TargetType="utu:TabBarItem">
+        <Setter Property="FontFamily" Value="{ThemeResource MaterialMediumFontFamily}" />
+        <Setter Property="FontSize" Value="{ThemeResource LabelMediumFontSize}" />
+        <Setter Property="FontWeight" Value="{ThemeResource LabelMediumFontWeight}" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="Background" Value="{ThemeResource NavigationTabBarBackground}" />
+        <Setter Property="Foreground" Value="{ThemeResource NavigationTabBarForeground}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource NavigationTabBarBorderBrush}" />
+        <Setter Property="Padding" Value="{ThemeResource NavigationTabBarItemPadding}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="utu:TabBarItem">
+                    <Grid
+                        x:Name="LayoutRoot"
+                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Control.IsTemplateFocusTarget="True">
+                        <um:Ripple
+                            x:Name="RippleControl"
+                            Padding="{TemplateBinding Padding}"
+                            AutomationProperties.AccessibilityView="Raw"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Feedback="{ThemeResource NavigationTabBarItemRippleFeedback}"
+                            FeedbackOpacity="{StaticResource PressedOpacity}">
+                            <um:Ripple.Content>
+                                <Grid>
+                                    <Rectangle
+                                        x:Name="PointerRectangle"
+                                        Fill="{ThemeResource NavigationTabBarItemPointerFillBrush}"
+                                        Visibility="Collapsed" />
+
+                                    <Grid x:Name="ContentGrid" RowSpacing="4">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition x:Name="IconRow" Height="*" />
+                                            <RowDefinition x:Name="ContentRow" Height="Auto" />
+                                        </Grid.RowDefinitions>
+
+                                        <Grid
+                                            x:Name="ActiveIndicator"
+                                            Width="{ThemeResource NavigationTabBarItemActiveIndicatorWidth}"
+                                            Height="{ThemeResource NavigationTabBarItemActiveIndicatorHeight}"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            Background="{ThemeResource NavigationTabBarItemActiveIndicatorBackground}"
+                                            CornerRadius="{ThemeResource NavigationTabBarItemActiveIndicatorCornerRadius}">
+                                            <Border
+                                                Width="{ThemeResource NavigationTabBarItemIconHeight}"
+                                                Height="{ThemeResource NavigationTabBarItemIconHeight}"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center">
+                                                <Viewbox x:Name="IconBox" HorizontalAlignment="Center">
+                                                    <ContentPresenter
+                                                        x:Name="Icon"
+                                                        Content="{TemplateBinding Icon}"
+                                                        Foreground="{TemplateBinding Foreground}" />
+                                                </Viewbox>
+                                            </Border>
+
+                                            <!--  BADGE  -->
+                                            <!--  This part can be replaced when InfoBadge will be available in WinUI3  -->
+                                            <!--  See this commit for the implementation: c935919b2c390014dd8509cc50e16b1549511ffa  -->
+                                            <!--  (Related Branch: dev/agzi/I274-InfoBadgeImplementationForTBI)  -->
+
+                                            <Grid Visibility="{TemplateBinding BadgeVisibility}">
+                                                <!--  Small Badge  -->
+                                                <Ellipse
+                                                    Width="{ThemeResource NavigationTabBarItemSmallBadgeWidth}"
+                                                    Height="{ThemeResource NavigationTabBarItemSmallBadgeHeight}"
+                                                    Margin="{ThemeResource NavigationTabBarItemSmallBadgeMargin}"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Top"
+                                                    Fill="{ThemeResource NavigationTabBarItemErrorBrush}"
+                                                    Visibility="{Binding BadgeValue, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToVisible}}" />
+
+                                                <!--  Large Badge  -->
+                                                <Border
+                                                    Height="{ThemeResource NavigationTabBarItemLargeBadgeHeight}"
+                                                    MinWidth="{ThemeResource NavigationTabBarItemLargeBadgeMinWidth}"
+                                                    Margin="{ThemeResource NavigationTabBarItemLargeBadgeMargin}"
+                                                    Padding="{ThemeResource NavigationTabBarItemLargeBadgePadding}"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Top"
+                                                    Background="{ThemeResource NavigationTabBarItemErrorBrush}"
+                                                    CornerRadius="{ThemeResource NavigationTabBarItemLargeBadgeCornerRadius}"
+                                                    Visibility="{Binding BadgeValue, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToCollapsed}}">
+                                                    <TextBlock
+                                                        HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center"
+                                                        Foreground="{ThemeResource NavigationTabBarItemOnErrorBrush}"
+                                                        MaxLines="1"
+                                                        Style="{StaticResource LabelExtraSmall}"
+                                                        Text="{TemplateBinding BadgeValue}"
+                                                        TextAlignment="Center" />
+                                                </Border>
+                                            </Grid>
+
+                                        </Grid>
+
+                                        <ContentPresenter
+                                            x:Name="ContentPresenter"
+                                            Grid.Row="1"
+                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            Content="{TemplateBinding Content}"
+                                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                            ContentTransitions="{TemplateBinding ContentTransitions}"
+                                            FontFamily="{TemplateBinding FontFamily}"
+                                            FontSize="{TemplateBinding FontSize}"
+                                            FontWeight="{TemplateBinding FontWeight}"
+                                            Foreground="{TemplateBinding Foreground}"
+                                            TextWrapping="NoWrap" />
+                                    </Grid>
+                                </Grid>
+                            </um:Ripple.Content>
+                        </um:Ripple>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="PointerStates">
+                                <VisualState x:Name="Normal" />
+                                <not_mobile:VisualState x:Name="PointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource NavigationTabBarBackgroundPointerOver}" />
+                                        <Setter Target="ActiveIndicator.Background" Value="{ThemeResource NavigationTabBarItemActiveIndicatorBackgroundPointerOver}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource NavigationTabBarItemIconForegroundPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource NavigationTabBarForegroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource NavigationTabBarBackgroundPressed}" />
+                                        <Setter Target="ActiveIndicator.Background" Value="{ThemeResource NavigationTabBarItemActiveIndicatorBackgroundPressed}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource NavigationTabBarItemIconForegroundPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource NavigationTabBarForegroundPressed}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Selected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource NavigationTabBarBackgroundSelected}" />
+                                        <Setter Target="ActiveIndicator.Background" Value="{ThemeResource NavigationTabBarItemActiveIndicatorBackgroundSelected}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource NavigationTabBarItemIconForegroundSelected}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource NavigationTabBarForegroundSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <not_mobile:VisualState x:Name="PointerOverSelected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource NavigationTabBarBackgroundSelectedPointerOver}" />
+                                        <Setter Target="ActiveIndicator.Background" Value="{ThemeResource NavigationTabBarItemActiveIndicatorBackgroundSelectedPointerOver}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource NavigationTabBarItemIconForegroundSelectedPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource NavigationTabBarForegroundSelectedPointerOver}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                                <VisualState x:Name="PressedSelected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource NavigationTabBarBackgroundSelectedPressed}" />
+                                        <Setter Target="ActiveIndicator.Background" Value="{ThemeResource NavigationTabBarItemActiveIndicatorBackgroundSelectedPressed}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource NavigationTabBarItemIconForegroundSelectedPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource NavigationTabBarForegroundSelectedPressed}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="DisabledStates">
+                                <VisualState x:Name="Enabled" />
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource NavigationTabBarBackgroundDisabled}" />
+                                        <Setter Target="ActiveIndicator.Background" Value="{ThemeResource NavigationTabBarItemActiveIndicatorBackgroundDisabled}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource NavigationTabBarItemIconForegroundDisabled}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource NavigationTabBarForegroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="TabBarIconPositionStates">
+                                <VisualState x:Name="IconOnTop" />
+                                <VisualState x:Name="IconOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
+                                        <Setter Target="ContentGrid.RowSpacing" Value="0" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ContentOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="IconBox.Visibility" Value="Collapsed" />
+                                        <Setter Target="ContentPresenter.Margin" Value="12,0" />
+                                        <Setter Target="IconRow.Height" Value="0" />
+                                        <Setter Target="ContentRow.Height" Value="*" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style
+        x:Key="MaterialVerticalTabBarItemStyle"
+        BasedOn="{StaticResource MaterialBaseNavigationTabBarItemStyle}"
+        TargetType="utu:TabBarItem" />
+
+    <Style
+        x:Key="MaterialBottomTabBarItemStyle"
+        BasedOn="{StaticResource MaterialBaseNavigationTabBarItemStyle}"
+        TargetType="utu:TabBarItem" />
+
+    <Style x:Key="MaterialTopTabBarItemStyle" TargetType="utu:TabBarItem">
+        <Setter Property="Background" Value="{ThemeResource TopTabBarItemBackground}" />
+        <Setter Property="Foreground" Value="{ThemeResource TopTabBarItemForeground}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource TopTabBarItemBorderBrush}" />
+        <Setter Property="FontFamily" Value="{ThemeResource MaterialRegularFontFamily}" />
+        <Setter Property="FontSize" Value="{ThemeResource LabelLargeFontSize}" />
+        <Setter Property="FontWeight" Value="{ThemeResource LabelLargeFontWeight}" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="utu:TabBarItem">
+                    <Grid
+                        x:Name="LayoutRoot"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Control.IsTemplateFocusTarget="True">
+                        <um:Ripple
+                            x:Name="RippleControl"
+                            Padding="{TemplateBinding Padding}"
+                            AutomationProperties.AccessibilityView="Raw"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Feedback="{ThemeResource TopTabBarItemRippleFeedback}"
+                            FeedbackOpacity="{StaticResource PressedOpacity}">
+                            <um:Ripple.Content>
+                                <Grid>
+                                    <Rectangle
+                                        x:Name="PointerRectangle"
+                                        Fill="{ThemeResource TopTabBarItemPointerFillBrush}"
+                                        Visibility="Collapsed" />
+
+                                    <Grid x:Name="ContentGrid" ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="IconRow" Width="*" />
+                                            <ColumnDefinition x:Name="ContentRow" Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <Viewbox
+                                            x:Name="IconBox"
+                                            Width="{ThemeResource TopTabBarItemIconHeight}"
+                                            Height="{ThemeResource TopTabBarItemIconHeight}">
+                                            <ContentPresenter
+                                                x:Name="Icon"
+                                                Content="{TemplateBinding Icon}"
+                                                Foreground="{TemplateBinding Foreground}" />
+                                        </Viewbox>
+                                        <ContentPresenter
+                                            x:Name="ContentPresenter"
+                                            Grid.Column="1"
+                                            Margin="{ThemeResource TopTabBarItemContentMargin}"
+                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            Content="{TemplateBinding Content}"
+                                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                            ContentTransitions="{TemplateBinding ContentTransitions}"
+                                            FontSize="{TemplateBinding FontSize}"
+                                            Foreground="{TemplateBinding Foreground}"
+                                            TextWrapping="NoWrap" />
+                                    </Grid>
+                                </Grid>
+                            </um:Ripple.Content>
+                        </um:Ripple>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <not_mobile:VisualState x:Name="PointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource TopTabBarItemBackgroundPointerOver}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TopTabBarItemPointerFillBrushPointerOver}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource TopTabBarItemIconForegroundPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TopTabBarItemForegroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                                <not_mobile:VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource TopTabBarItemBackgroundPressed}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TopTabBarItemPointerFillBrushPressed}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource TopTabBarItemIconForegroundPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TopTabBarItemForegroundPressed}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                                <VisualState x:Name="Selected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource TopTabBarItemBackgroundSelected}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TopTabBarItemPointerFillBrushSelected}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource TopTabBarItemIconForegroundSelected}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TopTabBarItemForegroundSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <not_mobile:VisualState x:Name="PointerOverSelected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource TopTabBarItemBackgroundSelectedPointerOver}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TopTabBarItemPointerFillBrushSelectedPointerOver}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource TopTabBarItemIconForegroundSelectedPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TopTabBarItemForegroundSelectedPointerOver}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                                <not_mobile:VisualState x:Name="PressedSelected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource TopTabBarItemBackgroundSelectedPressed}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TopTabBarItemPointerFillBrushSelectedPressed}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource TopTabBarItemIconForegroundSelectedPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TopTabBarItemForegroundSelectedPressed}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="FocusStates">
+                                <VisualState x:Name="Focused">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource TopTabBarItemBackgroundFocused}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TopTabBarItemPointerFillBrushFocused}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource TopTabBarItemIconForegroundFocused}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TopTabBarItemForegroundFocused}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerFocused" />
+                                <VisualState x:Name="Unfocused" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="DisabledStates">
+                                <VisualState x:Name="Enabled" />
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource TopTabBarItemBackgroundDisabled}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource TopTabBarItemPointerFillBrushDisabled}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource TopTabBarItemIconForegroundDisabled}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TopTabBarItemForegroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="TabBarIconPositionStates">
+                                <VisualState x:Name="IconOnTop" />
+                                <VisualState x:Name="IconOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="PointerRectangle.Visibility" Value="Visible" />
+                                        <Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ContentOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="IconBox.Visibility" Value="Collapsed" />
+                                        <Setter Target="ContentPresenter.Margin" Value="12,0" />
+                                        <Setter Target="IconRow.Width" Value="0" />
+                                        <Setter Target="ContentRow.Width" Value="*" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style
+        x:Key="MaterialColoredTopTabBarItemStyle"
+        BasedOn="{StaticResource MaterialTopTabBarItemStyle}"
+        TargetType="utu:TabBarItem">
+        <Setter Property="Foreground" Value="{ThemeResource ColoredTopTabBarItemForeground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="utu:TabBarItem">
+                    <Grid
+                        x:Name="LayoutRoot"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Control.IsTemplateFocusTarget="True">
+                        <um:Ripple
+                            x:Name="RippleControl"
+                            Padding="{TemplateBinding Padding}"
+                            AutomationProperties.AccessibilityView="Raw"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Feedback="{ThemeResource ColoredTopTabBarItemRippleFeedback}"
+                            FeedbackOpacity="{StaticResource PressedOpacity}">
+                            <um:Ripple.Content>
+                                <Grid>
+                                    <Rectangle
+                                        x:Name="PointerRectangle"
+                                        Fill="{ThemeResource ColoredTopTabBarItemPointerFillBrush}"
+                                        Visibility="Collapsed" />
+
+                                    <Grid x:Name="ContentGrid" ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="IconRow" Width="*" />
+                                            <ColumnDefinition x:Name="ContentRow" Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <Viewbox
+                                            x:Name="IconBox"
+                                            Width="{ThemeResource TopTabBarItemIconHeight}"
+                                            Height="{ThemeResource TopTabBarItemIconHeight}">
+                                            <ContentPresenter
+                                                x:Name="Icon"
+                                                Content="{TemplateBinding Icon}"
+                                                Foreground="{TemplateBinding Foreground}" />
+                                        </Viewbox>
+                                        <ContentPresenter
+                                            x:Name="ContentPresenter"
+                                            Grid.Column="1"
+                                            Margin="{ThemeResource TopTabBarItemContentMargin}"
+                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            Content="{TemplateBinding Content}"
+                                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                            ContentTransitions="{TemplateBinding ContentTransitions}"
+                                            FontSize="{TemplateBinding FontSize}"
+                                            Foreground="{TemplateBinding Foreground}"
+                                            TextWrapping="NoWrap" />
+                                    </Grid>
+                                </Grid>
+                            </um:Ripple.Content>
+                        </um:Ripple>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <not_mobile:VisualState x:Name="PointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource ColoredTopTabBarItemBackgroundPointerOver}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource ColoredTopTabBarItemPointerFillBrushPointerOver}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource ColoredTopTabBarItemIconForegroundPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ColoredTopTabBarItemForegroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                                <not_mobile:VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource ColoredTopTabBarItemBackgroundPressed}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource ColoredTopTabBarItemPointerFillBrushPressed}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource ColoredTopTabBarItemIconForegroundPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ColoredTopTabBarItemForegroundPressed}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                                <VisualState x:Name="Selected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource ColoredTopTabBarItemBackgroundSelected}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource ColoredTopTabBarItemPointerFillBrushSelected}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource ColoredTopTabBarItemIconForegroundSelected}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ColoredTopTabBarItemForegroundSelected}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <not_mobile:VisualState x:Name="PointerOverSelected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource ColoredTopTabBarItemBackgroundSelectedPointerOver}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource ColoredTopTabBarItemPointerFillBrushSelectedPointerOver}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource ColoredTopTabBarItemIconForegroundSelectedPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ColoredTopTabBarItemForegroundSelectedPointerOver}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                                <not_mobile:VisualState x:Name="PressedSelected">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource ColoredTopTabBarItemBackgroundSelectedPressed}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource ColoredTopTabBarItemPointerFillBrushSelectedPressed}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource ColoredTopTabBarItemIconForegroundSelectedPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ColoredTopTabBarItemForegroundSelectedPressed}" />
+                                    </VisualState.Setters>
+                                </not_mobile:VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="FocusStates">
+                                <VisualState x:Name="Focused">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource ColoredTopTabBarItemBackgroundFocused}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource ColoredTopTabBarItemPointerFillBrushFocused}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource ColoredTopTabBarItemIconForegroundFocused}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ColoredTopTabBarItemForegroundFocused}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerFocused" />
+                                <VisualState x:Name="Unfocused" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="DisabledStates">
+                                <VisualState x:Name="Enabled" />
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource ColoredTopTabBarItemBackgroundDisabled}" />
+                                        <Setter Target="PointerRectangle.Fill" Value="{ThemeResource ColoredTopTabBarItemPointerFillBrushDisabled}" />
+                                        <Setter Target="Icon.Foreground" Value="{ThemeResource ColoredTopTabBarItemIconForegroundDisabled}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ColoredTopTabBarItemForegroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="TabBarIconPositionStates">
+                                <VisualState x:Name="IconOnTop" />
+                                <VisualState x:Name="IconOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="PointerRectangle.Visibility" Value="Visible" />
+                                        <Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ContentOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="IconBox.Visibility" Value="Collapsed" />
+                                        <Setter Target="ContentPresenter.Margin" Value="12,0" />
+                                        <Setter Target="IconRow.Width" Value="0" />
+                                        <Setter Target="ContentRow.Width" Value="*" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <!--#endregion-->
+
+    <!--#region FAB TabBarItem Styles-->
+    <Style x:Key="MaterialBaseFabTabBarItemStyle" TargetType="utu:TabBarItem">
+        <Setter Property="FontFamily" Value="{ThemeResource MaterialMediumFontFamily}" />
+        <Setter Property="FontSize" Value="{ThemeResource LabelMediumFontSize}" />
+        <Setter Property="FontWeight" Value="{ThemeResource LabelMediumFontWeight}" />
+        <Setter Property="IsSelectable" Value="False" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{ThemeResource FabTabBarItemCornerRadius}" />
+        <Setter Property="Padding" Value="{ThemeResource FabTabBarItemPadding}" />
+        <Setter Property="Background" Value="{ThemeResource FabTabBarItemBackground}" />
+        <Setter Property="Foreground" Value="{ThemeResource FabTabBarItemForeground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="utu:TabBarItem">
+                    <Grid HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}">
+                        <toolkit:ElevatedView
+                            x:Name="ElevatedView"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Background="Transparent"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Elevation="6">
+
+                            <um:Ripple
+                                x:Name="Ripple"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                Feedback="{TemplateBinding Foreground}"
+                                FeedbackOpacity="{StaticResource PressedOpacity}">
+                                <Grid CornerRadius="{TemplateBinding CornerRadius}">
+                                    <Grid x:Name="Root" Background="{TemplateBinding Background}">
+                                        <StackPanel
+                                            x:Name="ContentPanel"
+                                            Margin="{TemplateBinding Padding}"
+                                            Orientation="Horizontal">
+
+                                            <!--  Icon  -->
+                                            <Viewbox
+                                                Width="{ThemeResource FabTabBarItemContentWidthOrHeight}"
+                                                Height="{ThemeResource FabTabBarItemContentWidthOrHeight}"
+                                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                Visibility="{Binding Path=Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
+                                                <ContentPresenter
+                                                    x:Name="IconPresenter"
+                                                    Content="{TemplateBinding Icon}"
+                                                    Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource TemplatedParent}}" />
+                                            </Viewbox>
+
+                                            <!--  Icon/Content spacing  -->
+                                            <Border Visibility="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialEmptyToCollapsed}, FallbackValue=Collapsed, TargetNullValue=Collapsed}">
+                                                <Border Width="{ThemeResource FabTabBarItemIconTextPadding}" Visibility="{Binding Path=Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+                                            </Border>
+
+                                            <!--  Content  -->
+                                            <ContentPresenter
+                                                x:Name="ContentPresenter"
+                                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                Content="{TemplateBinding Content}"
+                                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                ContentTransitions="{TemplateBinding ContentTransitions}"
+                                                FontFamily="{TemplateBinding FontFamily}"
+                                                FontSize="{TemplateBinding FontSize}"
+                                                FontWeight="{TemplateBinding FontWeight}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <Border
+                                        x:Name="StateOverlay"
+                                        Background="Transparent"
+                                        CornerRadius="{TemplateBinding CornerRadius}" />
+                                </Grid>
+                            </um:Ripple>
+                        </toolkit:ElevatedView>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="PointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource FabTabBarItemIconForegroundPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource FabTabBarItemForegroundPointerOver}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource FabTabBarItemBackgroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource FabTabBarItemIconForegroundPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource FabTabBarItemForegroundPressed}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource FabTabBarItemBackgroundPressed}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource FabTabBarItemIconForegroundDisabled}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource FabTabBarItemForegroundDisabled}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource FabTabBarItemBackgroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+
+                            <VisualStateGroup x:Name="FocusStates">
+                                <VisualState x:Name="Focused">
+                                    <VisualState.Setters>
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource FabTabBarItemIconForegroundFocused}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource FabTabBarItemForegroundFocused}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource FabTabBarItemBackgroundFocused}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="PointerFocused" />
+                                <VisualState x:Name="Unfocused" />
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style
+        x:Key="MaterialVerticalFabTabBarItemStyle"
+        BasedOn="{StaticResource MaterialBaseFabTabBarItemStyle}"
+        TargetType="utu:TabBarItem" />
+
+    <Style
+        x:Key="MaterialBottomFabTabBarItemStyle"
+        BasedOn="{StaticResource MaterialBaseFabTabBarItemStyle}"
+        TargetType="utu:TabBarItem">
+        <!--  KNOWN ISSUE: The part of the FAB that is translated outside of the TabBar bounds is not clickable  -->
+        <!--  https://github.com/unoplatform/uno/issues/7393  -->
+        <Setter Property="RenderTransform">
+            <Setter.Value>
+                <TranslateTransform Y="{ThemeResource FabTabBarItemOffset}" />
+            </Setter.Value>
+        </Setter>
+
+    </Style>
+    <!--#endregion-->
+
+    <!--#region SelectionIndicator-->
+    <Style x:Key="MaterialTabBarSelectionIndicatorPresenterStyle" TargetType="utu:TabBarSelectionIndicatorPresenter">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="utu:TabBarSelectionIndicatorPresenter">
+                    <Grid
+                        x:Name="Root"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter
+                            x:Name="IndicatorPresenter"
+                            Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorMaxSize.Width}"
+                            Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorMaxSize.Height}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            RenderTransformOrigin=".5,.5">
+                            <ContentPresenter.RenderTransform>
+                                <CompositeTransform x:Name="IndicatorTransform" />
+                            </ContentPresenter.RenderTransform>
+                        </ContentPresenter>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="IndicatorTransitionStates">
+                                <VisualState x:Name="Horizontal">
+                                    <Storyboard x:Name="IndicatorTransitionHorizontalStoryboard">
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="IndicatorTransform"
+                                            Storyboard.TargetProperty="TranslateX"
+                                            From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.X}"
+                                            To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.X}"
+                                            Duration="00:00:00.200" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Vertical">
+                                    <Storyboard x:Name="IndicatorTransitionVerticalStoryboard">
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="IndicatorTransform"
+                                            Storyboard.TargetProperty="TranslateY"
+                                            From="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionFrom.Y}"
+                                            To="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorTransitionTo.Y}"
+                                            Duration="00:00:00.200" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <!--#endregion-->
+
+    <!--#region Default AppBar style-->
+    <Style
+        x:Key="MaterialDefaultMainCommandStyle"
+        BasedOn="{StaticResource MaterialMainCommandStyle}"
+        TargetType="AppBarButton" />
+    <!--#endregion-->
 </ResourceDictionary>


### PR DESCRIPTION
closes #594

GitHub Issue (If applicable): #594


## PR Type
- Refactoring (no functional changes, no api changes)


## Description
Current behaviour:
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/54756963/a61ed85f-b9db-4dfa-8e86-c31c5182885d)

Overriden:
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/54756963/a458e6f1-3d9c-459a-afb7-a7a55c76820e)

Overriden with:

    <Page.Resources>
        <SolidColorBrush x:Key="TopTabBarItemBackground" Color="Red" />
        <SolidColorBrush x:Key="TopTabBarItemBackgroundPointerOver" Color="Orange" />
        <SolidColorBrush x:Key="TopTabBarItemBackgroundFocused" Color="Yellow" />
        <SolidColorBrush x:Key="TopTabBarItemBackgroundPressed" Color="Green" />
        <SolidColorBrush x:Key="TopTabBarItemBackgroundDisabled" Color="Blue" />
        <SolidColorBrush x:Key="TopTabBarItemBackgroundSelected" Color="Indigo" />
        <SolidColorBrush x:Key="TopTabBarItemBackgroundSelectedPointerOver" Color="Pink" />
        <SolidColorBrush x:Key="TopTabBarItemBackgroundSelectedPressed" Color="Red" />

        <SolidColorBrush x:Key="TopTabBarItemForeground" Color="Orange" />
        <SolidColorBrush x:Key="TopTabBarItemForegroundPointerOver" Color="Yellow" />
        <SolidColorBrush x:Key="TopTabBarItemForegroundFocused" Color="Green" />
        <SolidColorBrush x:Key="TopTabBarItemForegroundPressed" Color="Blue" />
        <SolidColorBrush x:Key="TopTabBarItemForegroundDisabled" Color="Indigo" />
        <SolidColorBrush x:Key="TopTabBarItemForegroundSelected" Color="Pink" />
        <SolidColorBrush x:Key="TopTabBarItemForegroundSelectedPointerOver" Color="Red" />
        <SolidColorBrush x:Key="TopTabBarItemForegroundSelectedPressed" Color="Orange" />

        <SolidColorBrush x:Key="TopTabBarItemBorderBrush" Color="Yellow" />

        <SolidColorBrush x:Key="TopTabBarItemIconForeground" Color="Green" />
        <SolidColorBrush x:Key="TopTabBarItemIconForegroundPointerOver" Color="Blue" />
        <SolidColorBrush x:Key="TopTabBarItemIconForegroundFocused" Color="Indigo" />
        <SolidColorBrush x:Key="TopTabBarItemIconForegroundPressed" Color="Pink" />
        <SolidColorBrush x:Key="TopTabBarItemIconForegroundDisabled" Color="Red" />
        <SolidColorBrush x:Key="TopTabBarItemIconForegroundSelected" Color="Orange" />
        <SolidColorBrush x:Key="TopTabBarItemIconForegroundSelectedPointerOver" Color="Yellow" />
        <SolidColorBrush x:Key="TopTabBarItemIconForegroundSelectedPressed" Color="Green" />

        <SolidColorBrush x:Key="TopTabBarItemPointerFillBrush" Color="Blue" />
        <SolidColorBrush x:Key="TopTabBarItemPointerFillBrushPointerOver" Color="Indigo" />
        <SolidColorBrush x:Key="TopTabBarItemPointerFillBrushFocused" Color="Pink" />
        <SolidColorBrush x:Key="TopTabBarItemPointerFillBrushPressed" Color="Red" />
        <SolidColorBrush x:Key="TopTabBarItemPointerFillBrushDisabled" Color="Orange" />
        <SolidColorBrush x:Key="TopTabBarItemPointerFillBrushSelected" Color="Yellow" />
        <SolidColorBrush x:Key="TopTabBarItemPointerFillBrushSelectedPointerOver" Color="Green" />
        <SolidColorBrush x:Key="TopTabBarItemPointerFillBrushSelectedPressed" Color="Blue" />

        <SolidColorBrush x:Key="TopTabBarItemRippleFeedback" Color="Indigo" />
    </Page.Resources>


## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
