### PR TITLE
fix: Properly resubscribe to nested prop changes

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarTests.cs
@@ -217,12 +217,14 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			await UnitTestsUIContentHelper.WaitForIdle();
 
 			var navBar = await frame.NavigateAndGetNavBar<RedNavBarPage>();
-
+			navBar!.Content = "Hello";
 			Assert.IsTrue(navBar!.Background is SolidColorBrush redBrush && redBrush.Color == Colors.Red);
+			await UnitTestsUIContentHelper.WaitForIdle();
 
 			try
 			{
 				navBar!.Background = new SolidColorBrush(Colors.Green);
+				navBar!.Padding = new Thickness(20);
 			}
 			catch (Exception ex)
 			{
@@ -434,8 +436,8 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 	{
 #if __IOS__
 		public static UINavigationBar? GetNativeNavBar(this NavigationBar? navBar) => navBar
-		?.TryGetRenderer<NavigationBar, NavigationBarRenderer>()
-		?.Native;
+			?.TryGetRenderer<NavigationBar, NavigationBarRenderer>()
+			?.Native;
 
 		public static UINavigationItem? GetNativeNavItem(this NavigationBar? navBar) => navBar
 			?.TryGetRenderer<NavigationBar, NavigationBarNavigationItemRenderer>()

--- a/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
@@ -1,5 +1,4 @@
-﻿﻿
-using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Uno.Disposables;


### PR DESCRIPTION
fixes #381 

## PR Type

What kind of change does this PR introduce?
- Bugfix

When a property would change at runtime, the logic to re-register to the nested property callback was incorrectly using the `sender` instead of the actual owner of the sub-properties 
