### PR TITLE
fix: Update Microsoft.UI.xaml

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -14,7 +14,7 @@
 			This is not an issue when libraries are referenced through nuget packages. See https://github.com/unoplatform/uno/issues/446 for more details.
 		-->
 		<PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.12" />
-		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.6.0" />
+		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
 		<PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.1" />
 		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.1.5" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.6.0" />
+		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
 		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.1.5" />
 		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageVersion Include="SkiaSharp.Views.Uno" Version="2.88.4-preview.84" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Canary is failing because uno.themes has updated to v2.7.1 of Microsoft.UI.Xaml (see https://github.com/unoplatform/Uno.Themes/pull/1144)

## What is the new behavior?

Updated to matching version

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] [Docs](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc) have been added/updated
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
