### PR TITLE
fix: Right padding becomes negative under certain conditions

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Arrange.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Arrange.cs
@@ -181,14 +181,6 @@ partial class AutoLayout
 			// Calculate the position of the child by applying the alignment instructions
 			var counterAlignment = GetCounterAlignment(child.Element);
 
-			var isPrimaryAlignmentStretch = GetPrimaryAlignment(child.Element) is AutoLayoutPrimaryAlignment.Stretch;
-			var isCounterAlignmentStretch = counterAlignment is AutoLayoutAlignment.Stretch;
-
-			if (child.Element is FrameworkElement frameworkElement)
-			{
-				UpdateCounterAlignmentToStretch(ref frameworkElement, isHorizontal, isPrimaryAlignmentStretch, isCounterAlignmentStretch);
-			}
-
 			var haveCounterStartPadding = counterAlignment is AutoLayoutAlignment.Stretch or AutoLayoutAlignment.Start;
 			var counterStartPadding = haveCounterStartPadding ? (isHorizontal ? padding.Top : padding.Left) : 0;
 
@@ -221,21 +213,6 @@ partial class AutoLayout
 		}
 
 		return finalSize;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private static void UpdateCounterAlignmentToStretch(ref FrameworkElement frameworkElement, bool isHorizontal, bool isPrimaryAlignmentStretch, bool isCounterAlignmentStretch)
-	{
-		if (isHorizontal)
-		{
-			frameworkElement.HorizontalAlignment = isPrimaryAlignmentStretch ? HorizontalAlignment.Stretch : frameworkElement.HorizontalAlignment;
-			frameworkElement.VerticalAlignment = isCounterAlignmentStretch ? VerticalAlignment.Stretch : frameworkElement.VerticalAlignment;
-		}
-		else
-		{
-			frameworkElement.VerticalAlignment = isPrimaryAlignmentStretch ? VerticalAlignment.Stretch : frameworkElement.VerticalAlignment;
-			frameworkElement.HorizontalAlignment = isCounterAlignmentStretch ? HorizontalAlignment.Stretch : frameworkElement.HorizontalAlignment;
-		}
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
GitHub Issue (If applicable): #624

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix


## What is the current behavior?

Some control had wrong layout 
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/16021239/06c305cf-9368-4f98-ad37-64137a18610f)


## What is the new behavior?

![image](https://github.com/unoplatform/uno.toolkit.ui/assets/16021239/aefbb241-3535-4676-9abf-90c5a0f721b9)

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
