### PR TITLE
Adding missing winui targets for markup packages

### DIFF
--- a/src/library/Uno.Toolkit.WinUI.Markup/Uno.Toolkit.WinUI.Markup.csproj
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Uno.Toolkit.WinUI.Markup.csproj
@@ -8,6 +8,7 @@
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'!=''">$(TargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'==''">net7.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'=='' and '$(DisableNet7MobileTargets)'==''">$(TargetFrameworks);net7.0-ios;net7.0-macos;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'=='' and '$(OS)'=='Windows_NT'">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/library/Uno.Toolkit.WinUI.Material.Markup/Uno.Toolkit.WinUI.Material.Markup.csproj
+++ b/src/library/Uno.Toolkit.WinUI.Material.Markup/Uno.Toolkit.WinUI.Material.Markup.csproj
@@ -8,6 +8,7 @@
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'!=''">$(TargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'==''">net7.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'=='' and '$(DisableNet7MobileTargets)'==''">$(TargetFrameworks);net7.0-ios;net7.0-macos;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TargetFrameworkOverride)'=='' and '$(OS)'=='Windows_NT'">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>


### PR DESCRIPTION
GitHub Issue (If applicable): #

- addresses build failure in unoplatform/uno.templates#371

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Markup packages are missing windows10 target

## What is the new behavior?

Markup packages match the same targets as Uno.Toolkit.WinUI