### PR TITLE
refactor(chip): Add lightweight styling to Chip style and add Fluent theme for Chip and ChipGroup

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Converters.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Converters.xaml
@@ -1,25 +1,45 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:converters="using:Uno.Toolkit.Samples.Converters">
-	
-	<converters:FromStringToValueConverter x:Key="IsNullOrEmptyToCollapsed"
-										   Check="IsNullOrEmpty"
-										   TrueValue="Collapsed"
-										   FalseValue="Visible" />
-	
-	<converters:FromStringToValueConverter x:Key="SelectedItemToVisible"
-										   Check="IsEqualToParameterValue"
-										   TrueValue="Visible"
-										   FalseValue="Collapsed" />
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Uno.Toolkit.Samples.Converters">
 
-	<converters:EnumDescriptionConverter x:Name="EnumToDescription" />
+    <converters:FromStringToValueConverter
+        x:Key="IsNullOrEmptyToCollapsed"
+        Check="IsNullOrEmpty"
+        FalseValue="Visible"
+        TrueValue="Collapsed" />
 
-	<converters:FromBoolToValueConverter x:Key="NotTrue"
-										 TrueValue="False"
-										 NullOrFalseValue="True" />
+    <converters:FromStringToValueConverter
+        x:Key="SelectedItemToVisible"
+        Check="IsEqualToParameterValue"
+        FalseValue="Collapsed"
+        TrueValue="Visible" />
 
-	<converters:FromBoolToValueConverter x:Key="IsFalse"
-										 FalseValue="True"
-										 NullOrTrueValue="False" />
-	
+    <converters:EnumDescriptionConverter x:Name="EnumToDescription" />
+
+    <converters:FromBoolToValueConverter
+        x:Key="NotTrue"
+        NullOrFalseValue="True"
+        TrueValue="False" />
+
+    <converters:FromBoolToValueConverter
+        x:Key="IsFalse"
+        FalseValue="True"
+        NullOrTrueValue="False" />
+
+    <converters:FromNullToValueConverter
+        x:Key="NullToCollapsed"
+        NotNullValue="Visible"
+        NullValue="Collapsed" />
+
+    <converters:FromNullToValueConverter
+        x:Key="NullToVisible"
+        NotNullValue="Collapsed"
+        NullValue="Visible" />
+
+    <converters:FromBoolToValueConverter
+        x:Key="FalseToCollapsed"
+        NullOrFalseValue="Collapsed"
+        TrueValue="Visible" />
+
 </ResourceDictionary>

--- a/src/Uno.Toolkit.UI/Controls/Chips/Chip.xaml
+++ b/src/Uno.Toolkit.UI/Controls/Chips/Chip.xaml
@@ -1,0 +1,369 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:not_win="http://uno.ui/not_win"
+    xmlns:todo="what should be done"
+    xmlns:toolkit="using:Uno.UI.Toolkit"
+    xmlns:utu="using:Uno.Toolkit.UI"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    mc:Ignorable="not_win todo">
+
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <x:Double x:Key="ChipCheckGlyphSize">20</x:Double>
+            <x:Double x:Key="ChipContentMinHeight">20</x:Double>
+            <x:Double x:Key="ChipDeleteIconContainerLength">18</x:Double>
+            <x:Double x:Key="ChipDeleteIconLength">11</x:Double>
+            <x:Double x:Key="ChipElevation">4</x:Double>
+            <x:Double x:Key="ChipElevationDisabled">0</x:Double>
+            <x:Double x:Key="ChipHeight">32</x:Double>
+            <x:Double x:Key="ChipIconSize">18</x:Double>
+            <x:Double x:Key="ChipSize">12</x:Double>
+
+            <CornerRadius x:Key="ChipCornerRadius">2</CornerRadius>
+            <Thickness x:Key="ChipBorderThickness">1</Thickness>
+            <Thickness x:Key="ChipCheckGlyphPadding">2</Thickness>
+            <Thickness x:Key="ChipContentMargin">8,0</Thickness>
+            <Thickness x:Key="ChipElevationMargin">4</Thickness>
+            <Thickness x:Key="ChipPadding">8,0</Thickness>
+
+            <!--  Brushes  -->
+            <StaticResource x:Key="ChipBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundDisabled" ResourceKey="ControlFillColorDisabledBrush" />
+            <StaticResource x:Key="ChipBackgroundChecked" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedPointerOver" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="ChipForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="ChipForegroundFocused" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="ChipForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="ChipForegroundChecked" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedFocused" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipDeleteIconBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipDeleteIconForeground" ResourceKey="TextFillColorPrimaryBrush" />
+
+            <StaticResource x:Key="ChipIconForeground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundFocused" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="ChipIconForegroundChecked" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedFocused" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+
+            <StaticResource x:Key="ChipBorderBrush" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushFocused" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="ChipBorderBrushDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="ChipBorderBrushChecked" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedPointerOver" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedFocused" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+
+            <StaticResource x:Key="ChipStateOverlay" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipStateOverlayFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="ChipStateOverlayDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayChecked" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedPointerOver" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Light">
+            <x:Double x:Key="ChipCheckGlyphSize">20</x:Double>
+            <x:Double x:Key="ChipContentMinHeight">20</x:Double>
+            <x:Double x:Key="ChipDeleteIconContainerLength">18</x:Double>
+            <x:Double x:Key="ChipDeleteIconLength">11</x:Double>
+            <x:Double x:Key="ChipElevation">4</x:Double>
+            <x:Double x:Key="ChipElevationDisabled">0</x:Double>
+            <x:Double x:Key="ChipHeight">32</x:Double>
+            <x:Double x:Key="ChipIconSize">18</x:Double>
+            <x:Double x:Key="ChipSize">12</x:Double>
+
+            <CornerRadius x:Key="ChipCornerRadius">2</CornerRadius>
+            <Thickness x:Key="ChipBorderThickness">1</Thickness>
+            <Thickness x:Key="ChipCheckGlyphPadding">2</Thickness>
+            <Thickness x:Key="ChipContentMargin">8,0</Thickness>
+            <Thickness x:Key="ChipElevationMargin">4</Thickness>
+            <Thickness x:Key="ChipPadding">8,0</Thickness>
+
+            <!--  Brushes  -->
+            <StaticResource x:Key="ChipBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundDisabled" ResourceKey="ControlFillColorDisabledBrush" />
+            <StaticResource x:Key="ChipBackgroundChecked" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedPointerOver" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="ChipForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="ChipForegroundFocused" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="ChipForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="ChipForegroundChecked" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedFocused" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipDeleteIconBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipDeleteIconForeground" ResourceKey="TextFillColorPrimaryBrush" />
+
+            <StaticResource x:Key="ChipIconForeground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundFocused" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="ChipIconForegroundChecked" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedFocused" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+
+            <StaticResource x:Key="ChipBorderBrush" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushFocused" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="ChipBorderBrushDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="ChipBorderBrushChecked" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedPointerOver" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedFocused" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+
+            <StaticResource x:Key="ChipStateOverlay" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+            <StaticResource x:Key="ChipStateOverlayFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="ChipStateOverlayDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayChecked" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedPointerOver" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    <x:String x:Key="ChipDeleteIcon">M11.25 1.8075L10.1925 0.75L6 4.9425L1.8075 0.75L0.75 1.8075L4.9425 6L0.75 10.1925L1.8075 11.25L6 7.0575L10.1925 11.25L11.25 10.1925L7.0575 6L11.25 1.8075Z</x:String>
+    <x:String x:Key="CheckGlyphPathData">M28.718018,0L32,3.2819897 10.666016,24.616999 0,13.951997 3.2810059,10.670007 10.666016,18.055033z</x:String>
+
+    <Style x:Key="ChipDeleteIconButtonStyle" TargetType="Button">
+        <Setter Property="Foreground" Value="{ThemeResource ChipDeleteIconForeground}" />
+        <Setter Property="Background" Value="{ThemeResource ChipDeleteIconBackground}" />
+
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border
+                        x:Name="BorderRoot"
+                        Width="{ThemeResource ChipDeleteIconContainerLength}"
+                        Height="{ThemeResource ChipDeleteIconContainerLength}"
+                        Background="{TemplateBinding Background}">
+
+                        <Path
+                            x:Name="GlyphElement"
+                            Width="{ThemeResource ChipDeleteIconLength}"
+                            Height="{ThemeResource ChipDeleteIconLength}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            AutomationProperties.AccessibilityView="Raw"
+                            Data="{StaticResource ChipDeleteIcon}"
+                            Fill="{TemplateBinding Foreground}"
+                            Stretch="Uniform" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="DefaultChipStyle" TargetType="utu:Chip">
+        <Setter Property="Foreground" Value="{ThemeResource ChipForeground}" />
+        <Setter Property="Background" Value="{ThemeResource ChipBackground}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource ChipBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipBorderThickness}" />
+        <Setter Property="CornerRadius" Value="{ThemeResource ChipCornerRadius}" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="{ThemeResource ChipPadding}" />
+
+        <Setter Property="Icon" Value="{x:Null}" />
+
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="utu:Chip">
+                    <Grid>
+                        <toolkit:ElevatedView
+                            x:Name="ElevatedRoot"
+                            Height="{ThemeResource ChipHeight}"
+                            Margin="{ThemeResource ChipElevationMargin}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Elevation="{TemplateBinding Elevation}">
+
+                            <Grid CornerRadius="{TemplateBinding CornerRadius}">
+
+                                <Border
+                                    x:Name="StateOverlay"
+                                    Background="{ThemeResource ChipStateOverlay}"
+                                    CornerRadius="{TemplateBinding CornerRadius}" />
+
+                                <Grid Padding="{TemplateBinding Padding}">
+                                    <Grid.ColumnDefinitions>
+                                        <!--  0: Leading Icon, 1: Content: 2: Remove Button  -->
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <!--
+                                        C0: Leading Icon / Check Glyph
+                                        fixme: ContentControl/Presenter template-binding to icon would crash on uwp
+                                    -->
+                                    <ContentPresenter
+                                        x:Name="IconPresenter"
+                                        Grid.Column="0"
+                                        Width="{ThemeResource ChipIconSize}"
+                                        Height="{ThemeResource ChipIconSize}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        Content="{TemplateBinding Icon}"
+                                        ContentTemplate="{TemplateBinding IconTemplate}"
+                                        Foreground="{ThemeResource ChipIconForeground}"
+                                        Visibility="{Binding Icon, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource NullToCollapsed}, FallbackValue=Collapsed}" />
+
+                                    <Grid
+                                        x:Name="CheckGlyphElement"
+                                        Grid.Column="0"
+                                        Width="{ThemeResource ChipCheckGlyphSize}"
+                                        Height="{ThemeResource ChipCheckGlyphSize}"
+                                        Padding="{ThemeResource ChipCheckGlyphPadding}"
+                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        Visibility="Collapsed">
+                                        <Path
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            Data="{StaticResource CheckGlyphPathData}"
+                                            Fill="{TemplateBinding Foreground}"
+                                            Stretch="Uniform"
+                                            Visibility="{Binding Icon, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource NullToVisible}, FallbackValue=Collapsed}" />
+                                    </Grid>
+                                    <!--  C1: Content  -->
+                                    <ContentPresenter
+                                        x:Name="ContentPresenter"
+                                        Grid.Column="1"
+                                        Margin="{ThemeResource ChipContentMargin}"
+                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        CharacterSpacing="7"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        ContentTransitions="{TemplateBinding ContentTransitions}"
+                                        Foreground="{TemplateBinding Foreground}" />
+                                    <!--  C2: Remove Button  -->
+                                    <Button
+                                        x:Name="PART_RemoveButton"
+                                        Grid.Column="2"
+                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Style="{StaticResource ChipDeleteIconButtonStyle}"
+                                        Visibility="{Binding CanRemove, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource FalseToCollapsed}, FallbackValue=Collapsed}" />
+                                </Grid>
+                            </Grid>
+                        </toolkit:ElevatedView>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="PointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundPointerOver}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushPointerOver}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundPointerOver}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundPressed}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushPressed}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundPressed}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundPressed}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Elevation" Value="{ThemeResource ChipElevationDisabled}" />
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundDisabled}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushDisabled}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayDisabled}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundDisabled}" />
+                                        <Setter Target="PART_RemoveButton.Foreground" Value="{ThemeResource ChipIconForegroundDisabled}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Checked">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundChecked}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushChecked}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayChecked}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundChecked}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundChecked}" />
+                                        <Setter Target="CheckGlyphElement.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundCheckedPointerOver}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushCheckedPointerOver}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayCheckedPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundCheckedPointerOver}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundCheckedPointerOver}" />
+                                        <Setter Target="CheckGlyphElement.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundCheckedPressed}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushCheckedPressed}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayCheckedPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundCheckedPressed}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundCheckedPressed}" />
+                                        <Setter Target="CheckGlyphElement.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.xaml
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:android="http://uno.ui/android"
+    xmlns:ios="http://uno.ui/ios"
+    xmlns:macos="http://uno.ui/macos"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:toolkit="using:Uno.UI.Toolkit"
+    xmlns:utu="using:Uno.Toolkit.UI"
+    xmlns:wasm="http://uno.ui/wasm"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    mc:Ignorable="android ios wasm macos">
+
+    <ItemsPanelTemplate x:Key="ChipGroupItemsPanel">
+        <StackPanel Orientation="Horizontal" Spacing="8" />
+    </ItemsPanelTemplate>
+
+    <Style x:Key="DefaultChipGroupStyle" TargetType="utu:ChipGroup">
+        <Setter Property="ItemsPanel" Value="{StaticResource ChipGroupItemsPanel}" />
+    </Style>
+</ResourceDictionary>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Chip.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Chip.xaml
@@ -1,234 +1,252 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:not_win="http://uno.ui/not_win"
-                    xmlns:todo="what should be done"
-                    xmlns:toolkit="using:Uno.UI.Toolkit"
-                    xmlns:um="using:Uno.Material"
-                    xmlns:utu="using:Uno.Toolkit.UI"
-                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    mc:Ignorable="not_win todo">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:not_win="http://uno.ui/not_win"
+    xmlns:todo="what should be done"
+    xmlns:toolkit="using:Uno.UI.Toolkit"
+    xmlns:um="using:Uno.Material"
+    xmlns:utu="using:Uno.Toolkit.UI"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    mc:Ignorable="not_win todo">
+
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <x:Double x:Key="ChipCheckGlyphSize">20</x:Double>
+            <x:Double x:Key="ChipContentMinHeight">20</x:Double>
+            <x:Double x:Key="ChipDeleteIconContainerLength">18</x:Double>
+            <x:Double x:Key="ChipDeleteIconLength">11</x:Double>
+            <x:Double x:Key="ChipElevation">4</x:Double>
+            <x:Double x:Key="ChipElevationDisabled">0</x:Double>
+            <x:Double x:Key="ChipHeight">32</x:Double>
+            <x:Double x:Key="ChipIconSize">18</x:Double>
+            <x:Double x:Key="ChipSize">12</x:Double>
+
+            <CornerRadius x:Key="ChipCornerRadius">8</CornerRadius>
+            <Thickness x:Key="ChipBorderThickness">1</Thickness>
+            <Thickness x:Key="ChipCheckGlyphPadding">2</Thickness>
+            <Thickness x:Key="ChipContentMargin">8,0</Thickness>
+            <Thickness x:Key="ChipElevationBorderThickness">0</Thickness>
+            <Thickness x:Key="ChipElevationMargin">4</Thickness>
+            <Thickness x:Key="ChipPadding">8,0</Thickness>
+
+            <!--  Brushes  -->
+            <StaticResource x:Key="ChipBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+            <StaticResource x:Key="ChipBackgroundChecked" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedPointerOver" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedPressed" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipForeground" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="ChipForegroundPointerOver" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="ChipForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipForegroundPressed" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="ChipForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+            <StaticResource x:Key="ChipForegroundChecked" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedPointerOver" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedPressed" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipDeleteIconBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipDeleteIconForeground" ResourceKey="OnSurfaceVariantBrush" />
+
+            <StaticResource x:Key="ChipIconForeground" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundPressed" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+            <StaticResource x:Key="ChipIconForegroundChecked" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedPressed" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipBorderBrush" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushPointerOver" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBorderBrushPressed" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushDisabled" ResourceKey="OnSurfaceVariantDisabledLowBrush" />
+            <StaticResource x:Key="ChipBorderBrushChecked" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedPointerOver" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedPressed" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipStateOverlay" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayPointerOver" ResourceKey="OnSurfaceVariantHoverBrush" />
+            <StaticResource x:Key="ChipStateOverlayFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayPressed" ResourceKey="OnSurfaceVariantPressedBrush" />
+            <StaticResource x:Key="ChipStateOverlayDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayChecked" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedPointerOver" ResourceKey="OnSecondaryContainerHoverBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedPressed" ResourceKey="OnSecondaryContainerSelectedBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipRippleFeedback" ResourceKey="OnSurfaceFocusedBrush" />
+
+            <StaticResource x:Key="ElevatedChipBackground" ResourceKey="SurfaceBrush" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Light">
+            <x:Double x:Key="ChipCheckGlyphSize">20</x:Double>
+            <x:Double x:Key="ChipContentMinHeight">20</x:Double>
+            <x:Double x:Key="ChipDeleteIconContainerLength">18</x:Double>
+            <x:Double x:Key="ChipDeleteIconLength">11</x:Double>
+            <x:Double x:Key="ChipElevation">4</x:Double>
+            <x:Double x:Key="ChipElevationDisabled">0</x:Double>
+            <x:Double x:Key="ChipHeight">32</x:Double>
+            <x:Double x:Key="ChipIconSize">18</x:Double>
+            <x:Double x:Key="ChipSize">12</x:Double>
+
+            <CornerRadius x:Key="ChipCornerRadius">8</CornerRadius>
+            <Thickness x:Key="ChipBorderThickness">1</Thickness>
+            <Thickness x:Key="ChipCheckGlyphPadding">2</Thickness>
+            <Thickness x:Key="ChipContentMargin">8,0</Thickness>
+            <Thickness x:Key="ChipElevationBorderThickness">0</Thickness>
+            <Thickness x:Key="ChipElevationMargin">4</Thickness>
+            <Thickness x:Key="ChipPadding">8,0</Thickness>
+
+            <!--  Brushes  -->
+            <StaticResource x:Key="ChipBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+            <StaticResource x:Key="ChipBackgroundChecked" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedPointerOver" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedPressed" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="ChipBackgroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipForeground" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="ChipForegroundPointerOver" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="ChipForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipForegroundPressed" ResourceKey="OnSurfaceVariantBrush" />
+            <StaticResource x:Key="ChipForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+            <StaticResource x:Key="ChipForegroundChecked" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedPointerOver" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedPressed" ResourceKey="OnSecondaryContainerBrush" />
+            <StaticResource x:Key="ChipForegroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipDeleteIconBackground" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipDeleteIconForeground" ResourceKey="OnSurfaceVariantBrush" />
+
+            <StaticResource x:Key="ChipIconForeground" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundPressed" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
+            <StaticResource x:Key="ChipIconForegroundChecked" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedPointerOver" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedPressed" ResourceKey="PrimaryBrush" />
+            <StaticResource x:Key="ChipIconForegroundCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipBorderBrush" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushPointerOver" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBorderBrushPressed" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushDisabled" ResourceKey="OnSurfaceVariantDisabledLowBrush" />
+            <StaticResource x:Key="ChipBorderBrushChecked" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedPointerOver" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedPressed" ResourceKey="OutlineBrush" />
+            <StaticResource x:Key="ChipBorderBrushCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipStateOverlay" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayPointerOver" ResourceKey="OnSurfaceVariantHoverBrush" />
+            <StaticResource x:Key="ChipStateOverlayFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayPressed" ResourceKey="OnSurfaceVariantPressedBrush" />
+            <StaticResource x:Key="ChipStateOverlayDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayChecked" ResourceKey="SecondaryContainerBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedPointerOver" ResourceKey="OnSecondaryContainerHoverBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedFocused" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedPressed" ResourceKey="OnSecondaryContainerSelectedBrush" />
+            <StaticResource x:Key="ChipStateOverlayCheckedDisabled" ResourceKey="SystemControlTransparentBrush" />
+
+            <StaticResource x:Key="ChipRippleFeedback" ResourceKey="OnSurfaceFocusedBrush" />
+
+            <StaticResource x:Key="ElevatedChipBackground" ResourceKey="SurfaceBrush" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
 
     <x:String x:Key="MaterialChipDeleteIcon">M11.25 1.8075L10.1925 0.75L6 4.9425L1.8075 0.75L0.75 1.8075L4.9425 6L0.75 10.1925L1.8075 11.25L6 7.0575L10.1925 11.25L11.25 10.1925L7.0575 6L11.25 1.8075Z</x:String>
     <x:String x:Key="MaterialCheckGlyphPathData">M28.718018,0L32,3.2819897 10.666016,24.616999 0,13.951997 3.2810059,10.670007 10.666016,18.055033z</x:String>
 
-    <StaticResource x:Key="MaterialChipBackground"
-                    ResourceKey="SystemControlTransparentBrush" />
-    <StaticResource x:Key="MaterialChipSelectedBackground"
-                    ResourceKey="SecondaryContainerBrush" />
-
-    <StaticResource x:Key="MaterialChipPointerOverStateOverlay"
-                    ResourceKey="OnSurfaceVariantHoverBrush" />
-    <StaticResource x:Key="MaterialChipFocusedStateOverlay"
-                    ResourceKey="OnSurfaceVariantFocusedBrush" />
-    <StaticResource x:Key="MaterialChipPressedStateOverlay"
-                    ResourceKey="OnSurfaceVariantPressedBrush" />
-
-
-    <StaticResource x:Key="MaterialChipSelectedPointerOverStateOverlay"
-                    ResourceKey="OnSecondaryContainerHoverBrush" />
-    <StaticResource x:Key="MaterialChipSelectedFocusedStateOverlay"
-                    ResourceKey="OnSecondaryContainerFocusedBrush" />
-    <StaticResource x:Key="MaterialChipSelectedPressedStateOverlay"
-                    ResourceKey="OnSecondaryContainerSelectedBrush" />
-
-    <StaticResource x:Key="MaterialChipForeground"
-                    ResourceKey="OnSurfaceVariantBrush" />
-    <StaticResource x:Key="MaterialChipPointerOverForeground"
-                    ResourceKey="OnSurfaceVariantBrush" />
-    <StaticResource x:Key="MaterialChipFocusedForeground"
-                    ResourceKey="OnSurfaceVariantBrush" />
-    <StaticResource x:Key="MaterialChipPressedForeground"
-                    ResourceKey="OnSurfaceVariantBrush" />
-
-    <StaticResource x:Key="MaterialChipSelectedForeground"
-                    ResourceKey="OnSecondaryContainerBrush" />
-    <StaticResource x:Key="MaterialChipSelectedPointerOverForeground"
-                    ResourceKey="OnSecondaryContainerBrush" />
-    <StaticResource x:Key="MaterialChipSelectedFocusedForeground"
-                    ResourceKey="OnSecondaryContainerBrush" />
-    <StaticResource x:Key="MaterialChipSelectedPressedForeground"
-                    ResourceKey="OnSecondaryContainerBrush" />
-
-    <StaticResource x:Key="MaterialChipIconForeground"
-                    ResourceKey="PrimaryBrush" />
-    <StaticResource x:Key="MaterialChipIconDisabledForeground"
-                    ResourceKey="OnSurfaceDisabledBrush" />
-    <StaticResource x:Key="MaterialChipDisabledForeground"
-                    ResourceKey="OnSurfaceDisabledBrush" />
-    <StaticResource x:Key="MaterialChipDisabledBackground"
-                    ResourceKey="OnSurfaceDisabledLowBrush" />
-    <StaticResource x:Key="MaterialChipDisabledBorderBrush"
-                    ResourceKey="OnSurfaceVariantDisabledLowBrush" />
-
-    <x:Double x:Key="MaterialChipHeight">32</x:Double>
-    <x:Double x:Key="MaterialChipContentMinHeight">20</x:Double>
-    <x:Double x:Key="MaterialChipSize">12</x:Double>
-    <x:Double x:Key="MaterialChipDeleteIconContainerLength">18</x:Double>
-    <x:Double x:Key="MaterialChipDeleteIconLength">11</x:Double>
-    <x:Double x:Key="MaterialChipBorderThickness">1</x:Double>
-    <x:Double x:Key="M3MateriaChipCheckGlyphSize">20</x:Double>
-    <x:Double x:Key="MaterialChipElevation">4</x:Double>
-    <x:Double x:Key="MaterialChipIconSize">18</x:Double>
-
-    <CornerRadius x:Key="MaterialChipCornerRadius">8</CornerRadius>
-    <Thickness x:Key="MaterialChipElevationMargin">4</Thickness>
-
-
-    <Style x:Key="MaterialChipDeleteIconButtonStyle"
-           TargetType="Button">
-        <Setter Property="Foreground"
-                Value="{ThemeResource OnSurfaceVariantBrush}" />
-        <Setter Property="Background"
-                Value="Transparent" />
+    <Style x:Key="MaterialChipDeleteIconButtonStyle" TargetType="Button">
+        <Setter Property="Foreground" Value="{ThemeResource ChipDeleteIconForeground}" />
+        <Setter Property="Background" Value="{ThemeResource ChipDeleteIconBackground}" />
 
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <Border x:Name="BorderRoot"
-                            Width="{StaticResource MaterialChipDeleteIconContainerLength}"
-                            Height="{StaticResource MaterialChipDeleteIconContainerLength}"
-                            Background="{TemplateBinding Background}">
+                    <Border
+                        x:Name="BorderRoot"
+                        Width="{ThemeResource ChipDeleteIconContainerLength}"
+                        Height="{ThemeResource ChipDeleteIconContainerLength}"
+                        Background="{TemplateBinding Background}">
 
-                        <Path x:Name="GlyphElement"
-                              Width="{StaticResource MaterialChipDeleteIconLength}"
-                              Height="{StaticResource MaterialChipDeleteIconLength}"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"
-                              AutomationProperties.AccessibilityView="Raw"
-                              Data="{StaticResource MaterialChipDeleteIcon}"
-                              Fill="{TemplateBinding Foreground}"
-                              Stretch="Uniform" />
+                        <Path
+                            x:Name="GlyphElement"
+                            Width="{ThemeResource ChipDeleteIconLength}"
+                            Height="{ThemeResource ChipDeleteIconLength}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            AutomationProperties.AccessibilityView="Raw"
+                            Data="{StaticResource MaterialChipDeleteIcon}"
+                            Fill="{TemplateBinding Foreground}"
+                            Stretch="Uniform" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <Style x:Key="MaterialChipStyle"
-           TargetType="utu:Chip">
-        <Setter Property="Foreground"
-                Value="{StaticResource MaterialChipForeground}" />
-        <Setter Property="Background"
-                Value="{StaticResource MaterialChipBackground}" />
-        <Setter Property="BorderBrush"
-                Value="{ThemeResource OutlineBrush}" />
-        <Setter Property="BorderThickness"
-                Value="{StaticResource MaterialChipBorderThickness}" />
-        <Setter Property="CornerRadius"
-                Value="{StaticResource MaterialChipCornerRadius}" />
-        <Setter Property="VerticalAlignment"
-                Value="Stretch" />
-        <Setter Property="VerticalContentAlignment"
-                Value="Center" />
-        <Setter Property="Padding"
-                Value="8,0" />
+    <Style x:Key="MaterialChipStyle" TargetType="utu:Chip">
+        <Setter Property="Foreground" Value="{ThemeResource ChipForeground}" />
+        <Setter Property="Background" Value="{ThemeResource ChipBackground}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource ChipBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipBorderThickness}" />
+        <Setter Property="CornerRadius" Value="{ThemeResource ChipCornerRadius}" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="{ThemeResource ChipPadding}" />
 
-        <Setter Property="Icon"
-                Value="{x:Null}" />
+        <Setter Property="Icon" Value="{x:Null}" />
 
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="utu:Chip">
                     <Grid>
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal" />
-                                <VisualState x:Name="PointerOver">
-                                    <VisualState.Setters>
-                                        <Setter Target="ElevatedRoot.Background"
-                                                Value="{StaticResource MaterialChipBackground}" />
-                                        <Setter Target="StateOverlay.Background"
-                                                Value="{StaticResource MaterialChipPointerOverStateOverlay}" />
-                                        <Setter Target="ContentPresenter.Foreground"
-                                                Value="{StaticResource MaterialChipPointerOverForeground}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Pressed">
-                                    <VisualState.Setters>
-                                        <Setter Target="ElevatedRoot.Background"
-                                                Value="{StaticResource MaterialChipBackground}" />
-                                        <Setter Target="StateOverlay.Background"
-                                                Value="{StaticResource MaterialChipPressedStateOverlay}" />
-                                        <Setter Target="ContentPresenter.Foreground"
-                                                Value="{StaticResource MaterialChipPressedForeground}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="ElevatedRoot.Elevation"
-                                                Value="0" />
-                                        <Setter Target="ElevatedRoot.Background"
-                                                Value="{StaticResource MaterialChipDisabledBackground}" />
-                                        <Setter Target="ContentPresenter.Foreground"
-                                                Value="{StaticResource MaterialChipDisabledForeground}" />
-                                        <Setter Target="PART_RemoveButton.Foreground"
-                                                Value="{StaticResource MaterialChipIconDisabledForeground}" />
-                                        <Setter Target="ElevatedRoot.BorderBrush"
-                                                Value="{ThemeResource MaterialChipDisabledBorderBrush}" />
-                                        <Setter Target="IconPresenter.Foreground"
-                                                Value="{StaticResource MaterialChipIconDisabledForeground}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Checked">
-                                    <VisualState.Setters>
-                                        <Setter Target="ElevatedRoot.Background"
-                                                Value="{StaticResource MaterialChipSelectedBackground}" />
-                                        <Setter Target="StateOverlay.Background"
-                                                Value="{StaticResource MaterialChipSelectedBackground}" />
-                                        <Setter Target="ContentPresenter.Foreground"
-                                                Value="{StaticResource MaterialChipSelectedForeground}" />
-                                        <Setter Target="IconPresenter.Foreground"
-                                                Value="{StaticResource MaterialChipIconForeground}" />
-                                        <Setter Target="CheckGlyphElement.Visibility"
-                                                Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="CheckedPointerOver">
-                                    <VisualState.Setters>
-                                        <Setter Target="ElevatedRoot.Background"
-                                                Value="{StaticResource MaterialChipSelectedBackground}" />
-                                        <Setter Target="StateOverlay.Background"
-                                                Value="{StaticResource MaterialChipSelectedPointerOverStateOverlay}" />
-                                        <Setter Target="ContentPresenter.Foreground"
-                                                Value="{StaticResource MaterialChipSelectedPointerOverForeground}" />
-                                        <Setter Target="CheckGlyphElement.Visibility"
-                                                Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="CheckedPressed">
-                                    <VisualState.Setters>
-                                        <Setter Target="ElevatedRoot.Background"
-                                                Value="{StaticResource MaterialChipSelectedBackground}" />
-                                        <Setter Target="StateOverlay.Background"
-                                                Value="{StaticResource MaterialChipSelectedPressedStateOverlay}" />
-                                        <Setter Target="ContentPresenter.Foreground"
-                                                Value="{StaticResource MaterialChipSelectedPressedForeground}" />
-                                        <Setter Target="CheckGlyphElement.Visibility"
-                                                Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-
-                        <toolkit:ElevatedView x:Name="ElevatedRoot"
-                                              Height="{StaticResource MaterialChipHeight}"
-                                              Margin="{StaticResource MaterialChipElevationMargin}"
-                                              Background="{TemplateBinding Background}"
-                                              BorderBrush="{TemplateBinding BorderBrush}"
-                                              BorderThickness="{TemplateBinding BorderThickness}"
-                                              CornerRadius="{TemplateBinding CornerRadius}"
-                                              Elevation="{TemplateBinding Elevation}">
+                        <toolkit:ElevatedView
+                            x:Name="ElevatedRoot"
+                            Height="{ThemeResource ChipHeight}"
+                            Margin="{ThemeResource ChipElevationMargin}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Elevation="{TemplateBinding Elevation}">
 
                             <Grid CornerRadius="{TemplateBinding CornerRadius}">
 
-                                <Border x:Name="StateOverlay"
-                                        Background="Transparent"
-                                        CornerRadius="{TemplateBinding CornerRadius}" />
+                                <Border
+                                    x:Name="StateOverlay"
+                                    Background="{ThemeResource ChipStateOverlay}"
+                                    CornerRadius="{TemplateBinding CornerRadius}" />
 
-                                <um:Ripple Padding="{TemplateBinding Padding}"
-                                           CornerRadius="{TemplateBinding CornerRadius}"
-                                           Feedback="{ThemeResource OnSurfaceFocusedBrush}">
+                                <um:Ripple
+                                    Padding="{TemplateBinding Padding}"
+                                    CornerRadius="{TemplateBinding CornerRadius}"
+                                    Feedback="{ThemeResource ChipRippleFeedback}">
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <!--  0: Leading Icon, 1: Content: 2: Remove Button  -->
@@ -239,149 +257,197 @@
 
                                         <!--  C0: Leading Icon / Check Glyph  -->
                                         <!--  fixme: ContentControl/Presenter template-binding to icon would crash on uwp  -->
-                                        <ContentPresenter x:Name="IconPresenter"
-                                                          Grid.Column="0"
-                                                          Width="{StaticResource MaterialChipIconSize}"
-                                                          Height="{StaticResource MaterialChipIconSize}"
-                                                          AutomationProperties.AccessibilityView="Raw"
-                                                          Content="{TemplateBinding Icon}"
-                                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                          ContentTemplate="{TemplateBinding IconTemplate}"
-                                                          Foreground="{StaticResource MaterialChipIconForeground}"
-                                                          Visibility="{Binding Icon, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed}" />
+                                        <ContentPresenter
+                                            x:Name="IconPresenter"
+                                            Grid.Column="0"
+                                            Width="{ThemeResource ChipIconSize}"
+                                            Height="{ThemeResource ChipIconSize}"
+                                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            Content="{TemplateBinding Icon}"
+                                            ContentTemplate="{TemplateBinding IconTemplate}"
+                                            Foreground="{ThemeResource ChipIconForeground}"
+                                            Visibility="{Binding Icon, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource MaterialNullToCollapsedConverter}, FallbackValue=Collapsed}" />
 
-                                        <Grid x:Name="CheckGlyphElement"
-                                              Grid.Column="0"
-                                              Width="{StaticResource M3MateriaChipCheckGlyphSize}"
-                                              Height="{StaticResource M3MateriaChipCheckGlyphSize}"
-                                              Padding="2"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Visibility="Collapsed">
-                                            <Path HorizontalAlignment="Center"
-                                                  VerticalAlignment="Center"
-                                                  AutomationProperties.AccessibilityView="Raw"
-                                                  Data="{StaticResource MaterialCheckGlyphPathData}"
-                                                  Fill="{TemplateBinding Foreground}"
-                                                  Stretch="Uniform"
-                                                  Visibility="{Binding Icon, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToVisible}, FallbackValue=Collapsed}" />
+                                        <Grid
+                                            x:Name="CheckGlyphElement"
+                                            Grid.Column="0"
+                                            Width="{ThemeResource ChipCheckGlyphSize}"
+                                            Height="{ThemeResource ChipCheckGlyphSize}"
+                                            Padding="{ThemeResource ChipCheckGlyphPadding}"
+                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            Visibility="Collapsed">
+                                            <Path
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                AutomationProperties.AccessibilityView="Raw"
+                                                Data="{StaticResource MaterialCheckGlyphPathData}"
+                                                Fill="{TemplateBinding Foreground}"
+                                                Stretch="Uniform"
+                                                Visibility="{Binding Icon, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource MaterialEmptyOrNullToVisible}, FallbackValue=Collapsed}" />
                                         </Grid>
 
-
                                         <!--  C1: Content  -->
-                                        <ContentPresenter x:Name="ContentPresenter"
-                                                          Grid.Column="1"
-                                                          Margin="8,0"
-                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                          AutomationProperties.AccessibilityView="Raw"
-                                                          CharacterSpacing="7"
-                                                          Content="{TemplateBinding Content}"
-                                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                          ContentTransitions="{TemplateBinding ContentTransitions}"
-                                                          FontFamily="{ThemeResource MaterialMediumFontFamily}"
-                                                          Foreground="{TemplateBinding Foreground}" />
+                                        <ContentPresenter
+                                            x:Name="ContentPresenter"
+                                            Grid.Column="1"
+                                            Margin="{ThemeResource ChipContentMargin}"
+                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            CharacterSpacing="7"
+                                            Content="{TemplateBinding Content}"
+                                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                                            ContentTransitions="{TemplateBinding ContentTransitions}"
+                                            FontFamily="{ThemeResource MaterialMediumFontFamily}"
+                                            Foreground="{TemplateBinding Foreground}" />
 
                                         <!--  C2: Remove Button  -->
-                                        <Button x:Name="PART_RemoveButton"
-                                                Grid.Column="2"
-                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                Foreground="{TemplateBinding Foreground}"
-                                                Style="{StaticResource MaterialChipDeleteIconButtonStyle}"
-                                                Visibility="{Binding CanRemove, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource MaterialTrueToVisible}, FallbackValue=Collapsed}" />
+                                        <Button
+                                            x:Name="PART_RemoveButton"
+                                            Grid.Column="2"
+                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            Foreground="{TemplateBinding Foreground}"
+                                            Style="{StaticResource MaterialChipDeleteIconButtonStyle}"
+                                            Visibility="{Binding CanRemove, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource MaterialTrueToVisible}, FallbackValue=Collapsed}" />
                                     </Grid>
                                 </um:Ripple>
                             </Grid>
                         </toolkit:ElevatedView>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="PointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundPointerOver}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushPointerOver}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundPointerOver}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundPointerOver}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundPressed}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushPressed}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundPressed}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundPressed}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Elevation" Value="{ThemeResource ChipElevationDisabled}" />
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundDisabled}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushDisabled}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayDisabled}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundDisabled}" />
+                                        <Setter Target="PART_RemoveButton.Foreground" Value="{ThemeResource ChipIconForegroundDisabled}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Checked">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundChecked}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushChecked}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayChecked}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundChecked}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundChecked}" />
+                                        <Setter Target="CheckGlyphElement.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundCheckedPointerOver}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushCheckedPointerOver}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayCheckedPointerOver}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundCheckedPointerOver}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundCheckedPointerOver}" />
+                                        <Setter Target="CheckGlyphElement.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="ElevatedRoot.Background" Value="{ThemeResource ChipBackgroundCheckedPressed}" />
+                                        <Setter Target="ElevatedRoot.BorderBrush" Value="{ThemeResource ChipBorderBrushCheckedPressed}" />
+                                        <Setter Target="StateOverlay.Background" Value="{ThemeResource ChipStateOverlayCheckedPressed}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ChipForegroundCheckedPressed}" />
+                                        <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ChipIconForegroundCheckedPressed}" />
+                                        <Setter Target="CheckGlyphElement.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <Style x:Key="MaterialAssistChipStyle"
-           BasedOn="{StaticResource MaterialChipStyle}"
-           TargetType="utu:Chip">
-        <Setter Property="BorderBrush"
-                Value="{ThemeResource OutlineBrush}" />
-        <Setter Property="BorderThickness"
-                Value="1" />
-        <Setter Property="CanRemove"
-                Value="False" />
+    <Style
+        x:Key="MaterialAssistChipStyle"
+        BasedOn="{StaticResource MaterialChipStyle}"
+        TargetType="utu:Chip">
+        <Setter Property="BorderBrush" Value="{ThemeResource ChipBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipBorderThickness}" />
+        <Setter Property="CanRemove" Value="False" />
     </Style>
 
-    <Style x:Key="MaterialElevatedAssistChipStyle"
-           BasedOn="{StaticResource MaterialChipStyle}"
-           TargetType="utu:Chip">
-        <Setter Property="BorderThickness"
-                Value="0" />
-        <Setter Property="Elevation"
-                Value="{StaticResource MaterialChipElevation}" />
-        <Setter Property="Background"
-                Value="{ThemeResource SurfaceBrush}" />
-        <Setter Property="CanRemove"
-                Value="False" />
+    <Style
+        x:Key="MaterialElevatedAssistChipStyle"
+        BasedOn="{StaticResource MaterialChipStyle}"
+        TargetType="utu:Chip">
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipElevationBorderThickness}" />
+        <Setter Property="Elevation" Value="{ThemeResource ChipElevation}" />
+        <Setter Property="Background" Value="{ThemeResource ElevatedChipBackground}" />
+        <Setter Property="CanRemove" Value="False" />
     </Style>
 
-    <Style x:Key="MaterialInputChipStyle"
-           BasedOn="{StaticResource MaterialChipStyle}"
-           TargetType="utu:Chip">
-        <Setter Property="BorderBrush"
-                Value="{ThemeResource OutlineBrush}" />
-        <Setter Property="BorderThickness"
-                Value="1" />
-        <Setter Property="CanRemove"
-                Value="True" />
+    <Style
+        x:Key="MaterialInputChipStyle"
+        BasedOn="{StaticResource MaterialChipStyle}"
+        TargetType="utu:Chip">
+        <Setter Property="BorderBrush" Value="{ThemeResource ChipBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipBorderThickness}" />
+        <Setter Property="CanRemove" Value="True" />
     </Style>
 
-    <Style x:Key="MaterialFilterChipStyle"
-           BasedOn="{StaticResource MaterialChipStyle}"
-           TargetType="utu:Chip">
-        <Setter Property="BorderBrush"
-                Value="{ThemeResource OutlineBrush}" />
-        <Setter Property="BorderThickness"
-                Value="1" />
-        <Setter Property="CanRemove"
-                Value="True" />
+    <Style
+        x:Key="MaterialFilterChipStyle"
+        BasedOn="{StaticResource MaterialChipStyle}"
+        TargetType="utu:Chip">
+        <Setter Property="BorderBrush" Value="{ThemeResource ChipBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipBorderThickness}" />
+        <Setter Property="CanRemove" Value="True" />
     </Style>
 
-    <Style x:Key="MaterialElevatedFilterChipStyle"
-           BasedOn="{StaticResource MaterialChipStyle}"
-           TargetType="utu:Chip">
-        <Setter Property="BorderThickness"
-                Value="0" />
-        <Setter Property="Elevation"
-                Value="{StaticResource MaterialChipElevation}" />
-        <Setter Property="Background"
-                Value="{ThemeResource SurfaceBrush}" />
-        <Setter Property="CanRemove"
-                Value="True" />
+    <Style
+        x:Key="MaterialElevatedFilterChipStyle"
+        BasedOn="{StaticResource MaterialChipStyle}"
+        TargetType="utu:Chip">
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipElevationBorderThickness}" />
+        <Setter Property="Elevation" Value="{ThemeResource ChipElevation}" />
+        <Setter Property="Background" Value="{ThemeResource ElevatedChipBackground}" />
+        <Setter Property="CanRemove" Value="True" />
     </Style>
 
 
-    <Style x:Key="MaterialSuggestionChipStyle"
-           BasedOn="{StaticResource MaterialChipStyle}"
-           TargetType="utu:Chip">
-        <Setter Property="BorderBrush"
-                Value="{ThemeResource OutlineBrush}" />
-        <Setter Property="BorderThickness"
-                Value="1" />
-        <Setter Property="CanRemove"
-                Value="False" />
+    <Style
+        x:Key="MaterialSuggestionChipStyle"
+        BasedOn="{StaticResource MaterialChipStyle}"
+        TargetType="utu:Chip">
+        <Setter Property="BorderBrush" Value="{ThemeResource ChipBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipBorderThickness}" />
+        <Setter Property="CanRemove" Value="False" />
     </Style>
 
-    <Style x:Key="MaterialElevatedSuggestionChipStyle"
-           BasedOn="{StaticResource MaterialChipStyle}"
-           TargetType="utu:Chip">
-        <Setter Property="BorderThickness"
-                Value="0" />
-        <Setter Property="Elevation"
-                Value="{StaticResource MaterialChipElevation}" />
-        <Setter Property="Background"
-                Value="{ThemeResource SurfaceBrush}" />
-        <Setter Property="CanRemove"
-                Value="False" />
+    <Style
+        x:Key="MaterialElevatedSuggestionChipStyle"
+        BasedOn="{StaticResource MaterialChipStyle}"
+        TargetType="utu:Chip">
+        <Setter Property="BorderThickness" Value="{ThemeResource ChipElevationBorderThickness}" />
+        <Setter Property="Elevation" Value="{ThemeResource ChipElevation}" />
+        <Setter Property="Background" Value="{ThemeResource ElevatedChipBackground}" />
+        <Setter Property="CanRemove" Value="False" />
     </Style>
-
-
-
 
 </ResourceDictionary>


### PR DESCRIPTION
closes #561 
closes #597 

GitHub Issue (If applicable): #561 #597 

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)


## Description
Current behavior:
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/54756963/22f67055-fd81-40ca-973e-5cff7e7a31b9)

Overridden behavior:
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/54756963/d01bc2c6-328f-4b89-b15b-540fa6c4c884)

Overridden with:

    <Page.Resources>
        <x:Double x:Key="ChipCheckGlyphSize">38</x:Double>
        <x:Double x:Key="ChipContentMinHeight">40</x:Double>

        <x:Double x:Key="ChipElevation">14</x:Double>
        <x:Double x:Key="ChipHeight">38</x:Double>
        <x:Double x:Key="ChipIconSize">38</x:Double>
        <x:Double x:Key="ChipSize">40</x:Double>

        <CornerRadius x:Key="ChipCornerRadius">0</CornerRadius>
        <Thickness x:Key="ChipBorderThickness">5</Thickness>
        <Thickness x:Key="ChipContentMargin">16,4</Thickness>
        <Thickness x:Key="ChipPadding">16,4</Thickness>

        <!--  Brushes  -->
        <SolidColorBrush x:Key="ChipBackground" Color="Red" />
        <SolidColorBrush x:Key="ChipBackgroundPointerOver" Color="Orange" />
        <SolidColorBrush x:Key="ChipBackgroundPressed" Color="Yellow" />
        <SolidColorBrush x:Key="ChipBackgroundDisabled" Color="Green" />
        <SolidColorBrush x:Key="ChipBackgroundChecked" Color="Blue" />
        <SolidColorBrush x:Key="ChipBackgroundCheckedPointerOver" Color="Indigo" />
        <SolidColorBrush x:Key="ChipBackgroundCheckedPressed" Color="Pink" />

        <SolidColorBrush x:Key="ChipForeground" Color="Red" />
        <SolidColorBrush x:Key="ChipForegroundPointerOver" Color="Orange" />
        <SolidColorBrush x:Key="ChipForegroundPressed" Color="Yellow" />
        <SolidColorBrush x:Key="ChipForegroundDisabled" Color="Green" />
        <SolidColorBrush x:Key="ChipForegroundChecked" Color="Blue" />
        <SolidColorBrush x:Key="ChipForegroundCheckedPointerOver" Color="Indigo" />
        <SolidColorBrush x:Key="ChipForegroundCheckedPressed" Color="Pink" />

        <SolidColorBrush x:Key="ChipDeleteIconBackground" Color="Red" />
        <SolidColorBrush x:Key="ChipDeleteIconForeground" Color="Orange" />

        <SolidColorBrush x:Key="ChipIconForeground" Color="Yellow" />
        <SolidColorBrush x:Key="ChipIconForegroundPointerOver" Color="Green" />
        <SolidColorBrush x:Key="ChipIconForegroundPressed" Color="Blue" />
        <SolidColorBrush x:Key="ChipIconForegroundDisabled" Color="Indigo" />
        <SolidColorBrush x:Key="ChipIconForegroundChecked" Color="Pink" />
        <SolidColorBrush x:Key="ChipIconForegroundCheckedPointerOver" Color="Red" />
        <SolidColorBrush x:Key="ChipIconForegroundCheckedPressed" Color="Orange" />


        <SolidColorBrush x:Key="ChipBorderBrush" Color="Yellow" />
        <SolidColorBrush x:Key="ChipBorderBrushPointerOver" Color="Green" />
        <SolidColorBrush x:Key="ChipBorderBrushPressed" Color="Blue" />
        <SolidColorBrush x:Key="ChipBorderBrushDisabled" Color="Indigo" />
        <SolidColorBrush x:Key="ChipBorderBrushChecked" Color="Pink" />
        <SolidColorBrush x:Key="ChipBorderBrushCheckedPointerOver" Color="Red" />
        <SolidColorBrush x:Key="ChipBorderBrushCheckedPressed" Color="Orange" />

        <SolidColorBrush x:Key="ChipStateOverlay" Color="Yellow" />
        <SolidColorBrush x:Key="ChipStateOverlayPointerOver" Color="Green" />
        <SolidColorBrush x:Key="ChipStateOverlayPressed" Color="Blue" />
        <SolidColorBrush x:Key="ChipStateOverlayDisabled" Color="Indigo" />
        <SolidColorBrush x:Key="ChipStateOverlayChecked" Color="Pink" />
        <SolidColorBrush x:Key="ChipStateOverlayCheckedPointerOver" Color="Red" />
        <SolidColorBrush x:Key="ChipStateOverlayCheckedPressed" Color="Orange" />
    </Page.Resources>


## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Other information
A Chip.xaml and a ChipGroup.xaml have been added to the style of Fluent in the Uno.Toolkit.UI project. However, the designs of the Fluent styles for Chip and ChipGround aren't available yet, so the content inside Chip.xaml and ChipGroup.xaml is just the base for future Fluent designs.
