### PR TITLE
fix(AutoLayout): check for filledChildrenCount was inverse

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -405,6 +405,50 @@ internal class AutoLayoutTest
 	}
 
 	[TestMethod]
+	public async Task When_Measure()
+	{
+		var SUT = new AutoLayout()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0))
+		};
+
+		var flipView = new FlipView();
+
+		var border0 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 255, 255)),
+			Width = 2000,
+			Height = 2000,
+		};
+
+		var border1 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 40,
+			Height = 40,
+		};
+
+		var border2 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 40,
+			Height = 40,
+		};
+
+		AutoLayout.SetPrimaryAlignment(flipView, AutoLayoutPrimaryAlignment.Stretch);
+
+		flipView.Items.Add(border0);
+		SUT.Children.Add(flipView);
+		SUT.Children.Add(border1);
+		SUT.Children.Add(border2);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var border0Transform = border0.TransformToVisual(SUT).TransformPoint(new Windows.Foundation.Point(0, 0));
+		Assert.AreEqual(0, border0Transform.Y);
+	}
+
+	[TestMethod]
 	[RequiresFullWindow]
 	public async Task When_Fixed_Dimensions_Padding_And_SpaceBetween_Vertical()
 	{

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Measure.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Measure.cs
@@ -283,7 +283,7 @@ partial class AutoLayout
 		{
 			var child = _calculatedChildren![i];
 
-			if (child.Role == AutoLayoutRole.Filled || child.IsVisible)
+			if (child.Role == AutoLayoutRole.Filled && child.IsVisible)
 			{
 				filledChildrenCount++;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): #851

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?

fill children was given the appropriate size information 

## What is the new behavior?

fill children are properly count and assigned size 

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [x] Android
	- [x] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
