### PR TITLE
refactor: add lightweight style resources for Card and CardContentControl

### DIFF
--- a/src/library/Uno.Toolkit.WinUI.Markup/ResourceValue.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/ResourceValue.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Uno.Extensions.Markup;
+
+namespace Uno.Toolkit.Markup
+{
+	public record struct ResourceValue<T>
+	{
+		public ResourceValue(string key, bool isThemeResource = false)
+		{
+			Key = key;
+			IsThemeResource = isThemeResource;
+		}
+
+		public string Key { get; }
+
+		public bool IsThemeResource { get; }
+
+		public static implicit operator Action<IDependencyPropertyBuilder<T>>(ResourceValue<T> resource) =>
+			resource.IsThemeResource ?
+				ThemeResource.Get<T>(resource.Key)
+				: StaticResource.Get<T>(resource.Key);
+
+	}
+}

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/Card.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/Card.cs
@@ -1,0 +1,201 @@
+﻿using Microsoft.UI.Xaml.Media;
+using Uno.Extensions.Markup.Internals;
+using Uno.Toolkit.Markup;
+
+namespace Uno.Toolkit.Markup
+{
+	public static partial class Theme
+	{
+		public static class Card
+		{
+			public static class Resources
+			{
+				public static class ContentTemplate
+				{
+					public static class Foreground
+					{
+						[ResourceKeyDefinition(typeof(Brush), "ContentTemplateForeground")]
+						public static ResourceValue<Brush> Default => new("ContentTemplateForeground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "ContentTemplateBorderBrush")]
+						public static ResourceValue<Brush> Default => new("ContentTemplateBorderBrush", true);
+					}
+				}
+
+				public static class Elevated
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardBackground")]
+						public static ResourceValue<Brush> Default => new("ElevatedCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("ElevatedCardBorderBrush", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardBorderBrushPointerOver")]
+						public static ResourceValue<Brush> PointerOver => new("ElevatedCardBorderBrushPointerOver", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardBorderBrushFocused")]
+						public static ResourceValue<Brush> Focused => new("ElevatedCardBorderBrushFocused", true);
+					}
+				}
+
+				public static class AvatarElevated
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "AvatarElevatedCardBackground")]
+						public static ResourceValue<Brush> Default => new("AvatarElevatedCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "AvatarElevatedCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("AvatarElevatedCardBorderBrush", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "AvatarElevatedCardBorderBrushPointerOver")]
+						public static ResourceValue<Brush> PointerOver => new("AvatarElevatedCardBorderBrushPointerOver", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "AvatarElevatedCardBorderBrushFocused")]
+						public static ResourceValue<Brush> Focused => new("AvatarElevatedCardBorderBrushFocused", true);
+					}
+				}
+
+				public static class SmallMediaElevated
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaElevatedCardBackground")]
+						public static ResourceValue<Brush> Default => new("SmallMediaElevatedCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaElevatedCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("SmallMediaElevatedCardBorderBrush", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaElevatedCardBorderBrushPointerOver")]
+						public static ResourceValue<Brush> PointerOver => new("SmallMediaElevatedCardBorderBrushPointerOver", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaElevatedCardBorderBrushFocused")]
+						public static ResourceValue<Brush> Focused => new("SmallMediaElevatedCardBorderBrushFocused", true);
+					}
+				}
+
+				public static class Outlined
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "OutlinedCardBackground")]
+						public static ResourceValue<Brush> Default => new("OutlinedCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "OutlinedCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("OutlinedCardBorderBrush", true);
+					}
+				}
+
+				public static class AvatarOutlined
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "AvatarOutlinedCardBackground")]
+						public static ResourceValue<Brush> Default => new("AvatarOutlinedCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "AvatarOutlinedCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("AvatarOutlinedCardBorderBrush", true);
+					}
+				}
+
+				public static class SmallMediaOutlined
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaOutlinedCardBackground")]
+						public static ResourceValue<Brush> Default => new("SmallMediaOutlinedCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaOutlinedCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("SmallMediaOutlinedCardBorderBrush", true);
+					}
+				}
+
+				public static class Filled
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardBackground")]
+						public static ResourceValue<Brush> Default => new("FilledCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("FilledCardBorderBrush", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardBorderBrushPointerOver")]
+						public static ResourceValue<Brush> PointerOver => new("FilledCardBorderBrushPointerOver", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardBorderBrushFocused")]
+						public static ResourceValue<Brush> Focused => new("FilledCardBorderBrushFocused", true);
+					}
+				}
+
+				public static class AvatarFilled
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "AvatarFilledCardBackground")]
+						public static ResourceValue<Brush> Default => new("AvatarFilledCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "AvatarFilledCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("AvatarFilledCardBorderBrush", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "AvatarFilledCardBorderBrushPointerOver")]
+						public static ResourceValue<Brush> PointerOver => new("AvatarFilledCardBorderBrushPointerOver", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "AvatarFilledCardBorderBrushFocused")]
+						public static ResourceValue<Brush> Focused => new("AvatarFilledCardBorderBrushFocused", true);
+					}
+				}
+
+				public static class SmallMediaFilled
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaFilledCardBackground")]
+						public static ResourceValue<Brush> Default => new("SmallMediaFilledCardBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaFilledCardBorderBrush")]
+						public static ResourceValue<Brush> Default => new("SmallMediaFilledCardBorderBrush", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaFilledCardBorderBrushPointerOver")]
+						public static ResourceValue<Brush> PointerOver => new("SmallMediaFilledCardBorderBrushPointerOver", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "SmallMediaFilledCardBorderBrushFocused")]
+						public static ResourceValue<Brush> Focused => new("SmallMediaFilledCardBorderBrushFocused", true);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/CardContentControl.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/CardContentControl.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.UI.Xaml.Media;
+using Uno.Extensions.Markup.Internals;
+
+namespace Uno.Toolkit.Markup
+{
+	public static partial class Theme
+	{
+		public static class CardContentControl
+		{
+			public static class Resources
+			{
+				public static class Elevated
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardContentBackground")]
+						public static ResourceValue<Brush> Default => new("ElevatedCardContentBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardContentBorderBrush")]
+						public static ResourceValue<Brush> Default => new("ElevatedCardContentBorderBrush", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardContentBorderBrushPointerOver")]
+						public static ResourceValue<Brush> PointerOver => new("ElevatedCardContentBorderBrushPointerOver", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardContentBorderBrushFocused")]
+						public static ResourceValue<Brush> Focused => new("ElevatedCardContentBorderBrushFocused", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "ElevatedCardContentBorderBrushPressed")]
+						public static ResourceValue<Brush> Pressed => new("ElevatedCardContentBorderBrushPressed", true);
+					}
+				}
+
+				public static class Outlined
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "OutlinedCardContentBackground")]
+						public static ResourceValue<Brush> Default => new("OutlinedCardContentBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "OutlinedCardContentBorderBrush")]
+						public static ResourceValue<Brush> Default => new("OutlinedCardContentBorderBrush", true);
+					}
+				}
+
+				public static class Filled
+				{
+					public static class Background
+					{
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardContentBackground")]
+						public static ResourceValue<Brush> Default => new("FilledCardContentBackground", true);
+					}
+
+					public static class BorderBrush
+					{
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardContentBorderBrush")]
+						public static ResourceValue<Brush> Default => new("FilledCardContentBorderBrush", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardContentBorderBrushPointerOver")]
+						public static ResourceValue<Brush> PointerOver => new("FilledCardContentBorderBrushPointerOver", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardContentBorderBrushFocused")]
+						public static ResourceValue<Brush> Focused => new("FilledCardContentBorderBrushFocused", true);
+
+						[ResourceKeyDefinition(typeof(Brush), "FilledCardContentBorderBrushPressed")]
+						public static ResourceValue<Brush> Pressed => new("FilledCardContentBorderBrushPressed", true);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/library/Uno.Toolkit.WinUI.Markup/Uno.Toolkit.WinUI.Markup.csproj
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Uno.Toolkit.WinUI.Markup.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.38">
+<Project Sdk="MSBuild.Sdk.Extras/3.0.38">
 
 	<!--
 	Adding project references to this project requires some manual adjustments.
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Extensions.Markup.Generators" PrivateAssets="All"/>
+		<PackageReference Include="Uno.Extensions.Markup.Generators" PrivateAssets="All" />
 		<PackageReference Include="Uno.WinUI.Markup" />
 	</ItemGroup>
 


### PR DESCRIPTION

GitHub Issue (If applicable): [Lightweight styling for Card/CardContent](https://github.com/unoplatform/uno.toolkit.ui-private/issues/4)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Refactoring (no functional changes, no api changes)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


