### PR TITLE
[Legacy] Bump Uno.Material and Material.WinUI version

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -27,8 +27,8 @@
 		<PackageVersion Include="Uno.Cupertino.WinUI" Version="2.6.0" />
 		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-		<PackageVersion Include="Uno.Material" Version="2.6.0" />
-		<PackageVersion Include="Uno.Material.WinUI" Version="2.6.0" />
+		<PackageVersion Include="Uno.Material" Version="2.7.0-dev.97" />
+		<PackageVersion Include="Uno.Material.WinUI" Version="2.7.0-dev.97" />
 		<PackageVersion Include="Uno.UI" Version="4.10.0-dev.85" />
 		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.9" />
 		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.10.0-dev.85" />

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -23,8 +23,8 @@
 		<PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.2" />
 		<PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageVersion Include="Uno.Cupertino" Version="2.6.0" />
-		<PackageVersion Include="Uno.Cupertino.WinUI" Version="2.6.0" />
+		<PackageVersion Include="Uno.Cupertino" Version="2.7.0-dev.97" />
+		<PackageVersion Include="Uno.Cupertino.WinUI" Version="2.7.0-dev.97" />
 		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageVersion Include="Uno.Material" Version="2.7.0-dev.97" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,8 +10,8 @@
 		<PackageVersion Include="Uno.Core.Extensions.Collections" Version="4.0.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Logging" Version="4.0.1" />
-		<PackageVersion Include="Uno.Cupertino" Version="2.6.0" />
-		<PackageVersion Include="Uno.Cupertino.WinUI" Version="2.6.0" />
+		<PackageVersion Include="Uno.Cupertino" Version="2.7.0-dev.97" />
+		<PackageVersion Include="Uno.Cupertino.WinUI" Version="2.7.0-dev.97" />
 		<PackageVersion Include="Uno.SourceGenerationTasks" Version="4.2.0" />
 		<PackageVersion Include="Uno.Material" Version="2.7.0-dev.97" />
 		<PackageVersion Include="Uno.Material.WinUI" Version="2.7.0-dev.97" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,8 +13,8 @@
 		<PackageVersion Include="Uno.Cupertino" Version="2.6.0" />
 		<PackageVersion Include="Uno.Cupertino.WinUI" Version="2.6.0" />
 		<PackageVersion Include="Uno.SourceGenerationTasks" Version="4.2.0" />
-		<PackageVersion Include="Uno.Material" Version="2.6.0" />
-		<PackageVersion Include="Uno.Material.WinUI" Version="2.6.0" />
+		<PackageVersion Include="Uno.Material" Version="2.7.0-dev.97" />
+		<PackageVersion Include="Uno.Material.WinUI" Version="2.7.0-dev.97" />
 		<PackageVersion Include="Uno.UI" Version="4.7.37" />
 		<PackageVersion Include="Uno.WinUI" Version="4.7.37" />
 		<PackageVersion Include="Uno.XamlMerge.Task" Version="1.1.0-dev.12" />


### PR DESCRIPTION
GitHub Issue (If applicable): #

This PR just bumps the `Uno.Material` and `Uno.Material.WinUI` version.

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
