### PR TITLE
fix: avoid creating disconnected native navbars on load

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarTests.cs
@@ -260,6 +260,32 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			AssertNavigationBar(frame);
 		}
 
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task Can_Navigate_Forward_And_Backwards()
+		{
+			var frame = new Frame() { Width = 400, Height = 400 };
+			var content = new Grid { Children = { frame } };
+			
+			await UnitTestUIContentHelperEx.SetContentAndWait(content);
+
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			var firstNavBar = await frame.NavigateAndGetNavBar<NavBarFirstPage>();
+
+			await UnitTestsUIContentHelper.WaitForLoaded(firstNavBar!);
+
+			var secondNavBar = await frame.NavigateAndGetNavBar<NavBarSecondPage>();
+			
+			await UnitTestsUIContentHelper.WaitForLoaded(secondNavBar!);
+
+			await Task.Delay(1000);
+
+			frame.GoBack();
+
+			await UnitTestsUIContentHelper.WaitForLoaded(firstNavBar!);
+		}
+
 
 #if __ANDROID__
 		private static void AssertNavigationBar(Frame frame)
@@ -534,17 +560,14 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 	{
 #if __IOS__
 		public static UINavigationBar? GetNativeNavBar(this NavigationBar? navBar) => navBar
-			?.TryGetRenderer<NavigationBar, NavigationBarRenderer>()
-			?.Native;
+			?.TryGetNative<NavigationBar, NavigationBarRenderer, UINavigationBar>(out var native) ?? false ? native : null;
 
 		public static UINavigationItem? GetNativeNavItem(this NavigationBar? navBar) => navBar
-			?.TryGetRenderer<NavigationBar, NavigationBarNavigationItemRenderer>()
-			?.Native;
+			?.TryGetNative<NavigationBar, NavigationBarNavigationItemRenderer, UINavigationItem>(out var native) ?? false ? native : null;
 
 #elif __ANDROID__
 		public static AndroidX.AppCompat.Widget.Toolbar? GetNativeNavBar(this NavigationBar? navBar) => navBar
-			?.TryGetRenderer<NavigationBar, NavigationBarRenderer>()
-			?.Native;
+			?.TryGetNative<NavigationBar, NavigationBarRenderer, AndroidX.AppCompat.Widget.Toolbar>(out var native) ?? false ? native : null;
 #endif
 		public static Task<NavigationBar?> NavigateAndGetNavBar<TPage>(this Frame frame) where TPage : Page
 		{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
@@ -50,7 +50,7 @@ namespace Uno.Toolkit.UI
 
 		public NavigationBarNavigationItemRenderer(NavigationBar element) : base(element) { }
 
-		protected override UINavigationItem CreateNativeInstance() => new UINavigationItem();
+		protected override UINavigationItem CreateNativeInstance() => throw new NotSupportedException("The Native instance must be provided.");
 
 		protected override IEnumerable<IDisposable> Initialize()
 		{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarRenderer.iOS.cs
@@ -36,17 +36,7 @@ namespace Uno.Toolkit.UI
 	{
 		public NavigationBarRenderer(NavigationBar element) : base(element) { }
 
-		protected override UINavigationBar CreateNativeInstance()
-		{
-			var navigationBar = new UINavigationBar();
-			if (Element is { } element)
-			{
-				var renderer = element.GetOrAddRenderer(navBar => new NavigationBarNavigationItemRenderer(navBar));
-				navigationBar.PushNavigationItem(renderer.Native, false);
-			}
-
-			return navigationBar;
-		}
+		protected override UINavigationBar CreateNativeInstance() => throw new NotSupportedException("The Native instance must be provided.");
 
 		protected override IEnumerable<IDisposable> Initialize()
 		{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
@@ -91,12 +91,14 @@ namespace Uno.Toolkit.UI
 			}
 		}
 
+		public bool HasNative => _native != null;
+
 		private void OnNativeChanged()
 		{
 			// We remove subscriptions to the previous pair of element and native 
 			_subscriptions.Dispose();
 
-			if (_native != null)
+			if (HasNative)
 			{
 				_subscriptions = new CompositeDisposable(Initialize());
 			}
@@ -109,7 +111,7 @@ namespace Uno.Toolkit.UI
 		public void Invalidate()
 		{
 			// We don't render anything if there's no rendering target
-			if (_native != null
+			if (HasNative
 				// Prevent Render() being called reentrantly - this can happen when the Element's parent changes within the Render() method
 				&& !_isRendering)
 			{
@@ -150,6 +152,25 @@ namespace Uno.Toolkit.UI
 			}
 
 			return renderer;
+		}
+
+		public static bool TryGetNative<TElement, TRenderer, TNative>(this TElement element, out TNative? native)
+			where TElement :
+#if HAS_UNO
+			class,
+#endif
+			DependencyObject
+			where TRenderer : Renderer<TElement, TNative>
+			where TNative : class
+		{
+			native = null;
+			if (TryGetRenderer<TElement, TRenderer>(element) is { } renderer && renderer.HasNative)
+			{
+				native = renderer.Native;
+				return true;
+			}
+
+			return false;
 		}
 
 		public static void SetRenderer<TElement, TRenderer>(this TElement element, TRenderer? renderer)


### PR DESCRIPTION
closes #885 


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

A crash when navigating from and then back to a page with a NavigationBar on it

## What is the new behavior?

No crash