### PR TITLE
[ShadowContainer][All Platforms] ShadowContainer not resizing properly

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
@@ -362,17 +362,17 @@
 								</StackPanel>
 
 
-							 <!--Test ShadowContainer stretching its content by default--> 
+								<!--Test ShadowContainer stretching its content by default-->
 
-							<StackPanel HorizontalAlignment="Stretch"
+								<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 
-								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+									<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -380,13 +380,13 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Shadows element"
 											 Text="NO Padding NO Margin"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
-								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+									<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -394,14 +394,14 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Shadows element"
 											 Text="Padding"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+									<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox BorderThickness="0"
+										<TextBox BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
 											 HorizontalAlignment="Stretch"
@@ -409,14 +409,14 @@
 											 PlaceholderText="Shadows element"
 											 Text="Margin"
 											 Margin="30,30,30,30"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+									<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -425,14 +425,14 @@
 											 PlaceholderText="Shadows element"
 											 Text="Padding + Margin diff"
 											 Margin="15,30,50,30"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
+									<utu:ShadowContainer Shadows="{StaticResource ButtonShadows}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox BorderThickness="0"
+										<TextBox BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
 											 HorizontalAlignment="Stretch"
@@ -440,18 +440,18 @@
 											 PlaceholderText="Shadows element"
 											 Text="Padding"
 											 Padding="15,30,50,30"/>
-								</utu:ShadowContainer>
-							</StackPanel>
-							
-							
-							<StackPanel HorizontalAlignment="Stretch"
+									</utu:ShadowContainer>
+								</StackPanel>
+
+
+								<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -459,13 +459,13 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Hollow element"
 											 Text="NO Padding NO Margin"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -473,14 +473,14 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Hollow element"
 											 Text="Padding"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox BorderThickness="0"
+										<TextBox BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
 											 HorizontalAlignment="Stretch"
@@ -488,14 +488,14 @@
 											 PlaceholderText="Hollow element"
 											 Text="Margin"
 											 Margin="30,30,30,30"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -504,14 +504,14 @@
 											 PlaceholderText="Hollow element"
 											 Text="Padding + Margin diff"
 											 Margin="15,30,50,30"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox 
+										<TextBox 
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -520,18 +520,18 @@
 											 PlaceholderText="Hollow element"
 											 Text="Padding"
 											 Padding="15,30,50,30"/>
-								</utu:ShadowContainer>
-							</StackPanel>
+									</utu:ShadowContainer>
+								</StackPanel>
 
-							<StackPanel HorizontalAlignment="Stretch"
+								<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -539,13 +539,13 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Raising element"
 											 Text="Center"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -553,14 +553,14 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Raising element"
 											 Text="Right"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox BorderThickness="0"
+										<TextBox BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
 											 HorizontalAlignment="Right"
@@ -568,14 +568,14 @@
 											 PlaceholderText="Hollow element"
 											 Text="Right"
 											 Margin="200,30,30,30"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -584,14 +584,14 @@
 											 PlaceholderText="Raising element"
 											 Text="Left"
 											 Margin="15,30,200,30"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox 
+										<TextBox 
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -600,12 +600,12 @@
 											 PlaceholderText="Hollow element"
 											 Text="Left"
 											 Padding="15,30,50,30"/>
-								</utu:ShadowContainer>
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									</utu:ShadowContainer>
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Center"
 													 HorizontalContentAlignment="Center"
 													 Background="{StaticResource UnoColor}">
-									<TextBox 
+										<TextBox 
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -614,19 +614,19 @@
 											 PlaceholderText="Hollow element"
 											 Text="Left on ShadowContainer Center"
 											 Padding="15,30,50,30"/>
-								</utu:ShadowContainer>
-							</StackPanel>
+									</utu:ShadowContainer>
+								</StackPanel>
 
 
-							<StackPanel HorizontalAlignment="Stretch"
+								<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -635,13 +635,13 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Raising element"
 											 Text="Center"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -650,14 +650,14 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Raising element"
 											 Text="Right"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -666,14 +666,14 @@
 											 PlaceholderForeground="LightGray"
 											 PlaceholderText="Raising element"
 											 Text="Right Top "/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismRaising}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -683,14 +683,14 @@
 											 PlaceholderText="Raising element"
 											 Text="Left"
 											 Margin="15,100,50,200"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox 
+										<TextBox 
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -700,12 +700,12 @@
 											 PlaceholderText="Hollow element"
 											 Text="Left"
 											 Margin="15,100,50,100"/>
-								</utu:ShadowContainer>
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
+									</utu:ShadowContainer>
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismHollow}"
 													 HorizontalAlignment="Center"
 													 HorizontalContentAlignment="Center"
 													 Background="{StaticResource UnoColor}">
-									<TextBox 
+										<TextBox 
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -715,24 +715,24 @@
 											 PlaceholderText="Hollow element"
 											 Text="Left on ShadowContainer Center"
 											 Padding="15,200,50,100"/>
-								</utu:ShadowContainer>
-							</StackPanel>
+									</utu:ShadowContainer>
+								</StackPanel>
 
 
 
 
-							<StackPanel HorizontalAlignment="Stretch"
+								<StackPanel HorizontalAlignment="Stretch"
 										Spacing="50"
 										Padding="20">
 
 
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -742,14 +742,14 @@
 											 PlaceholderText="Raising element"
 											 Text="Left Margin 0,130,300,20"
 											 Margin="0,130,300,20"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -759,7 +759,7 @@
 											 PlaceholderText="Raising element"
 											 Text="Left Margin 300,20,0,130"
 											 Margin="300,20,0,130"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
 
@@ -767,11 +767,11 @@
 
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -781,14 +781,14 @@
 											 PlaceholderText="Raising element"
 											 Text="Right Margin 0,130,300,20"
 											 Margin="0,130,300,20"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -798,16 +798,16 @@
 											 PlaceholderText="Raising element"
 											 Text="Right Margin 300,20,0,130"
 											 Margin="300,20,0,130"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -817,14 +817,14 @@
 											 PlaceholderText="Raising element"
 											 Text="Center Margin 0,130,300,20"
 											 Margin="0,130,300,20"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -834,16 +834,16 @@
 											 PlaceholderText="Raising element"
 											 Text="Center Margin 300,20,0,130"
 											 Margin="300,20,0,130"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 BorderThickness="0"
 											 CornerRadius="20"
 											 Foreground="White"
@@ -853,14 +853,14 @@
 											 PlaceholderText="Raising element"
 											 Text="Stretch Margin 0,130,300,20"
 											 Margin="0,130,300,20"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
 
-								<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
+									<utu:ShadowContainer Shadows="{StaticResource NeumorphismBulging}"
 													 HorizontalAlignment="Stretch"
 													 HorizontalContentAlignment="Stretch"
 													 Background="{StaticResource UnoColor}">
-									<TextBox Padding="10"
+										<TextBox Padding="10"
 											 
 											 BorderThickness="0"
 											 CornerRadius="20"
@@ -871,13 +871,43 @@
 											 PlaceholderText="Raising element"
 											 Text="Stretch Margin 300,20,0,130"
 											 Margin="300,20,0,130"/>
-								</utu:ShadowContainer>
+									</utu:ShadowContainer>
 
+
+								</StackPanel>
 
 							</StackPanel>
+							<Grid>
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+								<utu:ShadowContainer Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+													 CornerRadius="20"
+													 Margin="32">
+									<utu:ShadowContainer.Shadows>
+										<utu:ShadowCollection >
+											<utu:Shadow BlurRadius="20"
+														IsInner="True"
+														OffsetX="10"
+														OffsetY="10"
+														Opacity="0.5"
+														Spread="0"
+														Color="{StaticResource UnoColor}" />
+											<utu:Shadow BlurRadius="20"
+														IsInner="True"
+														OffsetX="-10"
+														OffsetY="-10"
+														Opacity="0.5"
+														Spread="0"
+														Color="{StaticResource UnoPink}" />
+										</utu:ShadowCollection>
+									</utu:ShadowContainer.Shadows>
+									<TextBox Text="Shadow Text" Height="50"/>
+								</utu:ShadowContainer>
 
-						</StackPanel>
-
+								<TextBox Text="Normal Text" Height="50" Grid.Column="1" />
+							</Grid>
 						</StackPanel>
 					</ScrollViewer>
 				</DataTemplate>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
@@ -94,6 +94,66 @@
 					<ScrollViewer HorizontalScrollMode="Disabled">
 						<StackPanel Spacing="24">
 
+							<StackPanel>
+								<ItemsControl x:Name="ShadowsItemsControlTest" Background="Yellow">
+									<ItemsControl.ItemsPanel>
+										<ItemsPanelTemplate>
+											<StackPanel Orientation="Vertical" Spacing="10" />
+										</ItemsPanelTemplate>
+									</ItemsControl.ItemsPanel>
+									<ItemsControl.ItemTemplate>
+										<DataTemplate>
+											<Grid ColumnSpacing="5" RowSpacing="5">
+												<Grid.RowDefinitions>
+													<RowDefinition Height="Auto" />
+													<RowDefinition Height="Auto" />
+												</Grid.RowDefinitions>
+												<Grid.ColumnDefinitions>
+													<ColumnDefinition Width="70" />
+													<ColumnDefinition Width="70" />
+													<ColumnDefinition Width="60" />
+													<ColumnDefinition Width="80" />
+												</Grid.ColumnDefinitions>
+
+												<TextBox Grid.ColumnSpan="2"
+																 PlaceholderText="Color"
+																 Text="{Binding Color, Mode=TwoWay, Converter={StaticResource HexToColor}}">
+													<TextBox.Foreground>
+														<SolidColorBrush Color="{Binding Color}" />
+													</TextBox.Foreground>
+												</TextBox>
+												<TextBox Grid.Column="2"
+																 PlaceholderText="Opacity"
+																 Text="{Binding Opacity, Mode=TwoWay}" />
+												<CheckBox Grid.Column="3"
+																  Padding="5,0"
+																  Content="Inner"
+																  IsChecked="{Binding IsInner, Mode=TwoWay}" />
+
+												<TextBox Grid.Row="1"
+																 PlaceholderText="X"
+																 Text="{Binding OffsetX, Mode=TwoWay}" />
+												<TextBox Grid.Row="1"
+																 Grid.Column="1"
+																 PlaceholderText="Y"
+																 Text="{Binding OffsetY, Mode=TwoWay}" />
+												<TextBox Grid.Row="1"
+																 Grid.Column="2"
+																 PlaceholderText="Blur"
+																 Text="{Binding BlurRadius, Mode=TwoWay}" />
+												<TextBox Grid.Row="1"
+																 Grid.Column="3"
+																 PlaceholderText="Spread"
+																 Text="{Binding Spread, Mode=TwoWay}" />
+
+											</Grid>
+										</DataTemplate>
+									</ItemsControl.ItemTemplate>
+								</ItemsControl>
+
+							</StackPanel>
+
+							
 							<!-- Calculator -->
 							<StackPanel>
 								<TextBlock Text="Many colored shadows" Style="{StaticResource TitleTextBlockStyle}" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml
@@ -94,66 +94,6 @@
 					<ScrollViewer HorizontalScrollMode="Disabled">
 						<StackPanel Spacing="24">
 
-							<StackPanel>
-								<ItemsControl x:Name="ShadowsItemsControlTest" Background="Yellow">
-									<ItemsControl.ItemsPanel>
-										<ItemsPanelTemplate>
-											<StackPanel Orientation="Vertical" Spacing="10" />
-										</ItemsPanelTemplate>
-									</ItemsControl.ItemsPanel>
-									<ItemsControl.ItemTemplate>
-										<DataTemplate>
-											<Grid ColumnSpacing="5" RowSpacing="5">
-												<Grid.RowDefinitions>
-													<RowDefinition Height="Auto" />
-													<RowDefinition Height="Auto" />
-												</Grid.RowDefinitions>
-												<Grid.ColumnDefinitions>
-													<ColumnDefinition Width="70" />
-													<ColumnDefinition Width="70" />
-													<ColumnDefinition Width="60" />
-													<ColumnDefinition Width="80" />
-												</Grid.ColumnDefinitions>
-
-												<TextBox Grid.ColumnSpan="2"
-																 PlaceholderText="Color"
-																 Text="{Binding Color, Mode=TwoWay, Converter={StaticResource HexToColor}}">
-													<TextBox.Foreground>
-														<SolidColorBrush Color="{Binding Color}" />
-													</TextBox.Foreground>
-												</TextBox>
-												<TextBox Grid.Column="2"
-																 PlaceholderText="Opacity"
-																 Text="{Binding Opacity, Mode=TwoWay}" />
-												<CheckBox Grid.Column="3"
-																  Padding="5,0"
-																  Content="Inner"
-																  IsChecked="{Binding IsInner, Mode=TwoWay}" />
-
-												<TextBox Grid.Row="1"
-																 PlaceholderText="X"
-																 Text="{Binding OffsetX, Mode=TwoWay}" />
-												<TextBox Grid.Row="1"
-																 Grid.Column="1"
-																 PlaceholderText="Y"
-																 Text="{Binding OffsetY, Mode=TwoWay}" />
-												<TextBox Grid.Row="1"
-																 Grid.Column="2"
-																 PlaceholderText="Blur"
-																 Text="{Binding BlurRadius, Mode=TwoWay}" />
-												<TextBox Grid.Row="1"
-																 Grid.Column="3"
-																 PlaceholderText="Spread"
-																 Text="{Binding Spread, Mode=TwoWay}" />
-
-											</Grid>
-										</DataTemplate>
-									</ItemsControl.ItemTemplate>
-								</ItemsControl>
-
-							</StackPanel>
-
-							
 							<!-- Calculator -->
 							<StackPanel>
 								<TextBlock Text="Many colored shadows" Style="{StaticResource TitleTextBlockStyle}" />
@@ -185,13 +125,8 @@
 												BorderBrush="{StaticResource CardStrokeColorDefaultBrush}"
 												CornerRadius="20"
 												BorderThickness="1">
-										<ItemsControl x:Name="ShadowsItemsControl">
-											<ItemsControl.ItemsPanel>
-												<ItemsPanelTemplate>
-													<StackPanel Orientation="Vertical" Spacing="10" />
-												</ItemsPanelTemplate>
-											</ItemsControl.ItemsPanel>
-											<ItemsControl.ItemTemplate>
+										<ItemsRepeater x:Name="ShadowsItemsControl">
+											<ItemsRepeater.ItemTemplate>
 												<DataTemplate>
 													<Grid ColumnSpacing="5" RowSpacing="5">
 														<Grid.RowDefinitions>
@@ -238,8 +173,8 @@
 
 													</Grid>
 												</DataTemplate>
-											</ItemsControl.ItemTemplate>
-										</ItemsControl>
+											</ItemsRepeater.ItemTemplate>
+										</ItemsRepeater>
 										<StackPanel Margin="0,16,0,0"
 													HorizontalAlignment="Center"
 													Orientation="Horizontal"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml.cs
@@ -22,11 +22,8 @@ namespace Uno.Toolkit.Samples.Content.Controls
 				{
 					_shadows = shadowContainer.Shadows;
 
-					var shadowsItemsControl = SamplePageLayout.GetSampleChild<ItemsControl>(Design.Agnostic, "ShadowsItemsControl");
+					var shadowsItemsControl = SamplePageLayout.GetSampleChild<ItemsRepeater>(Design.Agnostic, "ShadowsItemsControl");
 					shadowsItemsControl.ItemsSource = _shadows;
-					var shadowsItemsControlTest = SamplePageLayout.GetSampleChild<ItemsControl>(Design.Agnostic, "ShadowsItemsControlTest");
-					shadowsItemsControlTest.ItemsSource = _shadows;
-					
 				}
 			};
 		}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/ShadowContainerSamplePage.WinUI.xaml.cs
@@ -24,6 +24,9 @@ namespace Uno.Toolkit.Samples.Content.Controls
 
 					var shadowsItemsControl = SamplePageLayout.GetSampleChild<ItemsControl>(Design.Agnostic, "ShadowsItemsControl");
 					shadowsItemsControl.ItemsSource = _shadows;
+					var shadowsItemsControlTest = SamplePageLayout.GetSampleChild<ItemsControl>(Design.Agnostic, "ShadowsItemsControlTest");
+					shadowsItemsControlTest.ItemsSource = _shadows;
+					
 				}
 			};
 		}

--- a/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
+++ b/src/Uno.Toolkit.Skia.WinUI/Controls/Shadows/ShadowContainer.cs
@@ -33,7 +33,7 @@ public partial class ShadowContainer : ContentControl
 	private static readonly ShadowsCache Cache = new ShadowsCache();
 
 	private readonly SerialDisposable _eventSubscriptions = new();
-	
+
 	private Grid? _panel;
 	private Canvas? _canvas;
 	private SKXamlCanvas? _shadowHost;
@@ -254,20 +254,32 @@ public partial class ShadowContainer : ContentControl
 		_canvas?.Children.Insert(0, _shadowHost!);
 	}
 
-	private async void InvalidateCanvasLayout()
+	private void InvalidateCanvasLayout()
 	{
 		if (Content is not FrameworkElement contentAsFE ||
-				_panel == null ||
-				_canvas == null ||
-				_shadowHost == null)
+						_panel == null ||
+						_canvas == null ||
+						_shadowHost == null)
 		{
 			return;
 		}
 
-		//Needed to allow Canvas to free up allocated space so content can reduce in size.
-		_canvas.Width = 0;
-		_canvas.Height = 0;
-		await Task.Yield();
+#if __ANDROID__ || __IOS__
+		this.GetDispatcherCompat().Schedule(() => InvalidateCanvasLayoutSize());
+#else
+		InvalidateCanvasLayoutSize();
+#endif
+
+	}
+	private void InvalidateCanvasLayoutSize()
+	{
+		if (Content is not FrameworkElement contentAsFE ||
+						_panel == null ||
+						_canvas == null ||
+						_shadowHost == null)
+		{
+			return;
+		}
 
 		var childWidth = contentAsFE.ActualWidth;
 		var childHeight = contentAsFE.ActualHeight;
@@ -276,6 +288,10 @@ public partial class ShadowContainer : ContentControl
 			return;
 		}
 
+
+#if __ANDROID__ || __IOS__
+		_canvas.GetDispatcherCompat().Schedule(() => _canvas.InvalidateMeasure());
+#endif
 		double absoluteMaxOffsetX = 0;
 		double absoluteMaxOffsetY = 0;
 		double maxBlurRadius = 0;
@@ -286,72 +302,35 @@ public partial class ShadowContainer : ContentControl
 			absoluteMaxOffsetX = shadows.Max(s => Math.Abs(s.OffsetX));
 			absoluteMaxOffsetY = shadows.Max(s => Math.Abs(s.OffsetY));
 			maxBlurRadius = shadows.Max(s => s.BlurRadius);
-			maxSpread = shadows.Max(s => s.Spread);
+			maxSpread = shadows.Max(s => Math.Abs(s.Spread));
 		}
-
-		_canvas.Width = contentAsFE.ActualWidth - contentAsFE.Margin.Left - contentAsFE.Margin.Right;
-		if (_canvas.Width < 0)
-		{
-			_canvas.Width = 0;
-		}
-		_canvas.Height = contentAsFE.ActualHeight - contentAsFE.Margin.Top - contentAsFE.Margin.Bottom;
-		if (_canvas.Height < 0)
-		{
-			_canvas.Height = 0;
-		}
-		_canvas.HorizontalAlignment = contentAsFE.HorizontalAlignment;
-		_canvas.VerticalAlignment = contentAsFE.VerticalAlignment;
 
 		double newHostSpreedHeight = maxBlurRadius + absoluteMaxOffsetY + maxSpread;
 		double newHostSpreedWidth = maxBlurRadius + absoluteMaxOffsetX + maxSpread;
 
-		double newHostHeight = contentAsFE.ActualHeight + newHostSpreedHeight * 2;
-		double newHostWidth = contentAsFE.ActualWidth + newHostSpreedWidth * 2;
-
+		double newHostHeight = childHeight + newHostSpreedHeight * 2;
+		double newHostWidth = childWidth + newHostSpreedWidth * 2;
 		_shadowHost.Height = newHostHeight;
 		_shadowHost.Width = newHostWidth;
+		_canvas.Height = childHeight / 2;
+		_canvas.Width = childWidth / 2;
+		_canvas.Margin = contentAsFE.Margin;
+		_canvas.HorizontalAlignment = contentAsFE.HorizontalAlignment;
+		_canvas.VerticalAlignment = contentAsFE.VerticalAlignment;
 
-		double top = 0;
-		double left = 0;
 
-		if (contentAsFE.VerticalAlignment == VerticalAlignment.Center)
-		{
-			_canvas.Margin = contentAsFE.Margin;
-			_canvas.Margin = contentAsFE.Margin;
 
-			if (contentAsFE.Margin == new Thickness(0, 0, 0, 0))
-			{
-				left = -newHostSpreedWidth;
-				top = -newHostSpreedHeight;
-			}
-			else
-			{
-				left =
-					-newHostSpreedWidth
-					- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Left ? 0 : 0)
-					- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Right ? contentAsFE.ActualWidth : 0)
-					- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Stretch ? +contentAsFE.Margin.Left / 2 + contentAsFE.Margin.Right / 2 : 0)
-					- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Center ? contentAsFE.ActualWidth / 2 : 0);
-				top = -newHostSpreedHeight - contentAsFE.ActualHeight / 2;
-			}
+		double left =
+			+(contentAsFE.HorizontalAlignment == HorizontalAlignment.Left ? -newHostSpreedWidth : 0)
+			+ (contentAsFE.HorizontalAlignment == HorizontalAlignment.Right ? -newHostSpreedWidth - childWidth / 2 : 0)
+			+ (contentAsFE.HorizontalAlignment == HorizontalAlignment.Stretch ? -newHostSpreedWidth - childWidth / 4 : 0)
+			+ (contentAsFE.HorizontalAlignment == HorizontalAlignment.Center ? -newHostSpreedWidth - childWidth / 4 : 0);
+		double top =
+			+(contentAsFE.VerticalAlignment == VerticalAlignment.Top ? -newHostSpreedHeight : 0)
+			+ (contentAsFE.VerticalAlignment == VerticalAlignment.Bottom ? -newHostSpreedHeight - childHeight / 2 : 0)
+			+ (contentAsFE.VerticalAlignment == VerticalAlignment.Stretch ? -newHostSpreedHeight - childHeight / 4 : 0)
+			+ (contentAsFE.VerticalAlignment == VerticalAlignment.Center ? -newHostSpreedHeight - childHeight / 4 : 0);
 
-		}
-		else
-		{
-			left =
-				-newHostSpreedWidth
-				- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Left ? -contentAsFE.Margin.Left : 0)
-				- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Right ? contentAsFE.Margin.Right == 0 ? 0 :
-								contentAsFE.ActualWidth + contentAsFE.Margin.Right - _canvas.Margin.Right : 0)
-				- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Stretch ? contentAsFE.Margin.Right : 0)
-				- (contentAsFE.HorizontalAlignment == HorizontalAlignment.Center ? contentAsFE.Margin.Left : 0);
-			top =
-				-newHostSpreedHeight
-				- (contentAsFE.VerticalAlignment == VerticalAlignment.Top ? -contentAsFE.Margin.Top : 0)
-				- (contentAsFE.VerticalAlignment == VerticalAlignment.Bottom ? +contentAsFE.Margin.Bottom + contentAsFE.ActualHeight : 0)
-				- (contentAsFE.VerticalAlignment == VerticalAlignment.Stretch ? contentAsFE.Margin.Bottom : 0)
-				- (contentAsFE.VerticalAlignment == VerticalAlignment.Center ? contentAsFE.Margin.Top : 0);
-		}
 		Canvas.SetLeft(_shadowHost, left);
 		Canvas.SetTop(_shadowHost, top);
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes: #798 

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
ShadowContainer is correctly stretching iwhen the content is changed to be larger but if the content is then shrunk, the ShadowContainer does not resize:

See Shadow Builder control inside of the Toolkit sample app:

![shadowcontainerstretch](https://github.com/unoplatform/uno.toolkit.ui/assets/4793020/bc0b52d2-2dad-4bb1-a1f8-bc8a2f04fd8a)
## What is the new behavior?

Removed some commented code and conditional layout refactoring.

Now the Canvas free up allocated space so content can reduce in size.



https://github.com/unoplatform/uno.toolkit.ui/assets/116665025/723a897e-40e8-43f3-b82d-ceb3cdbb99ec




## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

