### PR TITLE
fix(StatusBar): OS theme change no longer crashes app

### DIFF
--- a/src/Uno.Toolkit.UI/Behaviors/StatusBar.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/StatusBar.cs
@@ -222,17 +222,21 @@ namespace Uno.Toolkit.UI
 		{
 			if (_lastActivePage is { } page)
 			{
+#if !HAS_UNO
 				page.GetDispatcherCompat().Schedule(() => {
+#endif
 					if (GetSubscription(page) != null &&
-					GetForeground(page) is StatusBarForegroundTheme.Auto or StatusBarForegroundTheme.AutoInverse &&
-					GetSystemTheme() is var theme && theme != _lastAppliedTheme)
-					{
-						// this will prevent deadlock, as setting the XamlStatusBar.Foreground will trigger ColorValuesChanged
-						_lastAppliedTheme = theme;
+						GetForeground(page) is StatusBarForegroundTheme.Auto or StatusBarForegroundTheme.AutoInverse &&
+						GetSystemTheme() is var theme && theme != _lastAppliedTheme)
+						{
+							// this will prevent deadlock, as setting the XamlStatusBar.Foreground will trigger ColorValuesChanged
+							_lastAppliedTheme = theme;
 
-						UpdateStatusBar(page);
-					}
+							UpdateStatusBar(page);
+						}
+#if !HAS_UNO
 				});
+#endif
 			}
 		}
 

--- a/src/Uno.Toolkit.UI/Behaviors/StatusBar.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/StatusBar.cs
@@ -222,15 +222,17 @@ namespace Uno.Toolkit.UI
 		{
 			if (_lastActivePage is { } page)
 			{
-				if (GetSubscription(page) != null &&
+				page.GetDispatcherCompat().Schedule(() => {
+					if (GetSubscription(page) != null &&
 					GetForeground(page) is StatusBarForegroundTheme.Auto or StatusBarForegroundTheme.AutoInverse &&
 					GetSystemTheme() is var theme && theme != _lastAppliedTheme)
-				{
-					// this will prevent deadlock, as setting the XamlStatusBar.Foreground will trigger ColorValuesChanged
-					_lastAppliedTheme = theme;
+					{
+						// this will prevent deadlock, as setting the XamlStatusBar.Foreground will trigger ColorValuesChanged
+						_lastAppliedTheme = theme;
 
-					UpdateStatusBar(page);
-				}
+						UpdateStatusBar(page);
+					}
+				});
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #866, closes unoplatform/uno.chefs#666

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On pages using StatusBar, apps using Toolkit.UI crash when changing the Windows OS theme in the OS Settings:
"The application called an interface that was marshalled for a different thread. (0x8001010E (RPC_E_WRONG_THREAD))"

## What is the new behavior?
No crash

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [x] UWP
	- [x] WinUI
	- [ ] iOS
	- [x] Android
	- [x] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.