### PR TITLE
doc: fix deadlink

### DIFF
--- a/doc/helpers/command-extensions.md
+++ b/doc/helpers/command-extensions.md
@@ -1,5 +1,5 @@
 ---
-uid: Toolkit.Helpers.ContorlExtensions
+uid: Toolkit.Helpers.CommandExtensions
 ---
 # CommandExtensions Attached Properties
 Provides Command/CommandParameter attached properties for common scenarios.

--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -43,7 +43,7 @@
     - name: AncestorBinding and ItemsControlBinding
       href: helpers/ancestor-itemscontrol-binding.md
     - name: CommandExtensions attached properties
-      href: helpers/control-extensions.md
+      href: helpers/command-extensions.md
     - name: InputExtensions attached properties
       href: helpers/input-extensions.md
     - name: ItemsRepeaterExtensions Attached Properties


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/private/issues/338

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Documentation content changes

## What is the current behavior?
controls-styles.md contains a deadlink to helper/command-extensions.md

## What is the new behavior?
- renamed helper/control-extensions.md to helper/command-extensions.md to match its associated class
- updated remaining to helper/control-extensions.md to the new location

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
regression from #385, where the link was updated, but the file was not renamed (which should've been done)
