### PR TITLE
fix(shadows): background theming issue

### DIFF
--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/Shadow.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/Shadow.cs
@@ -1,11 +1,5 @@
 ﻿using System.ComponentModel;
-
-#if IS_WINUI
 using Microsoft.UI.Xaml;
-#else
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-#endif
 
 namespace Uno.Toolkit.UI;
 

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowCollection.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowCollection.cs
@@ -1,15 +1,8 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 
 namespace Uno.Toolkit.UI;
 
-public class ShadowCollection : ObservableCollection<Shadow>
-{
-	public bool HasInnerShadow() => this.Any(s => s.IsInner);
-
-	public string ToKey(double width, double height, Windows.UI.Color? contentBackground)
-		=> string.Create(CultureInfo.InvariantCulture, $"w{width},h{height}") +
-		(contentBackground.HasValue ? $",cb{contentBackground.Value}:" : ":") +
-		string.Join("/", this.Select(x => x.ToKey()));
-}
+public class ShadowCollection : ObservableCollection<Shadow> { }

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
@@ -41,25 +41,17 @@ public partial class ShadowContainer : ContentControl
 
 	public ShadowContainer()
 	{
-		Shadows = new();
-
 		DefaultStyleKey = typeof(ShadowContainer);
 
-		_cornerRadius = new CornerRadius(0);
+		Shadows = new();
 
 		Loaded += ShadowContainerLoaded;
 		Unloaded += ShadowContainerUnloaded;
 	}
 
-	private void ShadowContainerUnloaded(object sender, RoutedEventArgs e)
-	{
-		RevokeListeners();
-	}
+	private void ShadowContainerLoaded(object sender, RoutedEventArgs e) => UpdateShadows();
 
-	private void ShadowContainerLoaded(object sender, RoutedEventArgs e)
-	{
-		UpdateShadows();
-	}
+	private void ShadowContainerUnloaded(object sender, RoutedEventArgs e) => RevokeListeners();
 
 	private void RevokeListeners()
 	{
@@ -105,31 +97,16 @@ public partial class ShadowContainer : ContentControl
 			_currentContent = newElement;
 			_currentContent.SizeChanged += OnContentSizeChanged;
 
-			// todo@xy: optimizable
-			if (TryGetCornerRadius(newElement, out var cornerRadius))
+			if (FindCornerRadiusProperty(newElement) is { } dp)
 			{
-				var cornerRadiusProperty = newElement switch
-				{
-					Grid _ => Grid.CornerRadiusProperty,
-					StackPanel _ => StackPanel.CornerRadiusProperty,
-					ContentPresenter _ => ContentPresenter.CornerRadiusProperty,
-					Border _ => Border.CornerRadiusProperty,
-					Control _ => Control.CornerRadiusProperty,
-					RelativePanel _ => RelativePanel.CornerRadiusProperty,
-					_ => default,
-
-				};
-
-				if (cornerRadiusProperty != null)
-				{
-					_cornerRadiusChanged.Disposable = newElement.RegisterDisposablePropertyChangedCallback(
-						cornerRadiusProperty,
-						(s, dp) => OnCornerRadiusChanged(s, dp)
-					);
-				}
+				_cornerRadius = (CornerRadius)newElement.GetValue(dp);
+				_cornerRadiusChanged.Disposable = newElement.RegisterDisposablePropertyChangedCallback(dp, OnCornerRadiusChanged);
 			}
-
-			_cornerRadius = cornerRadius;
+			else
+			{
+				_cornerRadius = default;
+				_cornerRadiusChanged.Disposable = null;
+			}
 		}
 
 		InvalidateShadowHosts();
@@ -139,31 +116,32 @@ public partial class ShadowContainer : ContentControl
 
 	private void OnCornerRadiusChanged(DependencyObject sender, DependencyProperty dp)
 	{
-		if (_currentContent is { })
+		if (_currentContent?.GetValue(dp) is CornerRadius value)
 		{
-			if (TryGetCornerRadius(_currentContent, out var cornerRadius))
-			{
-				_cornerRadius = cornerRadius;
-				InvalidateShadowHosts();
-			}
+			_cornerRadius = value;
+			InvalidateShadowHosts();
+		}
+		else
+		{
+			_cornerRadius = default;
 		}
 	}
 
-	// todo@xy: optimizable
-	private static bool TryGetCornerRadius(FrameworkElement element, out CornerRadius cornerRadius)
+	private static DependencyProperty? FindCornerRadiusProperty(FrameworkElement element)
 	{
-		CornerRadius? localCornerRadius = element switch
+		return element switch
 		{
-			Control control => control.CornerRadius,
-			StackPanel stackPanel => stackPanel.CornerRadius,
-			RelativePanel relativePanel => relativePanel.CornerRadius,
-			Grid grid => grid.CornerRadius,
-			Border border => border.CornerRadius,
-			_ => VisualTreeHelperEx.TryGetDpValue<CornerRadius>(element, "CornerRadius", out var value) ? value : default(CornerRadius?),
-		};
+			// fast path to avoid reflection
+			Grid _ => Grid.CornerRadiusProperty,
+			StackPanel _ => StackPanel.CornerRadiusProperty,
+			ContentPresenter _ => ContentPresenter.CornerRadiusProperty,
+			Border _ => Border.CornerRadiusProperty,
+			Control _ => Control.CornerRadiusProperty,
+			RelativePanel _ => RelativePanel.CornerRadiusProperty,
 
-		cornerRadius = localCornerRadius ?? new CornerRadius(0);
-		return localCornerRadius != null;
+			DependencyObject @do => @do.FindDependencyPropertyUsingReflection<CornerRadius>("CornerRadiusProperty"),
+			_ => null,
+		};
 	}
 
 	private void OnContentSizeChanged(object sender, SizeChangedEventArgs args)

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
@@ -1,18 +1,21 @@
-﻿using System;
-using System.Linq;
-
-#if IS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using SkiaSharp.Views.Windows;
-#else
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using SkiaSharp.Views.UWP;
+﻿#if false
+// We keep that as a reference cause it would be better to use the hardware-accelerated version
+#define ANDROID_REFERENTIAL_IMPL
 #endif
 
-#if __ANDROID__
-using Android.Views;
+using System;
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using SkiaSharp;
+using SkiaSharp.Views.Windows;
+
+#if __ANDROID__ && ANDROID_REFERENTIAL_IMPL
+using _SKXamlCanvas = SkiaSharp.Views.Windows.SKSwapChainPanel;
+using _SKPaintSurfaceEventArgs = SkiaSharp.Views.Windows.SKPaintGLSurfaceEventArgs;
+#else
+using _SKXamlCanvas = SkiaSharp.Views.Windows.SKXamlCanvas;
+using _SKPaintSurfaceEventArgs = SkiaSharp.Views.Windows.SKPaintSurfaceEventArgs;
 #endif
 
 namespace Uno.Toolkit.UI;
@@ -30,18 +33,10 @@ public partial class ShadowContainer : ContentControl
 	private const string PART_Canvas = "PART_Canvas";
 
 	private Canvas? _canvas;
-
-#if false // ANDROID (see comment below)
-    private readonly SKSwapChainPanel _shadowHost;
-    private bool _notOpaqueSet = false;
-#else
-	private SKXamlCanvas? _shadowHost;
-#endif
-
-	private static readonly ShadowsCache Cache = new ShadowsCache();
-
 	private FrameworkElement? _currentContent;
 
+	private readonly ShadowPaintContext _backgroundPaintContext = new() { IsBackground = true };
+	private readonly ShadowPaintContext _foregroundPaintContext = new();
 	private CornerRadius _cornerRadius;
 
 	public ShadowContainer()
@@ -75,25 +70,24 @@ public partial class ShadowContainer : ContentControl
 
 	protected override void OnApplyTemplate()
 	{
-		_canvas = GetTemplateChild(nameof(PART_Canvas)) as Canvas;
+		base.OnApplyTemplate();
 
+		_canvas =
+			GetTemplateChild(nameof(PART_Canvas)) as Canvas ??
+			throw new InvalidOperationException($"Canvas '{PART_Canvas}' was not found in the control-template.");
 
-#if false // ANDROID: We keep that as a reference cause it would be better to use the hardware-accelerated version
-        var skiaCanvas = new SKSwapChainPanel();
-        skiaCanvas.PaintSurface += OnSurfacePainted;
-#else
-		var skiaCanvas = new SKXamlCanvas();
-		skiaCanvas.PaintSurface += OnSurfacePainted;
-#endif
+		_backgroundPaintContext.ShadowHost = new();
+		_foregroundPaintContext.ShadowHost = new() { IsHitTestVisible = false };
+		_backgroundPaintContext.ShadowHost.PaintSurface += OnPaintSurface;
+		_foregroundPaintContext.ShadowHost.PaintSurface += OnPaintSurface;
 
 #if __IOS__ || __MACCATALYST__
-        skiaCanvas.Opaque = false;
+		_backgroundPaintContext.ShadowHost.Opaque = false;
+		_foregroundPaintContext.ShadowHost.Opaque = false;
 #endif
 
-		_shadowHost = skiaCanvas;
-		_canvas?.Children.Insert(0, _shadowHost!);
-
-		base.OnApplyTemplate();
+		_canvas.Children.Insert(0, _backgroundPaintContext.ShadowHost);
+		_canvas.Children.Add(_foregroundPaintContext.ShadowHost);
 	}
 
 	/// <inheritdoc/>
@@ -106,12 +100,12 @@ public partial class ShadowContainer : ContentControl
 			_canvas?.Children.Remove(oldElement);
 			oldElement.SizeChanged -= OnContentSizeChanged;
 		}
-
 		if (newContent is FrameworkElement newElement)
 		{
 			_currentContent = newElement;
 			_currentContent.SizeChanged += OnContentSizeChanged;
 
+			// todo@xy: optimizable
 			if (TryGetCornerRadius(newElement, out var cornerRadius))
 			{
 				var cornerRadiusProperty = newElement switch
@@ -121,7 +115,7 @@ public partial class ShadowContainer : ContentControl
 					ContentPresenter _ => ContentPresenter.CornerRadiusProperty,
 					Border _ => Border.CornerRadiusProperty,
 					Control _ => Control.CornerRadiusProperty,
-					RelativePanel _ => RelativePanel.CornerRadiusProperty, 
+					RelativePanel _ => RelativePanel.CornerRadiusProperty,
 					_ => default,
 
 				};
@@ -138,7 +132,8 @@ public partial class ShadowContainer : ContentControl
 			_cornerRadius = cornerRadius;
 		}
 
-		_shadowHost?.Invalidate();
+		InvalidateShadowHosts();
+
 		base.OnContentChanged(oldContent, newContent);
 	}
 
@@ -149,11 +144,12 @@ public partial class ShadowContainer : ContentControl
 			if (TryGetCornerRadius(_currentContent, out var cornerRadius))
 			{
 				_cornerRadius = cornerRadius;
-				_shadowHost?.Invalidate();
+				InvalidateShadowHosts();
 			}
 		}
 	}
 
+	// todo@xy: optimizable
 	private static bool TryGetCornerRadius(FrameworkElement element, out CornerRadius cornerRadius)
 	{
 		CornerRadius? localCornerRadius = element switch
@@ -175,21 +171,23 @@ public partial class ShadowContainer : ContentControl
 		if (args.NewSize.Width > 0 && args.NewSize.Height > 0)
 		{
 			UpdateCanvasSize(args.NewSize.Width, args.NewSize.Height, Shadows);
-			_shadowHost?.Invalidate();
+			InvalidateShadowHosts();
 		}
 	}
 
 	private void UpdateCanvasSize(double childWidth, double childHeight, ShadowCollection? shadows)
 	{
-		if (_currentContent == null || _canvas == null || _shadowHost == null)
+		if (_currentContent == null ||
+			_canvas == null ||
+			_backgroundPaintContext.ShadowHost == null || _foregroundPaintContext.ShadowHost == null)
 		{
 			return;
 		}
 
-		double absoluteMaxOffsetX = 0;
-		double absoluteMaxOffsetY = 0;
-		double maxBlurRadius = 0;
-		double maxSpread = 0;
+		var absoluteMaxOffsetX = 0d;
+		var absoluteMaxOffsetY = 0d;
+		var maxBlurRadius = 0d;
+		var maxSpread = 0d;
 
 		if (shadows?.Any() == true)
 		{
@@ -201,21 +199,32 @@ public partial class ShadowContainer : ContentControl
 
 		_canvas.Height = childHeight;
 		_canvas.Width = childWidth;
+
 #if __ANDROID__ || __IOS__
 		_canvas.GetDispatcherCompat().Schedule(() => _canvas.InvalidateMeasure());
 #endif
-		double newHostHeight = childHeight + maxBlurRadius * 2 + absoluteMaxOffsetY * 2 + maxSpread * 2;
-		double newHostWidth = childWidth + maxBlurRadius * 2 + absoluteMaxOffsetX * 2 + maxSpread * 2;
-		_shadowHost.Height = newHostHeight;
-		_shadowHost.Width = newHostWidth;
 
-		double diffWidthShadowHostChild = newHostWidth - childWidth;
-		double diffHeightShadowHostChild = newHostHeight - childHeight;
+		var newHostHeight = childHeight + maxBlurRadius * 2 + absoluteMaxOffsetY * 2 + maxSpread * 2;
+		var newHostWidth = childWidth + maxBlurRadius * 2 + absoluteMaxOffsetX * 2 + maxSpread * 2;
+		var diffWidthShadowHostChild = newHostWidth - childWidth;
+		var diffHeightShadowHostChild = newHostHeight - childHeight;
+		var left = -diffWidthShadowHostChild / 2 + _currentContent.Margin.Left;
+		var top = -diffHeightShadowHostChild / 2 + _currentContent.Margin.Top;
 
-		float left = (float)(-diffWidthShadowHostChild / 2 + _currentContent.Margin.Left);
-		float top = (float)(-diffHeightShadowHostChild / 2 + _currentContent.Margin.Top);
+		FixOntoCanvas(_backgroundPaintContext.ShadowHost, left, top, newHostWidth, newHostHeight);
+		FixOntoCanvas(_foregroundPaintContext.ShadowHost, left, top, newHostWidth, newHostHeight);
+		void FixOntoCanvas(FrameworkElement fe, double left, double top, double width, double height)
+		{
+			fe.Width = width;
+			fe.Height = height;
+			Canvas.SetLeft(fe, left);
+			Canvas.SetTop(fe, top);
+		}
+	}
 
-		Canvas.SetLeft(_shadowHost, left);
-		Canvas.SetTop(_shadowHost, top);
+	private void InvalidateShadowHosts()
+	{
+		_backgroundPaintContext.ShadowHost?.Invalidate();
+		_foregroundPaintContext.ShadowHost?.Invalidate();
 	}
 }

--- a/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Uno.Logging;
 
+using static System.Reflection.BindingFlags;
+
 #if IS_WINUI
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Controls;
@@ -191,8 +193,9 @@ namespace Uno.Toolkit.UI
 				return property;
 			}
 
-			property = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as DependencyProperty
-				?? type.GetField(propertyName, BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as DependencyProperty;
+			property =
+				type.GetProperty(propertyName, Public | Static | FlattenHierarchy)?.GetValue(null) as DependencyProperty ??
+				type.GetField(propertyName, Public | Static | FlattenHierarchy)?.GetValue(null) as DependencyProperty;
 
 			if (property == null)
 			{

--- a/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
+++ b/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#define USE_CACHED_DP_REFLECTION
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -247,8 +249,13 @@ namespace Uno.Toolkit.UI
 		internal static bool TryGetDpValue<T>(object owner, string property, out T? value)
 		{
 			if (owner is DependencyObject @do &&
+#if USE_CACHED_DP_REFLECTION
+				@do.FindDependencyPropertyUsingReflection<T>($"{property}Property") is { } dp
+#else
 				owner.GetType().GetProperty($"{property}Property", Public | Static | FlattenHierarchy)
-					?.GetValue(null, null) is DependencyProperty dp)
+					?.GetValue(null, null) is DependencyProperty dp
+#endif
+			)
 			{
 				value = (T)@do.GetValue(dp);
 				return true;


### PR DESCRIPTION
GitHub Issue (If applicable): closes: #707

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
ShadowContainer currently strips its child's background and use it as the background for the image-brush. This is done because the inner shadows need to be drawn on top of the content background. This approach has a few problems where it doesnt subscribes to updates to the background property, nor theme updates from the `{ThemeResource}` brush.

## What is the new behavior?
ShadowContainer now creates two layers of shadows, one for background shadows and one for foreground shadows, that sandwiches the content.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [x] UWP
	- [x] WinUI
	- [x] iOS
	- [x] Android
	- [x] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->