### PR TITLE
fix: skia and IOS shadows not updating properly

### DIFF
--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.Paint.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.Paint.cs
@@ -72,7 +72,7 @@ public partial class ShadowContainer
 		using var _ = canvas.SnapshotState();
 
 		var key =
-			FormattableString.Invariant($"[{contentAsFE.ActualWidth}x{contentAsFE.ActualHeight},{background}]: ") +
+			FormattableString.Invariant($"[{contentAsFE.ActualWidth}x{contentAsFE.ActualHeight},{_shadowHost.ActualWidth}x{_shadowHost.ActualHeight},{background}]: ") +
 			string.Join("; ", state.Shadows.Select(x => x.ToKey()));
 		if (Cache.TryGetValue(key, out var snapshot))
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #748

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Right now, on skia, and IOS you add a shadow to a shadow container and increase the size of the shadow content, the shadows appear too small, 
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/90481654/bcee3c0a-13e6-4f93-9129-5f03fbf92b5d)

## What is the new behavior?
They stay the right size and visible
![shadowskia](https://github.com/unoplatform/uno.toolkit.ui/assets/90481654/839d70f0-be5a-4a2f-a3cd-28c5228ef71a)

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [X] WinUI
	- [X] iOS
	- [X] Android
	- [ ] WASM Could not build
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.