### PR TITLE
[ShadowContainer] CornerRadius performance issue

### DIFF
--- a/build/workflow/stage-uitests-ios.yml
+++ b/build/workflow/stage-uitests-ios.yml
@@ -1,7 +1,7 @@
 ﻿jobs:
 - job: iOS_UITests
   displayName: 'Run iOS UI Tests'
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   variables:
     CI_Build: true
     SourceLinkEnabled: false

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ShadowContainerTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ShadowContainerTests.cs
@@ -29,6 +29,10 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.UI.ViewManagement;
 using FluentAssertions;
+using SkiaSharp;
+using SkiaSharp.Views.Windows;
+using System.Drawing;
+using Windows.Globalization.DateTimeFormatting;
 
 namespace Uno.Toolkit.RuntimeTests.Tests
 {
@@ -36,46 +40,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 	[RunsOnUIThread]
 	internal partial class ShadowContainerTests
 	{
-
-
-		[TestMethod]
-		public async Task Displays_Content()
-		{
-			if (!ImageAssertHelper.IsScreenshotSupported())
-			{
-				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
-			}
-
-			var greenBorder = new ShadowContainer
-			{
-				Content = new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Green) }
-			};
-
-			var shadowContainer = new ShadowContainer
-			{
-				Content = greenBorder
-			};
-
-			var stackPanel = new StackPanel
-			{
-				Background = new SolidColorBrush(Colors.Yellow),
-				HorizontalAlignment = HorizontalAlignment.Center,
-				Children =
-				{
-					new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Red) },
-					shadowContainer,
-					new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Red) },
-				}
-			};
-
-			UnitTestsUIContentHelper.Content = stackPanel;
-
-			await UnitTestsUIContentHelper.WaitForIdle();
-			await UnitTestsUIContentHelper.WaitForLoaded(stackPanel);
-
-			var renderer = await stackPanel.TakeScreenshot();
-			await renderer.AssertColorAt(Colors.Green, 100, 300);
-		}
 
 #if !(__ANDROID__ || __IOS__)
 
@@ -179,46 +143,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 
 		}
 
-
-		[TestMethod]
-		public async Task Displays_Content()
-		{
-			if (!ImageAssertHelper.IsScreenshotSupported())
-			{
-				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
-			}
-
-			var greenBorder = new ShadowContainer
-			{
-				Content = new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Green) }
-			};
-
-			var shadowContainer = new ShadowContainer
-			{
-				Content = greenBorder
-			};
-
-			var stackPanel = new StackPanel
-			{
-				Background = new SolidColorBrush(Colors.Yellow),
-				HorizontalAlignment = HorizontalAlignment.Center,
-				Children =
-				{
-					new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Red) },
-					shadowContainer,
-					new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Red) },
-				}
-			};
-
-			UnitTestsUIContentHelper.Content = stackPanel;
-
-			await UnitTestsUIContentHelper.WaitForIdle();
-			await UnitTestsUIContentHelper.WaitForLoaded(stackPanel);
-
-			var renderer = await stackPanel.TakeScreenshot();
-			await renderer.AssertColorAt(Colors.Green, 100, 300);
-		}
-
 		[TestMethod]
 		public async Task Displays_Content_With_Margin()
 		{
@@ -254,7 +178,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			await renderer.AssertColorAt(Colors.Green, 75, 225);
 		}
 
-#if !(__ANDROID__ || __IOS__)
 		[TestMethod]
 		[DataRow(10, 10, false)]
 		[DataRow(10, 10, true)]
@@ -317,6 +240,45 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			}
 		}
 #endif
+
+		[TestMethod]
+		public async Task Displays_Content()
+		{
+			if (!ImageAssertHelper.IsScreenshotSupported())
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
+			var greenBorder = new ShadowContainer
+			{
+				Content = new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Green) }
+			};
+
+			var shadowContainer = new ShadowContainer
+			{
+				Content = greenBorder
+			};
+
+			var stackPanel = new StackPanel
+			{
+				Background = new SolidColorBrush(Colors.Yellow),
+				HorizontalAlignment = HorizontalAlignment.Center,
+				Children =
+				{
+					new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Red) },
+					shadowContainer,
+					new Border { Height = 200, Width = 200, Background = new SolidColorBrush(Colors.Red) },
+				}
+			};
+
+			UnitTestsUIContentHelper.Content = stackPanel;
+
+			await UnitTestsUIContentHelper.WaitForIdle();
+			await UnitTestsUIContentHelper.WaitForLoaded(stackPanel);
+
+			var renderer = await stackPanel.TakeScreenshot();
+			await renderer.AssertColorAt(Colors.Green, 100, 300);
+		}
 
 		[TestMethod]
 		public async Task ShadowContainer_ReLayoutsAfterChangeInSize()

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.Paint.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.Paint.cs
@@ -274,9 +274,9 @@ public partial class ShadowContainer
 			var rect = new SKRect(0, 0, (float)Width * state.PixelRatio, (float)Height * state.PixelRatio);
 			var radii = new SKPoint[] {
 				new SKPoint((float)CornerRadius.TopLeft * state.PixelRatio, (float)CornerRadius.TopLeft * state.PixelRatio),
-				new SKPoint((float)(state.PixelRatio * CornerRadius.TopRight), (float)(state.PixelRatio * CornerRadius.TopRight)),
-				new SKPoint((float)(state.PixelRatio * CornerRadius.BottomRight),(float)(state.PixelRatio * CornerRadius.BottomRight)),
-				new SKPoint((float)(state.PixelRatio * CornerRadius.BottomLeft), (float)(state.PixelRatio * CornerRadius.BottomLeft))
+				new SKPoint((float)CornerRadius.TopRight * state.PixelRatio, (float)CornerRadius.TopRight * state.PixelRatio),
+				new SKPoint((float)CornerRadius.BottomRight * state.PixelRatio,(float)CornerRadius.BottomRight * state.PixelRatio),
+				new SKPoint((float)CornerRadius.BottomLeft * state.PixelRatio, (float)CornerRadius.BottomLeft * state.PixelRatio)
 			};
 			var shape = new SKRoundRect();
 			shape.SetRectRadii(rect, radii);

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.Paint.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.Paint.cs
@@ -273,7 +273,7 @@ public partial class ShadowContainer
 		{
 			var rect = new SKRect(0, 0, (float)Width * state.PixelRatio, (float)Height * state.PixelRatio);
 			var radii = new SKPoint[] {
-				new SKPoint((float)(state.PixelRatio * CornerRadius.TopLeft), (float)(state.PixelRatio * CornerRadius.TopLeft)),
+				new SKPoint((float)CornerRadius.TopLeft * state.PixelRatio, (float)CornerRadius.TopLeft * state.PixelRatio),
 				new SKPoint((float)(state.PixelRatio * CornerRadius.TopRight), (float)(state.PixelRatio * CornerRadius.TopRight)),
 				new SKPoint((float)(state.PixelRatio * CornerRadius.BottomRight),(float)(state.PixelRatio * CornerRadius.BottomRight)),
 				new SKPoint((float)(state.PixelRatio * CornerRadius.BottomLeft), (float)(state.PixelRatio * CornerRadius.BottomLeft))

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.Paint.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.Paint.cs
@@ -272,10 +272,12 @@ public partial class ShadowContainer
 		protected override SKRoundRect GetContentShape(ShadowPaintState state)
 		{
 			var rect = new SKRect(0, 0, (float)Width * state.PixelRatio, (float)Height * state.PixelRatio);
-			var radii = new[] { CornerRadius.TopLeft, CornerRadius.TopRight, CornerRadius.BottomRight, CornerRadius.BottomLeft }
-				.Select(x => (float)x * state.PixelRatio)
-				.Select(x => new SKPoint(x, x))
-				.ToArray();
+			var radii = new SKPoint[] {
+				new SKPoint((float)(state.PixelRatio * CornerRadius.TopLeft), (float)(state.PixelRatio * CornerRadius.TopLeft)),
+				new SKPoint((float)(state.PixelRatio * CornerRadius.TopRight), (float)(state.PixelRatio * CornerRadius.TopRight)),
+				new SKPoint((float)(state.PixelRatio * CornerRadius.BottomRight),(float)(state.PixelRatio * CornerRadius.BottomRight)),
+				new SKPoint((float)(state.PixelRatio * CornerRadius.BottomLeft), (float)(state.PixelRatio * CornerRadius.BottomLeft))
+			};
 			var shape = new SKRoundRect();
 			shape.SetRectRadii(rect, radii);
 			


### PR DESCRIPTION
GitHub Issue (If applicable): closes: #789 


## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

For better performance.

## What is the new behavior?

Using array.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
