### PR TITLE
feat: Support all IconElements for native NavBar

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -136,6 +136,37 @@ namespace Uno.Toolkit.UI
 			native.SetActionView(null);
 			native.SetIcon(null);
 
+			var iconOrContent = element.Icon ?? element.Content;
+
+			switch (iconOrContent)
+			{
+				case BitmapIcon bitmap:
+					var drawable = DrawableHelper.FromUri(bitmap.UriSource);
+					native.SetIcon(drawable);
+					break;
+
+				case string text:
+					titleText = text;
+					break;
+
+				case FrameworkElement fe:
+					if (_appBarButtonWrapper is not { } wrapper || fe.Visibility != Visibility.Visible)
+					{ 
+						break;
+					}
+
+					var currentParent = element.Parent;
+					wrapper.Child = element;
+
+					//Restore the original parent if any, as we
+					// want the DataContext to flow properly from the
+					// NavigationBar.
+					element.SetParent(currentParent);
+					native.SetActionView(wrapper);
+					break;
+			}
+
+
 			// (Icon ?? Content) and Label
 			if (!TrySetIcon() && element.Content is { } content)
 			{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -166,24 +166,6 @@ namespace Uno.Toolkit.UI
 					break;
 			}
 
-
-			// (Icon ?? Content) and Label
-			if (!TrySetIcon() && element.Content is { } content)
-			{
-				if (content is string text)
-				{
-					titleText = text;
-				}
-				else if (content is FrameworkElement { Visibility: Visibility.Visible } fe &&
-					_appBarButtonWrapper is { } wrapper)
-				{
-					_elementParent = element.Parent;
-					wrapper.Child = element;
-					element.SetParent(_elementParent);
-					native.SetActionView(wrapper);
-				}
-			}
-
 			// IsEnabled
 			native.SetEnabled(element.IsEnabled);
 			// According to the Material Design guidelines, the opacity inactive icons should be:

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
@@ -124,42 +124,36 @@ namespace Uno.Toolkit.UI
 			native.Image = null;
 			native.ClearCustomView();
 			native.Title = element.Content is string content ? content : element.Label;
-			if (element.Icon is { } icon)
-			{
-				switch (icon)
-				{
-					case BitmapIcon bitmap:
-						native.Image = ImageHelper.FromUri(bitmap.UriSource);
-						native.ClearCustomView();
-						break;
 
-					case FontIcon: // not supported
-					case PathIcon: // not supported
-					case SymbolIcon: // not supported
-					default:
-						this.Log().WarnIfEnabled(() => $"{icon.GetType().Name ?? "FontIcon, PathIcon and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
-						native.Image = null;
-						native.ClearCustomView();
-						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
-						// We default to an empty string to ensure it is added.
-						native.Title ??= string.Empty;
-						break;
-				}
-			}
-			else if (element.Content is FrameworkElement fe)
+			var iconOrContent = element.Icon ?? element.Content;
+			switch (iconOrContent)
 			{
-				var currentParent = element.Parent;
-				_appBarButtonWrapper.Child = element;
+				case BitmapIcon bitmap:
+					native.Image = ImageHelper.FromUri(bitmap.UriSource);
+					native.ClearCustomView();
+					break;
 
-				//Restore the original parent if any, as we
-				//want the DataContext to flow properly from the
-				//NavigationBar.
-				element.SetParent(currentParent);
-				native.Image = null;
-				native.CustomView = fe.Visibility == Visibility.Visible ? _appBarButtonWrapper : null;
-				// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
-				// We default to an empty string to ensure it is added, in order to support late-bound Content.
-				native.Title ??= string.Empty;
+				case FrameworkElement fe:
+					var currentParent = element.Parent;
+					_appBarButtonWrapper.Child = element;
+
+					//Restore the original parent if any, as we
+					//want the DataContext to flow properly from the
+					//NavigationBar.
+					element.SetParent(currentParent);
+					native.Image = null;
+					native.CustomView = fe.Visibility == Visibility.Visible ? _appBarButtonWrapper : null;
+					// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
+					// We default to an empty string to ensure it is added, in order to support late-bound Content.
+					native.Title ??= string.Empty;
+					break;
+				default:
+					native.Image = null;
+					native.ClearCustomView();
+					// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
+					// We default to an empty string to ensure it is added.
+					native.Title ??= string.Empty;
+					break;
 			}
 
 			// Foreground


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno.toolkit.ui/issues/623

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Only BitmapIcons are supported in the Android and iOS native NavigationBar renderers

## What is the new behavior?

All IconElements are supported