### PR TITLE
fix [TabBar] (#719): Fixes wrong selector offset when switching tabs

### DIFF
--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.Android.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.Android.cs
@@ -56,16 +56,8 @@ namespace Uno.Toolkit.UI
 				&& sender is FlipView flipView
 				&& flipView.FindFirstChild<ViewPager>() is { } viewPager)
 			{
-				viewPager.PageScrolled += OnPageScrolled;
-				_scrolledRevoker.Disposable = Disposable.Create(() => viewPager.PageScrolled -= OnPageScrolled);
-
 				_flipViewSizeChangedRevoker.Disposable = null;
 			}
-		}
-
-		private void OnPageScrolled(object? sender, ViewPager.PageScrolledEventArgs e)
-		{
-			UpdateOffset(e.Position, e.PositionOffset, GetOffset(e));
 		}
 
 		private double GetOffset(ViewPager.PageScrolledEventArgs e)

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.Others.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.Others.cs
@@ -66,26 +66,6 @@ namespace Uno.Toolkit.UI
 			}
 
 			Console.WriteLine($"ViewChanged: offset={scrollViewer.HorizontalOffset}");
-
-			// The inner ScrollViewer of a FlipView on UWP uses strange values for HorizontalOffset.
-			// It seems that there is a 1-based index of the FlipViewItems.
-			// So if we are on the first FlipViewItem, the HorizontalOffset of the ScrollViewer will actually be 2,
-			// since the offset is relative to the end of the viewable item
-			// -------------
-			// |   |   |   |
-			// |   |   |   |
-			// -------------
-			// 1   2   3   4    
-			var offset =
-#if WINDOWS || WINDOWS_UWP
-				(scrollViewer.HorizontalOffset - 2) * Selector.ActualWidth;
-#else
-				scrollViewer.HorizontalOffset;
-#endif
-			if (GetProgress(offset) is (int position, double positionOffset))
-			{
-				UpdateOffset(position, positionOffset, offset);
-			}
 		}
 
 		private (int, double)? GetProgress(double offset)

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.cs
@@ -117,7 +117,10 @@ namespace Uno.Toolkit.UI
 			return nextPosPoint.X;
 		}
 
-
+		// TO REVIEW: #719
+		// This no longer seems to serve any purpose, selector offset seems to render correctly without it.
+		// Having this actually causes buggy behavior
+		// ******************************************************************************************************
 		public void UpdateOffset(int position, double progress, double totalOffset)
 		{
 			UIElement? selectionIndicator;
@@ -168,6 +171,7 @@ namespace Uno.Toolkit.UI
 				: indicatorPosition - ((1 - progress) * distance)
 			);
 		}
+		// ******************************************************************************************************
 
 		private void UpdateOffsetToPosition(int position, UIElement selectionIndicator)
 		{

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.iOS.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarSelectorBehaviorState.iOS.cs
@@ -72,15 +72,6 @@ namespace Uno.Toolkit.UI
 			_flipViewSource = flipViewSource;
 		}
 
-		public override void Scrolled(UIScrollView scrollView)
-		{
-			var offset = scrollView.ContentOffset.X;
-
-			if (GetProgress(offset) is (int position, double positionOffset))
-			{
-				_state.UpdateOffset(position, positionOffset, offset);
-			}
-		}
 		public override void DecelerationEnded(UIScrollView scrollView)
 		{
 			_flipViewSource?.DecelerationEnded(scrollView);


### PR DESCRIPTION
GitHub Issue (If applicable): #719 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR-->
- Bugfix

## What is the current behavior?

TabBar selector indicator offset is wrong for slide selection behavior

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

TabBar selector indicator is correctly rendered.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Tested the changes where applicable:
	- [X] UWP
	- [X] WinUI
	- [X] iOS
	- [X] Android
	- [X] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
