### PR TITLE
perf(ResExpr): prevent unnecessary updates

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/ResponsiveView/ResponsiveView.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/ResponsiveView/ResponsiveView.Properties.cs
@@ -100,11 +100,11 @@ public partial class ResponsiveView
 
 	#endregion
 
-	private static void OnNarrowestTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.ResolveTemplate();
-	private static void OnNarrowTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.ResolveTemplate();
-	private static void OnNormalTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.ResolveTemplate();
-	private static void OnWideTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.ResolveTemplate();
-	private static void OnWidestTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.ResolveTemplate();
+	private static void OnNarrowestTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.UpdateTemplate(forceApplyValue: true);
+	private static void OnNarrowTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.UpdateTemplate(forceApplyValue: true);
+	private static void OnNormalTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.UpdateTemplate(forceApplyValue: true);
+	private static void OnWideTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.UpdateTemplate(forceApplyValue: true);
+	private static void OnWidestTemplateChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.UpdateTemplate(forceApplyValue: true);
 
-	private static void OnResponsiveLayoutChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.ResolveTemplate();
+	private static void OnResponsiveLayoutChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => (sender as ResponsiveView)?.UpdateTemplate();
 }

--- a/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
+++ b/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
@@ -260,8 +260,7 @@ namespace Uno.Toolkit.UI
 				#region Toolkit Control Details
 				if (x is ResponsiveView rv)
 				{
-					if (rv.ResolvedLayout is { } resolved) yield return $"Resolved={resolved.Layout}";
-					yield return $"Layout={rv.GetAppliedLayout()}";
+					yield return $"Responsive: {FormatSize(rv.LastResolved.Size)}@{rv.LastResolved.Layout}->{rv.LastResolved.Result}";
 				}
 #if DEBUG
 				if (ResponsiveExtension.TrackedInstances.Where(y => y.Owner.Target == x).ToArray() is { Length: > 0 } instances)
@@ -270,7 +269,7 @@ namespace Uno.Toolkit.UI
 					{
 						if (item.Extension.Target is ResponsiveExtension re)
 						{
-							yield return $"{item.Property}@Responsive: {re.LastUsedLayout}->{re.ResolvedValue?.Layout}\\{re.ResolvedValue?.Value}";
+							yield return $"{item.Property}@Responsive: {FormatSize(re.LastResolved.Size)}@{re.LastResolved.Layout}->{re.LastResolved.Result}\\{re.CurrentValue}";
 						}
 					}
 				}

--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
@@ -9,6 +9,8 @@ using Windows.Foundation;
 using Uno.Extensions;
 using Uno.Logging;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
 
 
 #if IS_WINUI
@@ -89,7 +91,7 @@ public partial class ResponsiveExtension : MarkupExtension, IResponsiveCallback
 			_targetProperty = dp;
 			_propertyType =
 #if HAS_UNO // workaround for uno#14719: uno doesn't inject the proper pvtp.Type
-				target.GetType().GetProperty(pvtp.Name, Public | Instance | FlattenHierarchy)?.PropertyType;
+				typeof(DependencyProperty).GetProperty("Type", Instance | NonPublic)?.GetValue(dp) as Type;
 #else
 				pvtp.Type;
 #endif
@@ -139,7 +141,8 @@ public partial class ResponsiveExtension : MarkupExtension, IResponsiveCallback
 			var resolved = helper.ResolveLayout(GetAppliedLayout(), GetAvailableLayoutOptions());
 			if (forceApplyValue || CurrentLayout != resolved.Result)
 			{
-				var value = resolved.Result;
+				var value = GetValueFor(resolved.Result);
+
 				target.SetValue(_targetProperty, value);
 
 				CurrentValue = value;

--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
@@ -3,11 +3,13 @@
 #endif
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Windows.Foundation;
 using Uno.Extensions;
 using Uno.Logging;
+using System.Diagnostics.CodeAnalysis;
+
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -49,10 +51,10 @@ public partial class ResponsiveExtension : MarkupExtension, IResponsiveCallback
 	private Type? _propertyType;
 	private DependencyProperty? _targetProperty;
 #endif
-	internal ResolvedLayout<object?>? ResolvedValue { get; private set; }
-#if DEBUG
-	internal ResponsiveLayout? LastUsedLayout { get; private set; }
-#endif
+
+	public Layout? CurrentLayout { get; private set; }
+	internal object? CurrentValue { get; private set; }
+	internal (ResponsiveLayout Layout, Size Size, Layout? Result) LastResolved { get; private set; }
 
 	public ResponsiveExtension()
 	{
@@ -62,7 +64,7 @@ public partial class ResponsiveExtension : MarkupExtension, IResponsiveCallback
 	/// <inheritdoc/>
 	protected override object? ProvideValue()
 	{
-		this.Log().WarnIfEnabled(() => "The property value, once initially set, cannot be updated due to UWP limitation. Consider upgrading to WinUI, on which the service provider context is exposed through a ProvideValue overload.");
+		_logger.WarnIfEnabled(() => "The property value, once initially set, cannot be updated due to UWP limitation. Consider upgrading to WinUI, on which the service provider context is exposed through a ProvideValue overload.");
 		return ResolveValue();
 	}
 #else
@@ -74,42 +76,6 @@ public partial class ResponsiveExtension : MarkupExtension, IResponsiveCallback
 		return ResolveValue();
 	}
 #endif
-
-	private object? ResolveValue()
-	{
-		var helper = ResponsiveHelper.GetForCurrentView();
-
-		return ResolveValue(helper.WindowSize, GetAppliedLayout() ?? helper.Layout);
-	}
-
-	private object? ResolveValue(Size size, ResponsiveLayout layout)
-	{
-		var defs = new (double MinWidth, ResolvedLayout<object?> Value)[]
-		{
-			(layout.Narrowest, new(nameof(layout.Narrowest), Narrowest)),
-			(layout.Narrow, new(nameof(layout.Narrow), Narrow)),
-			(layout.Normal, new(nameof(layout.Normal), Normal)),
-			(layout.Wide, new(nameof(layout.Wide), Wide)),
-			(layout.Widest, new(nameof(layout.Widest), Widest)),
-		}.Where(x => x.Value.Value != null).ToArray();
-		var match = defs.FirstOrNull(y => y.MinWidth >= size.Width) ?? defs.LastOrNull();
-		var resolved = match?.Value;
-
-#if DEBUG
-		LastUsedLayout = layout;
-#endif
-		ResolvedValue = resolved;
-
-		var result = resolved?.Value;
-#if SUPPORTS_XAML_SERVICE_PROVIDER
-		if (result != null && _propertyType != null && result.GetType() != _propertyType)
-		{
-			result = XamlCastSafe(result, _propertyType);
-		}
-#endif
-
-		return result;
-	}
 
 #if SUPPORTS_XAML_SERVICE_PROVIDER
 	private void BindToEvents(IXamlServiceProvider serviceProvider)
@@ -154,20 +120,47 @@ public partial class ResponsiveExtension : MarkupExtension, IResponsiveCallback
 			// Along the visual tree, we may have a DefaultResponsiveLayout defined in the resources which could cause a different value to be resolved.
 			// But because in ProvideValue, the target has not been added to the visual tree yet, we cannot access the "full" .resources yet.
 			// So we need to rectify that here.
-			target.SetValue(_targetProperty, ResolveValue());
+			UpdateBindingIfNeeded(forceApplyValue: true);
 		}
 	}
 #endif
 
-	public void OnSizeChanged(Size size, ResponsiveLayout layout)
+	public void OnSizeChanged(ResponsiveHelper helper) => UpdateBindingIfNeeded(helper);
+
+	[SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "platform-specific block...")]
+	private void UpdateBindingIfNeeded(ResponsiveHelper? helper = null, bool forceApplyValue = false)
 	{
 #if SUPPORTS_XAML_SERVICE_PROVIDER
+		helper ??= ResponsiveHelper.GetForCurrentView();
+
 		if (TargetWeakRef?.Target is FrameworkElement target &&
 			_targetProperty is not null)
 		{
-			target.SetValue(_targetProperty, ResolveValue(size, GetAppliedLayout() ?? layout));
+			var resolved = helper.ResolveLayout(GetAppliedLayout(), GetAvailableLayoutOptions());
+			if (forceApplyValue || CurrentLayout != resolved.Result)
+			{
+				var value = resolved.Result;
+				target.SetValue(_targetProperty, value);
+
+				CurrentValue = value;
+				CurrentLayout = resolved.Result;
+				LastResolved = resolved;
+			}
 		}
 #endif
+	}
+
+	private object? ResolveValue()
+	{
+		var helper = ResponsiveHelper.GetForCurrentView();
+		var resolved = helper.ResolveLayout(GetAppliedLayout(), GetAvailableLayoutOptions());
+		var value = GetValueFor(resolved.Result);
+		
+		CurrentValue = value;
+		CurrentLayout = resolved.Result;
+		LastResolved = resolved;
+
+		return value;
 	}
 
 	private static object? XamlCastSafe(object value, Type type)
@@ -185,6 +178,36 @@ public partial class ResponsiveExtension : MarkupExtension, IResponsiveCallback
 
 			return value;
 		}
+	}
+
+	private object? GetValueFor(Layout? layout)
+	{
+		var value =  layout switch
+		{
+			UI.Layout.Narrowest => Narrowest,
+			UI.Layout.Narrow => Narrow,
+			UI.Layout.Normal => Normal,
+			UI.Layout.Wide => Wide,
+			UI.Layout.Widest => Widest,
+			_ => null,
+		};
+#if SUPPORTS_XAML_SERVICE_PROVIDER
+		if (value != null && _propertyType != null && value.GetType() != _propertyType)
+		{
+			value = XamlCastSafe(value, _propertyType);
+		}
+#endif
+
+		return value;
+	}
+
+	private IEnumerable<Layout> GetAvailableLayoutOptions()
+	{
+		if (Narrowest != null) yield return UI.Layout.Narrowest;
+		if (Narrow != null) yield return UI.Layout.Narrow;
+		if (Normal != null) yield return UI.Layout.Normal;
+		if (Wide != null) yield return UI.Layout.Wide;
+		if (Widest != null) yield return UI.Layout.Widest;
 	}
 
 	internal ResponsiveLayout? GetAppliedLayout() =>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #951

## PR Type
What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
ResponsiveExpression performs value conversion and binding update on at every size changed proc.

## What is the new behavior?
- ^ it will only do so when significant layout change (eg: going from Normal->Wide) has occurred since last update.
- improved TreeGraph output details for ResponsiveView & ResponsiveExpression
- refactored ResponsiveView's & ResponsiveExpression's shared logics into ResponsiveHelper

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:(https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->