### PR TITLE
chore(Autolayout): doc update

### DIFF
--- a/doc/controls/AutoLayoutControl.md
+++ b/doc/controls/AutoLayoutControl.md
@@ -46,6 +46,6 @@ Property|Type|Description
 -|-|-
 PrimaryAlignment|AutoLayoutPrimaryAlignment|Either Auto, the child grid take only the place it need in the autolayout direction, or Stretch, the child grid take all the available place in the autolayout direction. Note if set to Strech AutoLayoutJustify will behave as if in Stack mode.
 CounterAlignment|AutoLayoutAlignment|Indicates where an element should be displayed on the counter axis of the parent orientation relative to the allocated layout slot of the parent element.
-PrimaryLength|double| Set the grid size in parent orientation [Deprecated should Height and Width instead].
-CounterLength|double|Sets the child size in parent counter orientation [Deprecated should Height and Width instead]. 
+PrimaryLength|double| Sets the height or width of the child depending on the `Orientation`. If height or width are already set they will have priority.
+CounterLength|double|Sets the height or width of the child depending on the inverse of `Orientation`. If height or width are already set they will have priority.
 IsIndependentLayout | bool | Make the child independent of the AutoLayout positioning. Should not be used with other Attached Properties. Reflect the Absolute Position option from Figma.


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Documentation content changes

## What is the current behavior?

- Did not reflet the change from control to panel 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

- counter and primary lenght are no longer deprecated

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
