### PR TITLE
fix(responsive): layout breakpoint calculation

### DIFF
--- a/doc/controls/ResponsiveView.md
+++ b/doc/controls/ResponsiveView.md
@@ -26,9 +26,6 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
 }
 ```
 
-## Inheritance
-Object &#8594; DependencyObject &#8594; UIElement &#8594; FrameworkElement &#8594; Control &#8594; ContentControl
-
 ## Properties
 | Property          | Type             | Description                                             |
 | ----------------- | ---------------- | ------------------------------------------------------- |
@@ -42,7 +39,7 @@ Object &#8594; DependencyObject &#8594; UIElement &#8594; FrameworkElement &#859
 ### ResponsiveLayout
 Provides the ability to override the breakpoint for each screen size: `Narrowest`, `Narrow`, `Normal`, `Wide`, and `Widest`.
 
-### Properties
+#### Properties
 | Property   | Type   | Description            |
 | ---------- | ------ | ---------------------- |
 | Narrowest  | double | Default value is 150.  |
@@ -50,6 +47,49 @@ Provides the ability to override the breakpoint for each screen size: `Narrowest
 | Normal     | double | Default value is 600.  |
 | Wide       | double | Default value is 800.  |
 | Widest     | double | Default value is 1080. |
+
+#### Resolution Logics
+The layouts whose value(ResponsiveExtension) or template(ResponsiveView) is not provided are first discarded. From the remaining layouts, we look for the first layout whose breakpoint at met by the current screen width. If none are found, the first layout is return regardless of its breakpoint.
+
+Below are the selected layout at different screen width if all layouts are provided:
+
+Width|Layout
+-|-
+149|Narrowest
+150(Narrowest)|Narrowest
+151|Narrowest
+299|Narrowest
+300(Narrow)|Narrow
+301|Narrow
+599|Narrow
+600(Normal)|Normal
+601|Normal
+799|Normal
+800(Wide)|Wide
+801|Wide
+1079|Wide
+1080(Widest)|Widest
+1081|Widest
+
+Here are the selected layout at different screen width if only `Narrow` and `Wide` are provided:
+
+Width|Layout
+-|-
+149|Narrow
+150(~~Narrowest~~)|Narrow
+151|Narrow
+299|Narrow
+300(Narrow)|Narrow
+301|Narrow
+599|Narrow
+600(~~Normal~~)|Narrow
+601|Narrow
+799|Narrow
+800(Wide)|Wide
+801|Wide
+1079|Wide
+1080(~~Widest~~)|Wide
+1081|Wide
 
 ## Usage
 

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveHelperTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveHelperTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.UI;
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+[TestClass]
+public class ResponsiveHelperTests
+{
+	private readonly static ResponsiveLayout DefaultLayout = ResponsiveLayout.Create(150, 300, 600, 800, 1080);
+
+	// note: not to scale; '[' = inclusive to the right
+	//       0        150         300      600      800     1080     ...
+	// Narrowest(also) - Narrowest [ Narrow [ Normal [ Wide  [ Widest - // full layout
+	// Normal          -           - 
+
+	[TestMethod]
+	public void When_Resolving_AllLayout()
+	{
+		var layout = DefaultLayout;
+		var options = Enum.GetValues<Layout>();
+
+		Assert.AreEqual(Layout.Narrowest, ResponsiveHelper.ResolveLayoutCore(layout, 149, options), "149");
+		Assert.AreEqual(Layout.Narrowest, ResponsiveHelper.ResolveLayoutCore(layout, 150, options), "150"); // breakpoint=Narrowest
+		Assert.AreEqual(Layout.Narrowest, ResponsiveHelper.ResolveLayoutCore(layout, 151, options), "151");
+		Assert.AreEqual(Layout.Narrowest, ResponsiveHelper.ResolveLayoutCore(layout, 299, options), "299");
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 300, options), "300"); // breakpoint=Narrow
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 301, options), "301");
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 599, options), "599");
+		Assert.AreEqual(Layout.Normal, ResponsiveHelper.ResolveLayoutCore(layout, 600, options), "600"); // breakpoint=Normal
+		Assert.AreEqual(Layout.Normal, ResponsiveHelper.ResolveLayoutCore(layout, 601, options), "601");
+		Assert.AreEqual(Layout.Normal, ResponsiveHelper.ResolveLayoutCore(layout, 799, options), "799");
+		Assert.AreEqual(Layout.Wide, ResponsiveHelper.ResolveLayoutCore(layout, 800, options), "800"); // breakpoint=Wide
+		Assert.AreEqual(Layout.Wide, ResponsiveHelper.ResolveLayoutCore(layout, 801, options), "801");
+		Assert.AreEqual(Layout.Wide, ResponsiveHelper.ResolveLayoutCore(layout, 1079, options), "1079");
+		Assert.AreEqual(Layout.Widest, ResponsiveHelper.ResolveLayoutCore(layout, 1080, options), "1080"); // breakpoint=Widest
+		Assert.AreEqual(Layout.Widest, ResponsiveHelper.ResolveLayoutCore(layout, 1081, options), "1081");
+	}
+
+	[TestMethod]
+	public void When_Resolving_PartialLayout()
+	{
+		var layout = DefaultLayout;
+		var options = new[] { Layout.Narrow, Layout.Wide, Layout.Widest };
+
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 149, options), "149");
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 150, options), "150"); // breakpoint=Narrowest (unavailable)
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 151, options), "151");
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 299, options), "299");
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 300, options), "300"); // breakpoint=Narrow
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 301, options), "301");
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 599, options), "599");
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 600, options), "600"); // breakpoint=Normal (unavailable)
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 601, options), "601");
+		Assert.AreEqual(Layout.Narrow, ResponsiveHelper.ResolveLayoutCore(layout, 799, options), "799");
+		Assert.AreEqual(Layout.Wide, ResponsiveHelper.ResolveLayoutCore(layout, 800, options), "800"); // breakpoint=Wide
+		Assert.AreEqual(Layout.Wide, ResponsiveHelper.ResolveLayoutCore(layout, 801, options), "801");
+		Assert.AreEqual(Layout.Wide, ResponsiveHelper.ResolveLayoutCore(layout, 1079, options), "1079");
+		Assert.AreEqual(Layout.Widest, ResponsiveHelper.ResolveLayoutCore(layout, 1080, options), "1080"); // breakpoint=Widest
+		Assert.AreEqual(Layout.Widest, ResponsiveHelper.ResolveLayoutCore(layout, 1081, options), "1081");
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveViewTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveViewTests.cs
@@ -54,7 +54,7 @@ internal class ResponsiveViewTests
 	{
 		using (ResponsiveHelper.UsingDebuggableInstance())
 		{
-			ResponsiveHelper.SetDebugSize(new Size(599, 400));
+			ResponsiveHelper.SetDebugSize(new Size(600, 400));
 
 			var host = XamlHelper.LoadXaml<ResponsiveView>("""
 				<utu:ResponsiveView>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #965

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
given only {normal, wide, widest} are provided:
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/2359550/65e3813b-c35a-4c35-a815-0795722b6d0c)

## What is the new behavior?
![image](https://github.com/unoplatform/uno.toolkit.ui/assets/2359550/24f87c64-44bd-40ce-9e7b-89eaa53fb891)

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [x] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [x] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.