### PR TITLE
feat(autolayout): collapsed children don't count in the measure

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Arrange.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Arrange.cs
@@ -47,6 +47,11 @@ partial class AutoLayout
 			var child = children[i];
 			var calculatedChild = _calculatedChildren[i];
 
+			if (child is FrameworkElement { Visibility: Visibility.Collapsed })
+			{
+				continue;
+			}
+
 			if (!ReferenceEquals(child, calculatedChild.Element))
 			{
 				// Invalid calculated child, invalidate measure and wait for next pass to fix this.
@@ -150,6 +155,11 @@ partial class AutoLayout
 				child.Element.Arrange(new Rect(default, finalSize));
 
 				continue; // next child, current offset remains unchanged
+			}
+
+			if (children[i] is FrameworkElement { Visibility: Visibility.Collapsed })
+			{
+				continue;
 			}
 
 			// Calculate the length of the child (size in the panel orientation)

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Measure.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Measure.cs
@@ -94,6 +94,7 @@ partial class AutoLayout
 			// 8b. Calculate the desired size of the panel, when there's at least one filled child
 			var stackedChildrenDesiredSize =
 				_calculatedChildren!
+					.Where(child => child.IsVisible)
 					.Select(c => c.MeasuredLength)
 					.Sum()
 				+ totalSpacingSize;
@@ -212,7 +213,7 @@ partial class AutoLayout
 		{
 			var calculatedChild = _calculatedChildren[i];
 
-			if (calculatedChild.Role != AutoLayoutRole.Fixed)
+			if (calculatedChild.Role != AutoLayoutRole.Fixed || !calculatedChild.IsVisible)
 			{
 				continue;
 			}
@@ -243,7 +244,7 @@ partial class AutoLayout
 		{
 			var calculatedChild = _calculatedChildren![i];
 
-			if (calculatedChild.Role != AutoLayoutRole.Hug)
+			if (calculatedChild.Role != AutoLayoutRole.Hug || !calculatedChild.IsVisible)
 			{
 				continue;
 			}
@@ -282,7 +283,7 @@ partial class AutoLayout
 		{
 			var child = _calculatedChildren![i];
 
-			if (child.Role == AutoLayoutRole.Filled)
+			if (child.Role == AutoLayoutRole.Filled || child.IsVisible)
 			{
 				filledChildrenCount++;
 			}
@@ -299,7 +300,7 @@ partial class AutoLayout
 		for (var i = 0; i < _calculatedChildren!.Length; i++)
 		{
 			var child = _calculatedChildren![i];
-			if (child.Role != AutoLayoutRole.Filled)
+			if (child.Role != AutoLayoutRole.Filled || !child.IsVisible)
 			{
 				continue;
 			}
@@ -446,7 +447,10 @@ partial class AutoLayout
 			Element = element;
 			Role = role;
 			MeasuredLength = measuredLength;
+			IsVisible = element.Visibility == Visibility.Visible;
 		}
+
+		internal bool IsVisible { get; }
 
 		internal UIElement Element { get; }
 


### PR DESCRIPTION
GitHub Issue (If applicable): #660

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Feature

## What is the current behavior?

Collapsed children are still measure

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?


Collapsed children are not measure

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
