### PR TITLE
fix: cupertino tabbar sliding

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.xaml
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.xaml
@@ -47,6 +47,7 @@
 	<x:Double x:Key="TabBarHeightOrWidth">64</x:Double>
 	<x:Double x:Key="TabBarItemIconHeight">16</x:Double>
 	<x:Double x:Key="TabBarItemIconWidth">16</x:Double>
+	<x:Double x:Key="TabBarCornerRadius">8</x:Double>
 	<Thickness x:Key="TabBarItemContentMargin">0,0,0,12</Thickness>
 	<Thickness x:Key="TabBarItemContentOnlyMargin">12,0</Thickness>
 	<Duration x:Key="TabBarIndicatorAnimationDuration">0:0:0.25</Duration>
@@ -64,13 +65,15 @@
 		</Setter>
 		<Setter Property="ItemContainerStyle" Value="{StaticResource DefaultTabBarItemStyle}" />
 		<Setter Property="SelectionIndicatorPresenterStyle" Value="{StaticResource DefaultTabBarSelectionIndicatorPresenterStyle}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource TabBarCornerRadius}"/>
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="utu:TabBar">
 					<Grid x:Name="TabBarGrid"
 						  Background="{TemplateBinding Background}"
 						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}">
+						  BorderThickness="{TemplateBinding BorderThickness}"
+						  CornerRadius="{TemplateBinding CornerRadius}">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="OrientationStates">
 								<VisualState x:Name="Horizontal">

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
@@ -9,206 +9,196 @@
 					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
-                    xmlns:mobile="http://uno.ui/mobile"
-                    xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:mobile="http://uno.ui/mobile"
+					xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					mc:Ignorable="d ios android wasm not_win mobile">
 
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackground"
-							ResourceKey="SystemControlTransparentBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundPointerOver"
-							ResourceKey="SystemControlTransparentBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundPressed"
-							ResourceKey="SystemControlTransparentBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundSelected"
-							ResourceKey="SystemControlTransparentBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundSelectedPointerOver"
-							ResourceKey="SystemControlTransparentBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundSelectedPressed"
-							ResourceKey="SystemControlTransparentBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackground"
+					ResourceKey="SystemControlTransparentBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundPointerOver"
+					ResourceKey="SystemControlTransparentBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundPressed"
+					ResourceKey="SystemControlTransparentBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundSelected"
+					ResourceKey="SystemControlTransparentBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundSelectedPointerOver"
+					ResourceKey="SystemControlTransparentBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemBackgroundSelectedPressed"
+					ResourceKey="SystemControlTransparentBrush" />
 
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemForeground"
-							ResourceKey="CupertinoLabelBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundPointerOver"
-							ResourceKey="CupertinoLabelBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundDisabled"
-							ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundSelected"
-							ResourceKey="CupertinoLabelBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundSelectedPointerOver"
-							ResourceKey="CupertinoLabelBrush" />
-    <StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundSelectedPressed"
-							ResourceKey="CupertinoLabelBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemForeground"
+					ResourceKey="CupertinoLabelBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundPointerOver"
+					ResourceKey="CupertinoLabelBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundDisabled"
+					ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundSelected"
+					ResourceKey="CupertinoLabelBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundSelectedPointerOver"
+					ResourceKey="CupertinoLabelBrush" />
+	<StaticResource x:Key="CupertinoSlidingSegmentedControlItemForegroundSelectedPressed"
+					ResourceKey="CupertinoLabelBrush" />
 
-    <StaticResource x:Key="TabBarItemBorderBrush"
-							ResourceKey="SystemControlTransparentBrush" />
+	<StaticResource x:Key="TabBarItemBorderBrush"
+					ResourceKey="SystemControlTransparentBrush" />
 
-    <x:Double x:Key="CupertinoSlidingSegmentedControlFontSize">12</x:Double>
-    <FontFamily x:Key="CupertinoSlidingSegmentedControlFontFamily">SF Pro</FontFamily>
-    <x:Double x:Key="CupertinoSlidingSegmentedControlHeight">28</x:Double>
-    <x:Double x:Key="CupertinoSlidingSegmentedItemIconHeight">16</x:Double>
-    <x:Double x:Key="CupertinoSlidingSegmentedItemIconWidth">16</x:Double>
-    <Thickness x:Key="CupertinoSlidingSegmentedItemContentMargin">0,0,0,12</Thickness>
-    <Thickness x:Key="CupertinoSlidingSegmentedItemContentOnlyMargin">12,0</Thickness>
-    <SolidColorBrush x:Key="CupertinoSlidingSegmentedControlItemForegroundPressed"
-						Color="{ThemeResource LabelColor}"
-						Opacity="0.2" />
+	<x:Double x:Key="CupertinoSlidingSegmentedControlFontSize">12</x:Double>
+	<FontFamily x:Key="CupertinoSlidingSegmentedControlFontFamily">SF Pro</FontFamily>
+	<x:Double x:Key="CupertinoSlidingSegmentedControlHeight">28</x:Double>
+	<x:Double x:Key="CupertinoSlidingSegmentedItemIconHeight">16</x:Double>
+	<x:Double x:Key="CupertinoSlidingSegmentedItemIconWidth">16</x:Double>
+	<Thickness x:Key="CupertinoSlidingSegmentedItemContentMargin">0,0,0,12</Thickness>
+	<Thickness x:Key="CupertinoSlidingSegmentedItemContentOnlyMargin">12,0</Thickness>
+	<SolidColorBrush x:Key="CupertinoSlidingSegmentedControlItemForegroundPressed"
+					 Color="{ThemeResource LabelColor}"
+					 Opacity="0.2" />
 
 
-    <utu:InflateDimensionConverter x:Key="DeflateWidthConverter"
+	<utu:InflateDimensionConverter x:Key="DeflateWidthConverter"
 								   Inflation="-4" />
 
-    <mobile:Style x:Key="CupertinoSlidingSegmentedStyle"
-		   TargetType="utu:TabBar">
-        <Setter Property="Background"
+	<mobile:Style x:Key="CupertinoSlidingSegmentedStyle"
+				  BasedOn="{StaticResource DefaultTabBarStyle}"
+				  TargetType="utu:TabBar">
+		<Setter Property="Background"
 				Value="{ThemeResource CupertinoTertiarySystemFillBrush}" />
-        <Setter Property="IsTabStop"
+		<Setter Property="IsTabStop"
 				Value="False" />
-        <Setter Property="Height"
+		<Setter Property="Height"
 				Value="{StaticResource CupertinoSlidingSegmentedControlHeight}" />
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <utu:TabBarListPanel />
-                </ItemsPanelTemplate>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="ItemContainerStyle"
+		<Setter Property="SelectionIndicatorTransitionMode"
+				Value="Slide" />
+		<Setter Property="SelectionIndicatorPlacement"
+				Value="Below" />
+		<Setter Property="ItemsPanel">
+			<Setter.Value>
+				<ItemsPanelTemplate>
+					<utu:TabBarListPanel />
+				</ItemsPanelTemplate>
+			</Setter.Value>
+		</Setter>
+		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource CupertinoSlidingSegmentedItemStyle}" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="utu:TabBar">
-                    <Grid x:Name="TabBarGrid"
-						  CornerRadius="8"
-						  Background="{TemplateBinding Background}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}"
-						  Height="{TemplateBinding Height}">
-                        <utu:TabBarSelectionIndicatorPresenter Owner="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-															   x:Name="SelectionIndicatorPresenter"
-															   AutomationProperties.AutomationId="SelectionIndicatorPresenter"
-															   IndicatorTransitionMode="Slide"
-															   Opacity="0">
-                            <toolkit:ElevatedView Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}"
-												  Height="28"
-												  Background="Transparent"
-												  CornerRadius="8"
-												  Elevation="5"
-												  ShadowColor="#CC94949A">
-                                <Rectangle Fill="{ThemeResource SystemBackgroundColor}"
-										   VerticalAlignment="Stretch"
-										   HorizontalAlignment="Stretch"
-										   RadiusX="8"
-										   RadiusY="8"
-										   Height="24"
-										   Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth, Converter={StaticResource DeflateWidthConverter}}" />
-                            </toolkit:ElevatedView>
-                        </utu:TabBarSelectionIndicatorPresenter>
+		<Setter Property="SelectionIndicatorContentTemplate">
+			<Setter.Value>
+				<DataTemplate>
+					<toolkit:ElevatedView Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}"
+										  Height="28"
+										  Background="Transparent"
+										  CornerRadius="8"
+										  Elevation="5"
+										  ShadowColor="#CC94949A">
+						<Rectangle Fill="{ThemeResource SystemBackgroundColor}"
+								   VerticalAlignment="Stretch"
+								   HorizontalAlignment="Stretch"
+								   RadiusX="8"
+								   RadiusY="8"
+								   Height="24"
+								   Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth, Converter={StaticResource DeflateWidthConverter}}" />
+					</toolkit:ElevatedView>
+				</DataTemplate>
+			</Setter.Value>
+		</Setter>
+	</mobile:Style>
 
-                        <ItemsPresenter Padding="{TemplateBinding Padding}" />
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </mobile:Style>
-
-    <mobile:Style x:Key="CupertinoSlidingSegmentedItemStyle"
-		   TargetType="utu:TabBarItem">
-        <Setter Property="Background"
+	<mobile:Style x:Key="CupertinoSlidingSegmentedItemStyle"
+				  TargetType="utu:TabBarItem">
+		<Setter Property="Background"
 				Value="{ThemeResource CupertinoSlidingSegmentedControlItemBackground}" />
-        <Setter Property="BorderBrush"
+		<Setter Property="BorderBrush"
 				Value="{ThemeResource TabBarItemBorderBrush}" />
-        <Setter Property="FontFamily"
+		<Setter Property="FontFamily"
 				Value="{StaticResource CupertinoSlidingSegmentedControlFontFamily}" />
-        <Setter Property="FontSize"
+		<Setter Property="FontSize"
 				Value="{StaticResource CupertinoSlidingSegmentedControlFontSize}" />
-        <Setter Property="FontWeight"
+		<Setter Property="FontWeight"
 				Value="Normal" />
-        <Setter Property="UseSystemFocusVisuals"
+		<Setter Property="UseSystemFocusVisuals"
 				Value="True" />
-        <Setter Property="HorizontalContentAlignment"
+		<Setter Property="HorizontalContentAlignment"
 				Value="Center" />
-        <Setter Property="CornerRadius"
+		<Setter Property="CornerRadius"
 				Value="6" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="utu:TabBarItem">
-                    <Grid x:Name="LayoutRoot"
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:TabBarItem">
+					<Grid x:Name="LayoutRoot"
 						  Background="Transparent"
 						  BorderBrush="{TemplateBinding BorderBrush}"
 						  BorderThickness="{TemplateBinding BorderThickness}"
 						  CornerRadius="{TemplateBinding CornerRadius}"
 						  Control.IsTemplateFocusTarget="True">
 
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="PointerStates">
-                                <VisualState x:Name="Normal" />
-                                <VisualState x:Name="Selected">
-                                    <VisualState.Setters>
-                                        <Setter Target="LayoutRoot.Background"
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="PointerStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="Selected">
+									<VisualState.Setters>
+										<Setter Target="LayoutRoot.Background"
 												Value="{ThemeResource CupertinoSlidingSegmentedControlItemBackgroundSelected}" />
-                                        <Setter Target="PointerRectangle.Fill"
+										<Setter Target="PointerRectangle.Fill"
 												Value="{ThemeResource CupertinoSlidingSegmentedControlItemBackgroundSelected}" />
-                                        <Setter Target="Icon.Foreground"
+										<Setter Target="Icon.Foreground"
 												Value="{ThemeResource CupertinoSlidingSegmentedControlItemForegroundSelected}" />
-                                        <Setter Target="ContentPresenter.Foreground"
+										<Setter Target="ContentPresenter.Foreground"
 												Value="{ThemeResource CupertinoSlidingSegmentedControlItemForegroundSelected}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="DisabledStates">
-                                <VisualState x:Name="Enabled" />
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="Icon.Foreground"
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="DisabledStates">
+								<VisualState x:Name="Enabled" />
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="Icon.Foreground"
 												Value="{ThemeResource CupertinoSlidingSegmentedControlItemForegroundDisabled}" />
-                                        <Setter Target="ContentPresenter.Foreground"
+										<Setter Target="ContentPresenter.Foreground"
 												Value="{ThemeResource CupertinoSlidingSegmentedControlItemForegroundDisabled}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="TabBarIconPositionStates">
-                                <VisualState x:Name="IconOnTop" />
-                                <VisualState x:Name="IconOnly">
-                                    <VisualState.Setters>
-                                        <Setter Target="PointerRectangle.Visibility"
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="TabBarIconPositionStates">
+								<VisualState x:Name="IconOnTop" />
+								<VisualState x:Name="IconOnly">
+									<VisualState.Setters>
+										<Setter Target="PointerRectangle.Visibility"
 												Value="Visible" />
-                                        <Setter Target="ContentPresenter.Visibility"
+										<Setter Target="ContentPresenter.Visibility"
 												Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ContentOnly">
-                                    <VisualState.Setters>
-                                        <Setter Target="IconBox.Visibility"
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="ContentOnly">
+									<VisualState.Setters>
+										<Setter Target="IconBox.Visibility"
 												Value="Collapsed" />
-                                        <Setter Target="ContentPresenter.Margin"
+										<Setter Target="ContentPresenter.Margin"
 												Value="{StaticResource CupertinoSlidingSegmentedItemContentOnlyMargin}" />
-                                        <Setter Target="IconRow.Width"
+										<Setter Target="IconRow.Width"
 												Value="0" />
-                                        <Setter Target="ContentRow.Width"
+										<Setter Target="ContentRow.Width"
 												Value="*" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-                        <Rectangle x:Name="PointerRectangle"
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+						<Rectangle x:Name="PointerRectangle"
 								   Fill="Transparent"
 								   Visibility="Collapsed" />
 
-                        <Grid x:Name="ContentGrid">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="IconRow"
+						<Grid x:Name="ContentGrid">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition x:Name="IconRow"
 												  Width="*" />
-                                <ColumnDefinition x:Name="ContentRow"
+								<ColumnDefinition x:Name="ContentRow"
 												  Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Viewbox x:Name="IconBox"
+							</Grid.ColumnDefinitions>
+							<Viewbox x:Name="IconBox"
 									 Height="{StaticResource CupertinoSlidingSegmentedItemIconHeight}"
 									 Width="{StaticResource CupertinoSlidingSegmentedItemIconWidth}">
-                                <ContentPresenter x:Name="Icon"
+								<ContentPresenter x:Name="Icon"
 												  Content="{TemplateBinding Icon}" />
-                            </Viewbox>
-                            <ContentPresenter x:Name="ContentPresenter"
+							</Viewbox>
+							<ContentPresenter x:Name="ContentPresenter"
 											  Grid.Column="1"
 											  TextWrapping="NoWrap"
 											  FontSize="{TemplateBinding FontSize}"
@@ -220,15 +210,15 @@
 											  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
 											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 											  AutomationProperties.AccessibilityView="Raw" />
-                        </Grid>
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </mobile:Style>
-    
-    <not_mobile:Style x:Key="CupertinoSlidingSegmentedItemStyle"
-		   TargetType="utu:TabBarItem">
+						</Grid>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</mobile:Style>
+
+	<not_mobile:Style x:Key="CupertinoSlidingSegmentedItemStyle"
+					  TargetType="utu:TabBarItem">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoSlidingSegmentedControlItemBackground}" />
 		<Setter Property="BorderBrush"
@@ -390,14 +380,19 @@
 		</Setter>
 	</not_mobile:Style>
 
-    <not_mobile:Style x:Key="CupertinoSlidingSegmentedStyle"
-		   TargetType="utu:TabBar">
+	<not_mobile:Style x:Key="CupertinoSlidingSegmentedStyle"
+					  BasedOn="{StaticResource DefaultTabBarStyle}"
+					  TargetType="utu:TabBar">
 		<Setter Property="Background"
 				Value="{ThemeResource CupertinoTertiarySystemFillBrush}" />
 		<Setter Property="IsTabStop"
 				Value="False" />
-		<Setter Property="Height"
+		<Setter Property="MinHeight"
 				Value="{StaticResource CupertinoSlidingSegmentedControlHeight}" />
+		<Setter Property="SelectionIndicatorTransitionMode"
+				Value="Slide" />
+		<Setter Property="SelectionIndicatorPlacement"
+				Value="Below" />
 		<Setter Property="ItemsPanel">
 			<Setter.Value>
 				<ItemsPanelTemplate>
@@ -407,39 +402,24 @@
 		</Setter>
 		<Setter Property="ItemContainerStyle"
 				Value="{StaticResource CupertinoSlidingSegmentedItemStyle}" />
-		<Setter Property="Template">
+		<Setter Property="SelectionIndicatorContentTemplate">
 			<Setter.Value>
-				<ControlTemplate TargetType="utu:TabBar">
-					<Grid x:Name="TabBarGrid"
-						  CornerRadius="8"
-						  Background="{TemplateBinding Background}"
-						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}"
-						  Height="{TemplateBinding Height}">
-						<utu:TabBarSelectionIndicatorPresenter Owner="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-															   x:Name="SelectionIndicatorPresenter"
-															   AutomationProperties.AutomationId="SelectionIndicatorPresenter"
-															   IndicatorTransitionMode="Slide"
-															   Opacity="0">
-							<toolkit:ElevatedView Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}"
-												  Height="28"
-												  Background="Transparent"
-												  CornerRadius="8"
-												  Elevation="5"
-												  ShadowColor="#CC94949A">
-								<Rectangle Fill="{ThemeResource SystemBackgroundColor}"
-										   VerticalAlignment="Stretch"
-										   HorizontalAlignment="Stretch"
-										   RadiusX="8"
-										   RadiusY="8"
-										   Height="24"
-										   Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth, Converter={StaticResource DeflateWidthConverter}}" />
-							</toolkit:ElevatedView>
-						</utu:TabBarSelectionIndicatorPresenter>
-
-						<ItemsPresenter Padding="{TemplateBinding Padding}" />
-					</Grid>
-				</ControlTemplate>
+				<DataTemplate>
+					<toolkit:ElevatedView Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}"
+										  Height="28"
+										  Background="Transparent"
+										  CornerRadius="8"
+										  Elevation="5"
+										  ShadowColor="#CC94949A">
+						<Rectangle Fill="{ThemeResource SystemBackgroundColor}"
+								   VerticalAlignment="Stretch"
+								   HorizontalAlignment="Stretch"
+								   RadiusX="8"
+								   RadiusY="8"
+								   Height="24"
+								   Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth, Converter={StaticResource DeflateWidthConverter}}" />
+					</toolkit:ElevatedView>
+				</DataTemplate>
 			</Setter.Value>
 		</Setter>
 	</not_mobile:Style>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #524 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- Cupertino TabBar selector now is visually correct (selects the correct index).
- Added CornerRadius of 8 for base TabBar.
- Refactored `CupertinoSlidingSegmentedStyle` to not use the old SelectionIndicator

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

![cupertino_sliding](https://github.com/unoplatform/uno.toolkit.ui/assets/70542961/8ae9634a-a395-442a-8ae7-7519ad4307b0)
