### PR TITLE
build: Use compiler from SDK instead of NuGet package to reduce developer friction

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,5 @@
-<Project ToolsVersion="15.0">
+<Project>
 	<PropertyGroup>
 		<NoWarn>$(NoWarn);NU1507</NoWarn>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" PrivateAssets="all" />
-	</ItemGroup>
 </Project>

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -7,7 +7,6 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.7.0-2.final" />
     <!--
 			If, in the same solution, you are referencing a project that uses https://github.com/onovotny/MSBuildSdkExtras,
 			you need to make sure that the version provided here matches https://github.com/novotnyllc/MSBuildSdkExtras/blob/main/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -38,7 +38,6 @@
     <PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.59" />
     <PackageVersion Include="Xamarin.UITest" Version="4.1.4" />
     <PackageVersion Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.7.0-2.final" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0-preview1.22518.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): re: #736, closes #929

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
## What is the new behavior?

## PR Checklist
Please check if your PR fulfills the following requirements:

## Other information
just rehosting pr, due to ci currently not able to sign from foreign repo