### PR TITLE
[WinUI/ShadowContainer] ShadowContainer content not stretching by default #708

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
@@ -16,8 +16,6 @@
 		<Color x:Key="UnoPink">#f85977</Color>
 		<Color x:Key="UnoBlue">#159bff</Color>
 		<Color x:Key="UnoGreen">#67e5ad</Color>
-		<Color x:Key="purple">#6858d3</Color>
-		
 
 		<utu:Shadow x:Key="DefaultShadow"
 					BlurRadius="20"
@@ -266,6 +264,7 @@
 												BorderBrush="{StaticResource UnoColor}"
 												Content="Bulging element"
 												CornerRadius="15"
+												HorizontalAlignment="Center"
 												Background="Transparent"
 												Foreground="White" />
 									</utu:ShadowContainer>
@@ -306,12 +305,9 @@
 								</StackPanel>
 
 
-							 <!--Test ShadowContainer not stretching its content by default--> 
+							 <!--Test ShadowContainer stretching its content by default--> 
 
-							<StackPanel Background="{StaticResource UnoColor}"
-										HorizontalAlignment="Stretch"
-										BorderBrush="Black"
-										BorderThickness="1"
+							<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 
@@ -391,10 +387,7 @@
 							</StackPanel>
 							
 							
-							<StackPanel Background="{StaticResource UnoColor}"
-										HorizontalAlignment="Stretch"
-										BorderBrush="Black"
-										BorderThickness="1"
+							<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
@@ -473,10 +466,7 @@
 								</utu:ShadowContainer>
 							</StackPanel>
 
-							<StackPanel Background="{StaticResource UnoColor}"
-										HorizontalAlignment="Stretch"
-										BorderBrush="Black"
-										BorderThickness="1"
+							<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 
@@ -571,10 +561,7 @@
 							</StackPanel>
 
 
-							<StackPanel Background="{StaticResource UnoColor}"
-										HorizontalAlignment="Stretch"
-										BorderBrush="Black"
-										BorderThickness="1"
+							<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 
@@ -677,10 +664,7 @@
 
 
 
-							<StackPanel Background="{StaticResource UnoColor}"
-										HorizontalAlignment="Stretch"
-										BorderBrush="Black"
-										BorderThickness="1"
+							<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
@@ -306,108 +306,6 @@
 								</StackPanel>
 
 
-							<TextBlock Margin="0,24,0,0"
-									   Style="{StaticResource TitleTextBlockStyle}"
-									   Text="Enable neumorphism" />
-							<TextBlock Style="{StaticResource BodyTextBlockStyle}"
-									   Text="Being able to add several shadows enables you to create neumorphic designs." />
-
-
-							<StackPanel HorizontalAlignment="Stretch"
-										Margin="0,32"
-										Padding="32"
-										Background="{StaticResource UnoColor}"
-										CornerRadius="30">
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}">
-									<Grid Width="300"
-										  Padding="20"
-										  Background="{StaticResource UnoColor}"
-										  CornerRadius="20">
-										<Grid.RowDefinitions>
-											<RowDefinition Height="20" />
-											<RowDefinition Height="20" />
-										</Grid.RowDefinitions>
-
-										<TextBlock FontSize="15"
-												   Foreground="White"
-												   Text="Neumorphism" />
-										<TextBlock Grid.Row="1"
-												   FontSize="12"
-												   Foreground="White"
-												   Text="Raising element" />
-									</Grid>
-								</utu:ShadowContainer>
-
-								<utu:ShadowContainer Margin="0,60,0,0"
-													 Shadows="{StaticResource NeumorphismHollow}">
-									<TextBox Width="200"
-											 Padding="10"
-											 Background="{StaticResource UnoColor}"
-											 BorderThickness="0"
-											 CornerRadius="20"
-											 Foreground="White"
-											 PlaceholderForeground="LightGray"
-											 PlaceholderText="Hollow element"
-											 Text="Login" />
-								</utu:ShadowContainer>
-								<utu:ShadowContainer Margin="0,15"
-													 Shadows="{StaticResource NeumorphismHollow}">
-									<TextBox Width="200"
-											 Padding="10"
-											 Background="{StaticResource UnoColor}"
-											 BorderThickness="0"
-											 CornerRadius="20"
-											 Foreground="White"
-											 PlaceholderForeground="LightGray"
-											 PlaceholderText="Hollow element"
-											 Text="Password" />
-								</utu:ShadowContainer>
-
-								<utu:ShadowContainer Margin="0,30"
-													 Shadows="{StaticResource NeumorphismBulging}">
-									<Button Width="200"
-											Height="40"
-											Background="{StaticResource UnoColor}"
-											BorderBrush="{StaticResource UnoColor}"
-											Content="Bulging element"
-											CornerRadius="15"
-											Foreground="White" />
-								</utu:ShadowContainer>
-
-								<StackPanel Margin="0,30,0,0"
-											Padding="24"
-											HorizontalAlignment="Center"
-											Orientation="Horizontal"
-											Spacing="16">
-
-									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}">
-										<Button Background="{StaticResource UnoColor}"
-												BorderThickness="0"
-												Content="Regular"
-												Foreground="White" />
-									</utu:ShadowContainer>
-
-									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}">
-										<Button Width="100"
-												Height="80"
-												Background="{StaticResource UnoColor}"
-												BorderBrush="{StaticResource UnoColor}"
-												Content="Circular"
-												CornerRadius="40"
-												Foreground="White" />
-									</utu:ShadowContainer>
-
-									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}">
-										<Button Height="60"
-												Background="{StaticResource UnoColor}"
-												BorderThickness="0"
-												Content="Bigger"
-												CornerRadius="20"
-												Foreground="White" />
-									</utu:ShadowContainer>
-								</StackPanel>
-							</StackPanel>
-							
 							 <!--Test ShadowContainer not stretching its content by default--> 
 
 							<StackPanel Background="{StaticResource UnoColor}"
@@ -419,9 +317,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -433,9 +331,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -448,9 +346,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
-									<TextBox Background="{StaticResource UnoColor}"
-											 BorderThickness="0"
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
+									<TextBox BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
 											 HorizontalAlignment="Stretch"
@@ -463,9 +361,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -479,10 +377,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
-									<TextBox 
-											 Background="{StaticResource UnoColor}"
-											 BorderThickness="0"
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
+									<TextBox BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
 											 HorizontalAlignment="Stretch"
@@ -502,9 +399,9 @@
 										Padding="20">
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -516,9 +413,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -531,9 +428,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
-									<TextBox Background="{StaticResource UnoColor}"
-											 BorderThickness="0"
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
+									<TextBox BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
 											 HorizontalAlignment="Stretch"
@@ -546,9 +443,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -562,9 +459,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox 
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -585,9 +482,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -599,9 +496,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -614,9 +511,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
-									<TextBox Background="{StaticResource UnoColor}"
-											 BorderThickness="0"
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
+									<TextBox BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
 											 HorizontalAlignment="Right"
@@ -629,9 +526,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -645,9 +542,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox 
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -659,9 +556,9 @@
 								</utu:ShadowContainer>
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Center"
-													 HorizontalContentAlignment="Center">
+													 HorizontalContentAlignment="Center"
+													 Background="{StaticResource UnoColor}">
 									<TextBox 
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -683,9 +580,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -698,9 +595,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -714,9 +611,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -730,9 +627,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -747,9 +644,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox 
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -762,9 +659,9 @@
 								</utu:ShadowContainer>
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Center"
-													 HorizontalContentAlignment="Center">
+													 HorizontalContentAlignment="Center"
+													 Background="{StaticResource UnoColor}">
 									<TextBox 
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -792,9 +689,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -809,9 +706,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -831,9 +728,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -848,9 +745,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -867,9 +764,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -884,9 +781,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -903,9 +800,9 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -920,9 +817,10 @@
 
 								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
-													 HorizontalContentAlignment="Stretch">
+													 HorizontalContentAlignment="Stretch"
+													 Background="{StaticResource UnoColor}">
 									<TextBox Padding="10"
-											 Background="{StaticResource UnoColor}"
+											 
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
@@ -16,6 +16,8 @@
 		<Color x:Key="UnoPink">#f85977</Color>
 		<Color x:Key="UnoBlue">#159bff</Color>
 		<Color x:Key="UnoGreen">#67e5ad</Color>
+		<Color x:Key="purple">#6858d3</Color>
+		
 
 		<utu:Shadow x:Key="DefaultShadow"
 					BlurRadius="20"
@@ -23,14 +25,14 @@
 					OffsetY="10"
 					Opacity="0.5"
 					Spread="0"
-					Color="{StaticResource UnoColor}" />
+					Color="{StaticResource UnoPink}" />
 
 		<utu:ShadowCollection x:Name="ButtonShadows">
 			<utu:Shadow BlurRadius="20"
 						OffsetX="8"
 						OffsetY="8"
 						Opacity="0.5"
-						Color="{StaticResource UnoColor}" />
+						Color="{StaticResource UnoPink}" />
 		</utu:ShadowCollection>
 
 		<utu:ShadowCollection x:Key="NeumorphismRaising">
@@ -39,7 +41,7 @@
 						OffsetY="10"
 						Opacity="1"
 						Spread="-5"
-						Color="#6858d3" />
+						Color="{StaticResource UnoPink}" />
 			<utu:Shadow BlurRadius="30"
 						OffsetX="-10"
 						OffsetY="-10"
@@ -55,7 +57,7 @@
 						OffsetY="5"
 						Opacity="1"
 						Spread="0"
-						Color="#6858d3" />
+						Color="{StaticResource UnoPink}" />
 			<utu:Shadow BlurRadius="10"
 						IsInner="True"
 						OffsetX="-4"
@@ -72,7 +74,7 @@
 						OffsetY="-5"
 						Opacity="1"
 						Spread="0"
-						Color="#6858d3" />
+						Color="{StaticResource UnoPink}" />
 			<utu:Shadow BlurRadius="10"
 						IsInner="True"
 						OffsetX="4"
@@ -303,7 +305,639 @@
 									</StackPanel>
 								</StackPanel>
 
+
+							<TextBlock Margin="0,24,0,0"
+									   Style="{StaticResource TitleTextBlockStyle}"
+									   Text="Enable neumorphism" />
+							<TextBlock Style="{StaticResource BodyTextBlockStyle}"
+									   Text="Being able to add several shadows enables you to create neumorphic designs." />
+
+
+							<StackPanel HorizontalAlignment="Stretch"
+										Margin="0,32"
+										Padding="32"
+										Background="{StaticResource UnoColor}"
+										CornerRadius="30">
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}">
+									<Grid Width="300"
+										  Padding="20"
+										  Background="{StaticResource UnoColor}"
+										  CornerRadius="20">
+										<Grid.RowDefinitions>
+											<RowDefinition Height="20" />
+											<RowDefinition Height="20" />
+										</Grid.RowDefinitions>
+
+										<TextBlock FontSize="15"
+												   Foreground="White"
+												   Text="Neumorphism" />
+										<TextBlock Grid.Row="1"
+												   FontSize="12"
+												   Foreground="White"
+												   Text="Raising element" />
+									</Grid>
+								</utu:ShadowContainer>
+
+								<utu:ShadowContainer Margin="0,60,0,0"
+													 Shadows="{StaticResource NeumorphismHollow}">
+									<TextBox Width="200"
+											 Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Login" />
+								</utu:ShadowContainer>
+								<utu:ShadowContainer Margin="0,15"
+													 Shadows="{StaticResource NeumorphismHollow}">
+									<TextBox Width="200"
+											 Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Password" />
+								</utu:ShadowContainer>
+
+								<utu:ShadowContainer Margin="0,30"
+													 Shadows="{StaticResource NeumorphismBulging}">
+									<Button Width="200"
+											Height="40"
+											Background="{StaticResource UnoColor}"
+											BorderBrush="{StaticResource UnoColor}"
+											Content="Bulging element"
+											CornerRadius="15"
+											Foreground="White" />
+								</utu:ShadowContainer>
+
+								<StackPanel Margin="0,30,0,0"
+											Padding="24"
+											HorizontalAlignment="Center"
+											Orientation="Horizontal"
+											Spacing="16">
+
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}">
+										<Button Background="{StaticResource UnoColor}"
+												BorderThickness="0"
+												Content="Regular"
+												Foreground="White" />
+									</utu:ShadowContainer>
+
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}">
+										<Button Width="100"
+												Height="80"
+												Background="{StaticResource UnoColor}"
+												BorderBrush="{StaticResource UnoColor}"
+												Content="Circular"
+												CornerRadius="40"
+												Foreground="White" />
+									</utu:ShadowContainer>
+
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}">
+										<Button Height="60"
+												Background="{StaticResource UnoColor}"
+												BorderThickness="0"
+												Content="Bigger"
+												CornerRadius="20"
+												Foreground="White" />
+									</utu:ShadowContainer>
+								</StackPanel>
 							</StackPanel>
+							
+							 <!--Test ShadowContainer not stretching its content by default--> 
+
+							<StackPanel Background="{StaticResource UnoColor}"
+										HorizontalAlignment="Stretch"
+										BorderBrush="Black"
+										BorderThickness="1"
+										Spacing="50"
+										Padding="20">
+
+								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Shadows element"
+											 Text="NO Padding NO Margin"/>
+								</utu:ShadowContainer>
+
+								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Shadows element"
+											 Text="Padding"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Shadows element"
+											 Text="Margin"
+											 Margin="30,30,30,30"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Shadows element"
+											 Text="Padding + Margin diff"
+											 Margin="15,30,50,30"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox 
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Shadows element"
+											 Text="Padding"
+											 Padding="15,30,50,30"/>
+								</utu:ShadowContainer>
+							</StackPanel>
+							
+							
+							<StackPanel Background="{StaticResource UnoColor}"
+										HorizontalAlignment="Stretch"
+										BorderBrush="Black"
+										BorderThickness="1"
+										Spacing="50"
+										Padding="20">
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="NO Padding NO Margin"/>
+								</utu:ShadowContainer>
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Padding"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Margin"
+											 Margin="30,30,30,30"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Padding + Margin diff"
+											 Margin="15,30,50,30"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox 
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Padding"
+											 Padding="15,30,50,30"/>
+								</utu:ShadowContainer>
+							</StackPanel>
+
+							<StackPanel Background="{StaticResource UnoColor}"
+										HorizontalAlignment="Stretch"
+										BorderBrush="Black"
+										BorderThickness="1"
+										Spacing="50"
+										Padding="20">
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Center"/>
+								</utu:ShadowContainer>
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Right"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Right"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Right"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Right"
+											 Margin="200,30,30,30"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Left"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Left"
+											 Margin="15,30,200,30"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox 
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Left"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Left"
+											 Padding="15,30,50,30"/>
+								</utu:ShadowContainer>
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Center"
+													 HorizontalContentAlignment="Center">
+									<TextBox 
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Left"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Left on ShadowContainer Center"
+											 Padding="15,30,50,30"/>
+								</utu:ShadowContainer>
+							</StackPanel>
+
+
+							<StackPanel Background="{StaticResource UnoColor}"
+										HorizontalAlignment="Stretch"
+										BorderBrush="Black"
+										BorderThickness="1"
+										Spacing="50"
+										Padding="20">
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Center"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Center"/>
+								</utu:ShadowContainer>
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Right"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Right"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Right"
+											 VerticalAlignment="Top"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Right Top "/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Left"
+											 VerticalAlignment="Bottom"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Left"
+											 Margin="15,100,50,200"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox 
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Left"
+											 VerticalAlignment="Top"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Left"
+											 Margin="15,100,50,100"/>
+								</utu:ShadowContainer>
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+													 HorizontalAlignment="Center"
+													 HorizontalContentAlignment="Center">
+									<TextBox 
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Left"
+											 VerticalAlignment="Top"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Hollow element"
+											 Text="Left on ShadowContainer Center"
+											 Padding="15,200,50,100"/>
+								</utu:ShadowContainer>
+							</StackPanel>
+
+
+
+
+							<StackPanel Background="{StaticResource UnoColor}"
+										HorizontalAlignment="Stretch"
+										BorderBrush="Black"
+										BorderThickness="1"
+										Spacing="50"
+										Padding="20">
+
+
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Left"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Left Margin 0,130,300,20"
+											 Margin="0,130,300,20"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Left"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Left Margin 300,20,0,130"
+											 Margin="300,20,0,130"/>
+								</utu:ShadowContainer>
+
+
+
+
+
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Right"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Right Margin 0,130,300,20"
+											 Margin="0,130,300,20"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Right"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Right Margin 300,20,0,130"
+											 Margin="300,20,0,130"/>
+								</utu:ShadowContainer>
+
+
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Center"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Center Margin 0,130,300,20"
+											 Margin="0,130,300,20"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Center"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Center Margin 300,20,0,130"
+											 Margin="300,20,0,130"/>
+								</utu:ShadowContainer>
+
+
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Stretch Margin 0,130,300,20"
+											 Margin="0,130,300,20"/>
+								</utu:ShadowContainer>
+
+
+								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+													 HorizontalAlignment="Stretch"
+													 HorizontalContentAlignment="Stretch">
+									<TextBox Padding="10"
+											 Background="{StaticResource UnoColor}"
+											 BorderThickness="0"
+											 CornerRadius="20"
+											 Foreground="White"
+											 HorizontalAlignment="Stretch"
+											 VerticalAlignment="Center"
+											 PlaceholderForeground="LightGray"
+											 PlaceholderText="Raising element"
+											 Text="Stretch Margin 300,20,0,130"
+											 Margin="300,20,0,130"/>
+								</utu:ShadowContainer>
+
+
+							</StackPanel>
+
+						</StackPanel>
 
 						</StackPanel>
 					</ScrollViewer>

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
@@ -27,12 +27,17 @@ namespace Uno.Toolkit.UI;
 public partial class ShadowContainer : ContentControl
 {
 	private const string PART_Canvas = "PART_Canvas";
+	private const string PART_Canvas_Inner = "PART_Canvas_Inner";
+	private const string PART_ShadowOwner = "PART_ShadowOwner";
+	private const string PART_ContentPresenter = "PART_ContentPresenter";
 
 	private static readonly ShadowsCache Cache = new ShadowsCache();
 
 	private readonly SerialDisposable _eventSubscriptions = new();
-
+	
+	private Grid? _panel;
 	private Canvas? _canvas;
+	private ContentPresenter? _contentPresenter;
 
 	private SKXamlCanvas? _shadowHost;
 
@@ -225,6 +230,8 @@ public partial class ShadowContainer : ContentControl
 		base.OnApplyTemplate();
 
 		_canvas = GetTemplateChild(nameof(PART_Canvas)) as Canvas;
+		_panel = GetTemplateChild(nameof(PART_ShadowOwner)) as Grid;
+		_contentPresenter = GetTemplateChild(nameof(PART_ContentPresenter)) as ContentPresenter;
 
 		var skiaCanvas = new SKXamlCanvas();
 		skiaCanvas.PaintSurface += OnSurfacePainted;
@@ -234,6 +241,7 @@ public partial class ShadowContainer : ContentControl
 #endif
 
 		_shadowHost = skiaCanvas;
+		_currentContent = (FrameworkElement?)_contentPresenter?.Content;
 		_canvas?.Children.Insert(0, _shadowHost!);
 	}
 

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
@@ -324,7 +324,7 @@ public partial class ShadowContainer : ContentControl
 			_canvas.Margin = contentAsFE.Margin;
 			_canvas.Margin = contentAsFE.Margin;
 
-			if (contentAsFE.Margin == Thickness.Empty)
+			if (contentAsFE.Margin == new Thickness(0, 0, 0, 0))
 			{
 				left = -newHostSpreedWidth;
 				top = -newHostSpreedHeight;

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
@@ -27,9 +27,7 @@ namespace Uno.Toolkit.UI;
 public partial class ShadowContainer : ContentControl
 {
 	private const string PART_Canvas = "PART_Canvas";
-	private const string PART_Canvas_Inner = "PART_Canvas_Inner";
 	private const string PART_ShadowOwner = "PART_ShadowOwner";
-	private const string PART_ContentPresenter = "PART_ContentPresenter";
 
 	private static readonly ShadowsCache Cache = new ShadowsCache();
 
@@ -37,8 +35,6 @@ public partial class ShadowContainer : ContentControl
 	
 	private Grid? _panel;
 	private Canvas? _canvas;
-	private ContentPresenter? _contentPresenter;
-
 	private SKXamlCanvas? _shadowHost;
 
 	public ShadowContainer()
@@ -181,6 +177,7 @@ public partial class ShadowContainer : ContentControl
 						BindItems(e.NewItems?.Cast<Shadow>());
 
 						_isShadowDirty = true;
+
 						InvalidateCanvasLayout();
 					}
 				}
@@ -231,7 +228,6 @@ public partial class ShadowContainer : ContentControl
 
 		_canvas = GetTemplateChild(nameof(PART_Canvas)) as Canvas;
 		_panel = GetTemplateChild(nameof(PART_ShadowOwner)) as Grid;
-		_contentPresenter = GetTemplateChild(nameof(PART_ContentPresenter)) as ContentPresenter;
 
 		var skiaCanvas = new SKXamlCanvas();
 		skiaCanvas.PaintSurface += OnSurfacePainted;
@@ -241,13 +237,15 @@ public partial class ShadowContainer : ContentControl
 #endif
 
 		_shadowHost = skiaCanvas;
-		_currentContent = (FrameworkElement?)_contentPresenter?.Content;
 		_canvas?.Children.Insert(0, _shadowHost!);
 	}
 
 	private void InvalidateCanvasLayout()
 	{
-		if (Content is not FrameworkElement contentAsFE || _canvas == null || _shadowHost == null)
+		if (Content is not FrameworkElement contentAsFE ||
+				_panel == null ||
+				_canvas == null ||
+				_shadowHost == null)
 		{
 			return;
 		}
@@ -272,22 +270,94 @@ public partial class ShadowContainer : ContentControl
 			maxSpread = shadows.Max(s => s.Spread);
 		}
 
-		_canvas.Height = childHeight;
-		_canvas.Width = childWidth;
-#if __ANDROID__ || __IOS__
-		_canvas.GetDispatcherCompat().Schedule(() => _canvas.InvalidateMeasure());
-#endif
-		double newHostHeight = childHeight + maxBlurRadius * 2 + absoluteMaxOffsetY * 2 + maxSpread * 2;
-		double newHostWidth = childWidth + maxBlurRadius * 2 + absoluteMaxOffsetX * 2 + maxSpread * 2;
+		//		_canvas.Height = childHeight;
+		//		_canvas.Width = childWidth;
+		//#if __ANDROID__ || __IOS__
+		//		_canvas.GetDispatcherCompat().Schedule(() => _canvas.InvalidateMeasure());
+		//#endif
+		//		double newHostHeight = childHeight + maxBlurRadius * 2 + absoluteMaxOffsetY * 2 + maxSpread * 2;
+		//		double newHostWidth = childWidth + maxBlurRadius * 2 + absoluteMaxOffsetX * 2 + maxSpread * 2;
+		//		_shadowHost.Height = newHostHeight;
+		//		_shadowHost.Width = newHostWidth;
+
+		//		double diffWidthShadowHostChild = newHostWidth - childWidth;
+		//		double diffHeightShadowHostChild = newHostHeight - childHeight;
+
+		//		float left = (float)(-diffWidthShadowHostChild / 2 + contentAsFE.Margin.Left);
+		//		float top = (float)(-diffHeightShadowHostChild / 2 + contentAsFE.Margin.Top);
+
+
+
+
+
+
+
+
+
+		_canvas.Width = contentAsFE.ActualWidth - contentAsFE.Margin.Left - contentAsFE.Margin.Right;
+		if (_canvas.Width < 0)
+		{
+			_canvas.Width = 0;
+		}
+		_canvas.Height = contentAsFE.ActualHeight - contentAsFE.Margin.Top - contentAsFE.Margin.Bottom;
+		if (_canvas.Height < 0)
+		{
+			_canvas.Height = 0;
+		}
+		_canvas.HorizontalAlignment = contentAsFE.HorizontalAlignment;
+		_canvas.VerticalAlignment = contentAsFE.VerticalAlignment;
+
+		double newHostSpreedHeight = maxBlurRadius + absoluteMaxOffsetY + maxSpread;
+		double newHostSpreedWidth = maxBlurRadius + absoluteMaxOffsetX + maxSpread;
+
+		double newHostHeight = contentAsFE.ActualHeight + newHostSpreedHeight * 2;
+		double newHostWidth = contentAsFE.ActualWidth + newHostSpreedWidth * 2;
+
 		_shadowHost.Height = newHostHeight;
 		_shadowHost.Width = newHostWidth;
 
-		double diffWidthShadowHostChild = newHostWidth - childWidth;
-		double diffHeightShadowHostChild = newHostHeight - childHeight;
+		double top = 0;
+		double left = 0;
 
-		float left = (float)(-diffWidthShadowHostChild / 2 + contentAsFE.Margin.Left);
-		float top = (float)(-diffHeightShadowHostChild / 2 + contentAsFE.Margin.Top);
+		if (contentAsFE.VerticalAlignment == VerticalAlignment.Center)
+		{
+			_canvas.Margin = contentAsFE.Margin;
+			_canvas.Margin = contentAsFE.Margin;
 
+			if (contentAsFE.Margin == new Thickness(0, 0, 0, 0))
+			{
+				left = -newHostSpreedWidth;
+				top = -newHostSpreedHeight;
+			}
+			else
+			{
+				left = -newHostSpreedWidth
+							- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Left ? 0 : 0)
+							- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Right ? contentAsFE.ActualWidth : 0)
+							- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Stretch ? +contentAsFE.Margin.Left / 2 + contentAsFE.Margin.Right / 2 : 0)
+							- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Center ? contentAsFE.ActualWidth / 2 : 0)
+
+							;
+				top = -newHostSpreedHeight - contentAsFE.ActualHeight / 2;
+			}
+
+		}
+		else
+		{
+			left = -(newHostSpreedWidth
+									+ (contentAsFE.HorizontalAlignment == HorizontalAlignment.Left ? -contentAsFE.Margin.Left : 0)
+									+ (contentAsFE.HorizontalAlignment == HorizontalAlignment.Right && contentAsFE.VerticalAlignment != VerticalAlignment.Center ? contentAsFE.Margin.Right == 0 ? 0 :
+													contentAsFE.ActualWidth + contentAsFE.Margin.Right - _canvas.Margin.Right : 0)
+									+ (contentAsFE.HorizontalAlignment == HorizontalAlignment.Stretch ? contentAsFE.Margin.Right : 0)
+									+ (contentAsFE.HorizontalAlignment == HorizontalAlignment.Center ? contentAsFE.Margin.Left : 0)
+									);
+			top = -(newHostSpreedHeight
+											+ (contentAsFE.VerticalAlignment == VerticalAlignment.Top ? -contentAsFE.Margin.Top : 0)
+											+ (contentAsFE.VerticalAlignment == VerticalAlignment.Bottom ? +contentAsFE.Margin.Bottom + contentAsFE.ActualHeight : 0)
+											+ (contentAsFE.VerticalAlignment == VerticalAlignment.Stretch ? contentAsFE.Margin.Bottom : 0)
+											+ (contentAsFE.VerticalAlignment == VerticalAlignment.Center ? contentAsFE.Margin.Top : 0)
+										);
+		}
 		Canvas.SetLeft(_shadowHost, left);
 		Canvas.SetTop(_shadowHost, top);
 	}

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
@@ -324,7 +324,7 @@ public partial class ShadowContainer : ContentControl
 			_canvas.Margin = contentAsFE.Margin;
 			_canvas.Margin = contentAsFE.Margin;
 
-			if (contentAsFE.Margin == new Thickness(0, 0, 0, 0))
+			if (contentAsFE.Margin == Thickness.Empty)
 			{
 				left = -newHostSpreedWidth;
 				top = -newHostSpreedHeight;

--- a/src/Uno.Toolkit.Skia.WinUI/Themes/Generic.xaml
+++ b/src/Uno.Toolkit.Skia.WinUI/Themes/Generic.xaml
@@ -11,7 +11,7 @@
 	<Style x:Key="DefaultShadowContainerStyle" TargetType="utu:ShadowContainer">
 		<Setter Property="IsTabStop" Value="False" />
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
-		<Setter Property="HorizontalContentAlignment" Value="Left" />
+		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
 		<Setter Property="VerticalAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Stretch" />
 		<Setter Property="Template">
@@ -21,13 +21,18 @@
 						note: Dont template-bind Background or CornerRadius here.
 						They will be painted in skia impl (see: ShadowContainer.Paint.cs).
 					-->
-					<Canvas x:Name="PART_Canvas"
+					<Grid x:Name="PART_ShadowOwner"
 							HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
 							VerticalAlignment="{TemplateBinding VerticalAlignment}">
-						<ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+
+						<Canvas x:Name="PART_Canvas"
+								HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalAlignment}"/>
+
+						<ContentPresenter x:Name="PART_ContentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 										  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 										  Content="{TemplateBinding Content}" />
-					</Canvas>
+					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/Uno.Toolkit.UITest/Controls/ShadowContainer/Given_ShadowContainer.cs
+++ b/src/Uno.Toolkit.UITest/Controls/ShadowContainer/Given_ShadowContainer.cs
@@ -1,11 +1,7 @@
 ﻿#if IS_WINUI
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Uno.Toolkit.UITest.Extensions;
 using Uno.Toolkit.UITest.Framework;
 using Uno.UITest.Helpers;
@@ -62,11 +58,11 @@ namespace Uno.Toolkit.UITest.Controls.ShadowContainer
 			var xStart = xOffset < 0 ? (int)outerBorderRect.X : (int)outerBorderRect.Right;
 			var yStart = yOffset < 0 ? (int)outerBorderRect.Y : (int)outerBorderRect.Bottom;
 
-			int currentX = 1;
-			int currentY = 1;
-
 			int absXOffset = Math.Abs(xOffset);
 			int absYOffset = Math.Abs(yOffset);
+
+			int currentX = absXOffset * 2;
+			int currentY = absYOffset * 2;
 
 			while (currentX < absXOffset || currentY < absYOffset)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #708

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

ShadowContainer content not stretching by default

![image](https://github.com/unoplatform/uno.toolkit.ui/assets/16295702/f7eebdea-70ae-42d2-bda9-124e56f85a17)

## What is the new behavior?

ShadowContainer content should stretch by default to allow controls inside to properly stretch also if needed

NeumorphismHollow
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/116665025/e35aafac-e2e4-4d71-8fef-367ea3f584ea)

NeumorphismRaising
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/116665025/da0a41df-520d-4d12-bf5d-220f2e26da98)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
