### PR TITLE
Avoid unnecessary allocations on DependencyObjectExtensions.RegisterDisposableNestedPropertyChangedCallback

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
@@ -231,7 +231,7 @@ namespace Uno.Toolkit.UI
 		// Even though we set the Navigation as the parent of the TitleView,
 		// it will change to the native control when the view is added (once MovedToSuperview is called).
 		// This native control is the visual parent but is not a DependencyObject and will not propagate the DataContext.
-		// In order to ensure the DataContext is propagated properly, we need to notify the renderer that this change has occured
+		// In order to ensure the DataContext is propagated properly, we need to notify the renderer that this change has occurred
 		// so we can restore the NavigationBar parent that can propagate the DataContext
 		public override void MovedToSuperview()
 		{

--- a/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Uno.Disposables;
@@ -53,12 +53,11 @@ namespace Uno.Toolkit.UI
 				.Select(group =>
 				{
 					var property = group.Key;
-					var subProperties = group.ToArray();
-
-					var childDisposable = new SerialDisposable();
 
 					if (instance.TryGetValue(property, out var dpValue))
 					{
+						var childDisposable = new SerialDisposable();
+						var subProperties = group.ToArray();
 						childDisposable.Disposable = dpValue?.RegisterDisposableNestedPropertyChangedCallback(callback, subProperties);
 
 						var disposable = instance.RegisterDisposablePropertyChangedCallback(property, (s, e) =>


### PR DESCRIPTION
## Overview

On the `RegisterDisposableNestedPropertyChangedCallback` we allocate an array and a `SerialDisposable` even when they aren't used. Moving the allocation inside the `if` will make sure we just allocate then if needed.

> Not sure if will be a case where that `if` will be `false`, if don't feel free to close this PR.

## PR Type

What kind of change does this PR introduce?
- Improvements

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
