### PR TITLE
fix: make center with padding behave like figma

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -369,6 +369,54 @@ internal class AutoLayoutTest
 
 	[TestMethod]
 	[RequiresFullWindow]
+	[DataRow(Orientation.Vertical, 80, 140, 125, 125)]
+	[DataRow(Orientation.Horizontal, 110, 110, 70, 180)]
+	public async Task When_Axis_Are_Center_With_No_Homogeneous_Padding(Orientation orientation, double rec1expectedY, double rec2expectedY, double rec1expectedX, double rec2expectedX)
+	{
+		var SUT = new AutoLayout()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)),
+			Padding = new Thickness(150, 20, 100, 50),
+			Spacing = 10, 
+			Width = 300,
+			Height = 300,
+			Orientation = orientation,
+			PrimaryAxisAlignment = AutoLayoutAlignment.Center,
+		};
+
+		var border1 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 100,
+			Height = 50,
+		};
+
+		var border2 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Width = 100,
+			Height = 50,
+		};
+
+		AutoLayout.SetCounterAlignment(border1, AutoLayoutAlignment.Center);
+		AutoLayout.SetCounterAlignment(border2, AutoLayoutAlignment.Center);
+
+		SUT.Children.Add(border1);
+		SUT.Children.Add(border2);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var border1Transform = border1.TransformToVisual(SUT).TransformPoint(new Windows.Foundation.Point(0, 0));
+		var border2Transform = border2.TransformToVisual(SUT).TransformPoint(new Windows.Foundation.Point(0, 0));
+
+		Assert.AreEqual(rec1expectedY, border1Transform!.Y);
+		Assert.AreEqual(rec2expectedY, border2Transform!.Y);
+		Assert.AreEqual(rec1expectedX, border1Transform!.X);
+		Assert.AreEqual(rec2expectedX, border2Transform!.X);
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
 	public async Task When_Fixed_Dimensions_Padding_And_SpaceBetween_Horizontal()
 	{
 		var SUT = new AutoLayout()


### PR DESCRIPTION
GitHub Issue (If applicable): #923

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix
## What is the current behavior?

- Centered child are strickly center independ of the padding 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

- use relative center with padding

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
