### PR TITLE
docs: adjust Divider usage examples

### DIFF
--- a/doc/controls/Divider.md
+++ b/doc/controls/Divider.md
@@ -10,22 +10,6 @@ Property|Type|Description
 SubHeader|String|Gets or sets the text of the text below the Divider.
 SubHeaderForeground|Brush|Gets or sets the foreground of the subheader.
 
-### C#
-```csharp
-public partial class Divider : Control
-```
-
-### XAML
-```xml
-xmlns:utu="using:Uno.Toolkit.UI"
-...
-
-content
-<utu:Divider/>
-content
-
-```
-
 ## Lightweight Styling
 
 Key|Type|Value
@@ -38,3 +22,17 @@ DividerSubHeaderFontSize|FontSize|BodySmallFontSize
 DividerSubHeaderCharacterSpacing|CharacterSpacing|BodySmallCharacterSpacing
 DividerSubHeaderMargin|Thickness|0,4,0,0
 DividerHeight|Double|1
+
+## Usage
+```xml
+xmlns:utu="using:Uno.Toolkit.UI"
+...
+
+<TextBlock Text="Asd" />
+<utu:Divider />
+<TextBlock Text="Asd" />
+<utu:Divider Foreground="Gray"
+			 SubHeader="Separator"
+			 SubHeaderForeground="Black" />
+<TextBlock Text="Asd" />
+```


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Documentation content changes

## What is the current behavior?
## What is the new behavior?
add copy-pastable usage examples for Divider control