### PR TITLE
refactor(responsive): remove ResponsiveHelper initialization

### DIFF
--- a/doc/controls/ResponsiveView.md
+++ b/doc/controls/ResponsiveView.md
@@ -9,24 +9,6 @@ The `ResponsiveView` provides the ability to display different content based on 
 
 The `ResponsiveView` control adapts to different screen sizes by dynamically choosing the right template. It looks at the current screen width and the defined templates. Since not all templates need a value, the control ensures a smooth user experience by picking the smallest defined template that satisfies the width requirements. If no match is found, it defaults to the largest defined template.
 
-**Initialization**: The `ResponsiveHelper` needs to be hooked up to the window's `SizeChanged` event in order for this control to receive updates when the window size changes.
-This is typically done in the `OnLaunched` method in the `App` class, where you can get the current `Window` instance for `ResponsiveHelper.HookupEvent`:
-
-```cs
-protected override void OnLaunched(LaunchActivatedEventArgs args)
-{
-#if NET6_0_OR_GREATER && WINDOWS && !HAS_UNO
-    MainWindow = new Window();
-#else
-    MainWindow = Microsoft.UI.Xaml.Window.Current;
-#endif
-
-    // ...
-    var helper = Uno.Toolkit.UI.ResponsiveHelper.GetForCurrentView();
-    helper.HookupEvent(MainWindow);
-}
-```
-
 ## Properties
 
 | Property          | Type             | Description                                             |
@@ -147,9 +129,9 @@ xmlns:utu="using:Uno.Toolkit.UI"
 ```
 
 > [!NOTE]
-> This `ResponsiveLayout` can also be provided from different locations. In order of precedences, they are:
+> The `ResponsiveLayout` can also be provided from different locations. In order of precedences, they are:
 >
 > - from the `.ResponsiveLayout` property
 > - in `ResponsiveView`'s parent `.Resources` with `x:Key="DefaultResponsiveLayout"`, or its ancestor's...
 > - in `Application.Resources` with `x:Key="DefaultResponsiveLayout"`
-> - from the hardcoded `ResponsiveHelper.Layout`
+> - from the hardcoded `ResponsiveHelper.DefaultLayout` which is defined as [150/300/600/800/1080]

--- a/doc/helpers/responsive-extension.md
+++ b/doc/helpers/responsive-extension.md
@@ -7,29 +7,9 @@ uid: Toolkit.Helpers.ResponsiveExtension
 The `ResponsiveExtension` class is a markup extension that enables the customization of `UIElement` properties based on screen size.
 This functionality provides a dynamic and responsive user interface experience.
 
-## Remarks
-
-**Initialization**: The `ResponsiveHelper` needs to be hooked up to the window's `SizeChanged` event in order for this markup to receive updates when the window size changes.
-This is typically done in the `OnLaunched` method in the `App` class, where you can get the current `Window` instance for `ResponsiveHelper.HookupEvent`:
-
-```cs
-protected override void OnLaunched(LaunchActivatedEventArgs args)
-{
-#if NET6_0_OR_GREATER && WINDOWS && !HAS_UNO
-    MainWindow = new Window();
-#else
-    MainWindow = Microsoft.UI.Xaml.Window.Current;
-#endif
-
-    // ...
-    var helper = Uno.Toolkit.UI.ResponsiveHelper.GetForCurrentView();
-    helper.HookupEvent(MainWindow);
-}
-```
-
 ## Platform limitation (UWP-desktop)
 
-`ResponsiveExtension` relies on `MarkupExtension.ProvideValue(IXamlServiceProvider)` to find the target control and property for continuous value updates, and to obtain the property type to apply automatic type conversion, as its value properties are parsed as string by the XAML engine. Since this overload is a recent addition exclusive to WinUI, UWP projects targeting Windows won't have access to these features. Uno UWP projects targeting non-Windows platforms do not face this limitation. However, the Windows app may crash or present unexpected behavior if you attempt to use this markup on a non-string property.
+`ResponsiveExtension` relies on `MarkupExtension.ProvideValue(IXamlServiceProvider)` to find the target control and property for continuous value updates, and to obtain the property type to apply automatic type conversion, as its value properties are parsed as `string` by the XAML engine. Since this overload is a recent addition exclusive to WinUI, UWP projects targeting Windows won't have access to these features. Uno UWP projects targeting non-Windows platforms do not face this limitation. However, the Windows app may crash or present unexpected behavior if you attempt to use this markup on a non-`string` property.
 
 ```xml
 <Border Background="{utu:Responsive Narrow=Red, Wide=Blue}"
@@ -137,7 +117,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 ...
 
 <Page.Resources>
-    <utu:ResponsiveLayout x:Key="CustomLayout" 
+    <utu:ResponsiveLayout x:Key="CustomLayout"
                           Narrow="400"
                           Wide="800" />
 </Page.Resources>
@@ -147,9 +127,9 @@ xmlns:utu="using:Uno.Toolkit.UI"
 ```
 
 > [!NOTE]
-> This `ResponsiveLayout` can also be provided from different locations. In the order of precedences, they are:
+> The `ResponsiveLayout` can also be provided from different locations. In the order of precedences, they are:
 >
 > - from the `Layout` property
 > - in the property owner's parent `.Resources` with `x:Key="DefaultResponsiveLayout"`, or the property owner's parent's parent's...
 > - in `Application.Resources` with `x:Key="DefaultResponsiveLayout"`
-> - from the hardcoded `ResponsiveHelper.Layout`
+> - from the hardcoded `ResponsiveHelper.DefaultLayout` which is defined as [150/300/600/800/1080]

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/App.xaml.cs
@@ -98,8 +98,6 @@ namespace Uno.Toolkit.Samples
 #else
 			_window = XamlWindow.Current;
 #endif
-			var helper = ResponsiveHelper.GetForCurrentView();
-			helper.HookupEvent(_window);
 
 			if (_window.Content is null)
 			{

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveExtensionsTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveExtensionsTests.cs
@@ -1,192 +1,160 @@
-﻿// Disabled until fix is implemented for https://github.com/unoplatform/uno/issues/14620
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using Uno.UI.RuntimeTests;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
 
-//using System.Threading.Tasks;
-//using Microsoft.VisualStudio.TestTools.UnitTesting;
-//using Uno.UI.RuntimeTests;
-//using Uno.Toolkit.RuntimeTests.Helpers;
-//using Uno.Toolkit.UI;
-//using Windows.Foundation;
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Media;
+#else
+using Windows.UI.Xaml.Controls;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+#endif
 
-//#if IS_WINUI
-//using Microsoft.UI.Xaml.Controls;
-//using Microsoft.UI;
-//using Microsoft.UI.Xaml.Media;
-//#else
-//using Windows.UI.Xaml.Controls;
-//using Windows.UI;
-//using Windows.UI.Xaml.Media;
-//#endif
+namespace Uno.Toolkit.RuntimeTests.Tests;
 
-//namespace Uno.Toolkit.RuntimeTests.Tests;
+[TestClass]
+#if HAS_UNO
+[Ignore("blocked by #14620: dynamically loaded MarkupExtension are not initialized.")] // https://github.com/unoplatform/uno/issues/14620
+#elif IS_UWP
+[Ignore("ResponsiveExtension is not supported on UWP.")]
+#endif
+[RunsOnUIThread]
+internal class ResponsiveExtensionsTests
+{
+	private static readonly Size NarrowSize = new Size(300, 400);
+	private static readonly Size WideSize = new Size(800, 400);
 
-//[TestClass]
-//[RunsOnUIThread]
-//internal class ResponsiveExtensionsTests
-//{
-//	private static readonly Size NarrowSize = new Size(300, 400);
-//	private static readonly Size WideSize = new Size(800, 400);
+	[TestMethod]
+	public async Task ProvideValue_String_Value()
+	{
+		var sut = XamlHelper.LoadXaml<TextBlock>("""
+			<TextBlock Text="{utu:Responsive Narrow=asd, Wide=qwe}" />
+		""");
+		var ext = ResponsiveExtension.GetInstanceFor(sut, nameof(sut.Text)) ?? throw new InvalidOperationException("Failed to resolve the markup extension.");
+		await UnitTestUIContentHelperEx.SetContentAndWait(sut);
 
-//	[TestMethod]
-//	public async Task ProvideValue_String_InitialValue()
-//	{
-//		using (ResponsiveHelper.UsingDebuggableInstance())
-//		{
-//			ResponsiveHelper.SetDebugSize(NarrowSize);
+		ext.ForceResponsiveSize(NarrowSize);
+		Assert.AreEqual("asd", sut.Text);
+	}
 
-//			var host = XamlHelper.LoadXaml<TextBlock>("""
-//				<TextBlock Text="{utu:Responsive Narrow=asd, Wide=qwe}" />
-//			""");
+	[TestMethod]
+	public async Task ProvideValue_String_SizeChange()
+	{
+		var sut = XamlHelper.LoadXaml<TextBlock>("""
+			<TextBlock Text="{utu:Responsive Narrow=asd, Wide=qwe}" />
+		""");
+		var ext = ResponsiveExtension.GetInstanceFor(sut, nameof(sut.Text)) ?? throw new InvalidOperationException("Failed to resolve the markup extension.");
+		await UnitTestUIContentHelperEx.SetContentAndWait(sut);
 
-//			await UnitTestUIContentHelperEx.SetContentAndWait(host);
+		ext.ForceResponsiveSize(NarrowSize);
+		Assert.AreEqual("asd", sut.Text);
 
-//			Assert.AreEqual("asd", host.Text);
-//		}
-//	}
+		ext.ForceResponsiveSize(WideSize);
+		Assert.AreEqual("qwe", sut.Text);
+	}
 
-//#if !IS_UWP || HAS_UNO
-//	[TestMethod]
-//	public async Task ProvideValue_String_SizeChange()
-//	{
-//		using (ResponsiveHelper.UsingDebuggableInstance())
-//		{
-//			ResponsiveHelper.SetDebugSize(NarrowSize);
+	[TestMethod]
+	public async Task ProvideValue_Color_Value()
+	{
+		var sut = XamlHelper.LoadXaml<Border>("""
+			<Border Width="30"
+					Height="30">
+				<Border.Resources>
+					<SolidColorBrush x:Key="BorderRed">Red</SolidColorBrush>
+					<SolidColorBrush x:Key="BorderBlue">Blue</SolidColorBrush>
+				</Border.Resources>
+				<Border.Background>
+					<utu:Responsive Narrow="{StaticResource BorderRed}" Wide="{StaticResource BorderBlue}" />
+				</Border.Background>
+			</Border>
+		""");
+		var ext = ResponsiveExtension.GetInstanceFor(sut, nameof(sut.Background)) ?? throw new InvalidOperationException("Failed to resolve the markup extension.");
+		await UnitTestUIContentHelperEx.SetContentAndWait(sut);
 
-//			var host = XamlHelper.LoadXaml<TextBlock>("""
-//				<TextBlock Text="{utu:Responsive Narrow=asd, Wide=qwe}" />
-//			""");
+		ext.ForceResponsiveSize(NarrowSize);
+		Assert.AreEqual(Colors.Red, ((SolidColorBrush)sut.Background).Color);
+	}
 
-//			await UnitTestUIContentHelperEx.SetContentAndWait(host);
+	[TestMethod]
+	public async Task ProvideValue_Color_SizeChange()
+	{
+		var sut = XamlHelper.LoadXaml<Border>("""
+			<Border Width="30"
+					Height="30">
+				<Border.Resources>
+					<SolidColorBrush x:Key="BorderRed">Red</SolidColorBrush>
+					<SolidColorBrush x:Key="BorderBlue">Blue</SolidColorBrush>
+				</Border.Resources>
+				<Border.Background>
+					<utu:Responsive Narrow="{StaticResource BorderRed}" Wide="{StaticResource BorderBlue}" />
+				</Border.Background>
+			</Border>
+		""");
+		var ext = ResponsiveExtension.GetInstanceFor(sut, nameof(sut.Background)) ?? throw new InvalidOperationException("Failed to resolve the markup extension.");
+		await UnitTestUIContentHelperEx.SetContentAndWait(sut);
 
-//			Assert.AreEqual("asd", host.Text);
+		ext.ForceResponsiveSize(NarrowSize);
+		Assert.AreEqual(Colors.Red, ((SolidColorBrush)sut.Background).Color);
 
-//			ResponsiveHelper.SetDebugSize(WideSize);
+		ext.ForceResponsiveSize(WideSize);
+		Assert.AreEqual(Colors.Blue, ((SolidColorBrush)sut.Background).Color);
+	}
 
-//			Assert.AreEqual("qwe", host.Text);
-//		}
-//	}
-//#endif
+	[TestMethod]
+	public async Task ProvideValue_Orientation_Value()
+	{
+		var container = XamlHelper.LoadXaml<Border>("""
+			<Border>
+				<Border.Resources>
+					<Orientation x:Key="NarrowOrientation">Vertical</Orientation>
+					<Orientation x:Key="WideOrientation">Horizontal</Orientation>
+				</Border.Resources>
+				<StackPanel Orientation="{utu:Responsive Narrow={StaticResource NarrowOrientation}, Wide={StaticResource WideOrientation}}">
+					<TextBlock Text="A" />
+					<TextBlock Text="B" />
+					<TextBlock Text="C" />
+				</StackPanel>
+			</Border>
+		""");
+		var sut = container.Child as StackPanel ?? throw new InvalidOperationException("Failed to resolve the SUT");
+		var ext = ResponsiveExtension.GetInstanceFor(sut, nameof(sut.Orientation)) ?? throw new InvalidOperationException("Failed to resolve the markup extension.");
+		await UnitTestUIContentHelperEx.SetContentAndWait(container);
 
-//	[TestMethod]
-//	public async Task ProvideValue_Color_InitialValue()
-//	{
-//		using (ResponsiveHelper.UsingDebuggableInstance())
-//		{
-//			ResponsiveHelper.SetDebugSize(NarrowSize);
+		ext.ForceResponsiveSize(NarrowSize);
+		Assert.AreEqual(Orientation.Vertical, (container.Child as StackPanel)?.Orientation);
+	}
 
-//			var border = XamlHelper.LoadXaml<Border>("""
-//				<Border Width="30"
-//						Height="30">
-//					<Border.Resources>
-//						<SolidColorBrush x:Key="BorderRed">Red</SolidColorBrush>
-//						<SolidColorBrush x:Key="BorderBlue">Blue</SolidColorBrush>
-//					</Border.Resources>
-//					<Border.Background>
-//						<utu:Responsive Narrow="{StaticResource BorderRed}" Wide="{StaticResource BorderBlue}" />
-//					</Border.Background>
-//				</Border>
-//			""");
+	[TestMethod]
+	public async Task ProvideValue_Orientation_SizeChange()
+	{
+		var container = XamlHelper.LoadXaml<Border>("""
+			<Border>
+				<Border.Resources>
+					<Orientation x:Key="NarrowOrientation">Vertical</Orientation>
+					<Orientation x:Key="WideOrientation">Horizontal</Orientation>
+				</Border.Resources>
+				<StackPanel Orientation="{utu:Responsive Narrow={StaticResource NarrowOrientation}, Wide={StaticResource WideOrientation}}">
+					<TextBlock Text="A" />
+					<TextBlock Text="B" />
+					<TextBlock Text="C" />
+				</StackPanel>
+			</Border>
+		""");
+		var sut = container.Child as StackPanel ?? throw new InvalidOperationException("Failed to resolve the SUT");
+		var ext = ResponsiveExtension.GetInstanceFor(sut, nameof(sut.Orientation)) ?? throw new InvalidOperationException("Failed to resolve the markup extension.");
+		await UnitTestUIContentHelperEx.SetContentAndWait(container);
 
-//			await UnitTestUIContentHelperEx.SetContentAndWait(border);
+		ext.ForceResponsiveSize(NarrowSize);
+		Assert.AreEqual(Orientation.Vertical, sut.Orientation);
 
-//			Assert.AreEqual(Colors.Red, ((SolidColorBrush)border.Background).Color);
-//		}
-//	}
-
-//#if !IS_UWP || HAS_UNO
-//	[TestMethod]
-//	public async Task ProvideValue_Color_SizeChange()
-//	{
-//		using (ResponsiveHelper.UsingDebuggableInstance())
-//		{
-//			ResponsiveHelper.SetDebugSize(NarrowSize);
-
-//			var border = XamlHelper.LoadXaml<Border>("""
-//				<Border Width="30"
-//						Height="30">
-//					<Border.Resources>
-//						<SolidColorBrush x:Key="BorderRed">Red</SolidColorBrush>
-//						<SolidColorBrush x:Key="BorderBlue">Blue</SolidColorBrush>
-//					</Border.Resources>
-//					<Border.Background>
-//						<utu:Responsive Narrow="{StaticResource BorderRed}" Wide="{StaticResource BorderBlue}" />
-//					</Border.Background>
-//				</Border>
-//			""");
-
-//			await UnitTestUIContentHelperEx.SetContentAndWait(border);
-
-//			Assert.AreEqual(Colors.Red, ((SolidColorBrush)border.Background).Color);
-
-//			ResponsiveHelper.SetDebugSize(WideSize);
-
-//			Assert.AreEqual(Colors.Blue, ((SolidColorBrush)border.Background).Color);
-
-//		}
-//	}
-//#endif
-
-//	[TestMethod]
-//	public async Task ProvideValue_Orientation_InitialValue()
-//	{
-//		using (ResponsiveHelper.UsingDebuggableInstance())
-//		{
-//			ResponsiveHelper.SetDebugSize(NarrowSize);
-
-//			var host = XamlHelper.LoadXaml<StackPanel>("""
-//				<StackPanel>
-//					<StackPanel.Resources>
-//						<Orientation x:Key="NarrowOrientation">Vertical</Orientation>
-//						<Orientation x:Key="WideOrientation">Horizontal</Orientation>
-//					</StackPanel.Resources>
-//					<StackPanel x:Name="MyStackPanel" Orientation="{utu:Responsive Narrow={StaticResource NarrowOrientation}, Wide={StaticResource WideOrientation}}">
-//						<TextBlock Text="A" />
-//						<TextBlock Text="B" />
-//						<TextBlock Text="C" />
-//					</StackPanel>
-//				</StackPanel>
-//			""");
-
-//			var stackPanel = (StackPanel)host.FindName("MyStackPanel");
-
-//			await UnitTestUIContentHelperEx.SetContentAndWait(host);
-
-//			Assert.AreEqual(Orientation.Vertical, stackPanel.Orientation);
-//		}
-//	}
-
-//#if !IS_UWP || HAS_UNO
-//	[TestMethod]
-//	public async Task ProvideValue_Orientation_SizeChange()
-//	{
-//		using (ResponsiveHelper.UsingDebuggableInstance())
-//		{
-//			ResponsiveHelper.SetDebugSize(NarrowSize);
-
-//			var host = XamlHelper.LoadXaml<StackPanel>("""
-//				<StackPanel>
-//					<StackPanel.Resources>
-//						<Orientation x:Key="NarrowOrientation">Vertical</Orientation>
-//						<Orientation x:Key="WideOrientation">Horizontal</Orientation>
-//					</StackPanel.Resources>
-//					<StackPanel x:Name="MyStackPanel" Orientation="{utu:Responsive Narrow={StaticResource NarrowOrientation}, Wide={StaticResource WideOrientation}}">
-//						<TextBlock Text="A" />
-//						<TextBlock Text="B" />
-//						<TextBlock Text="C" />
-//					</StackPanel>
-//				</StackPanel>
-//			""");
-
-//			var stackPanel = (StackPanel)host.FindName("MyStackPanel");
-
-//			await UnitTestUIContentHelperEx.SetContentAndWait(host);
-
-//			Assert.AreEqual(Orientation.Vertical, stackPanel.Orientation);
-
-//			ResponsiveHelper.SetDebugSize(WideSize);
-
-//			Assert.AreEqual(Orientation.Horizontal, stackPanel.Orientation);
-//		}
-//	}
-//#endif
-
-//}
+		ext.ForceResponsiveSize(WideSize);
+		Assert.AreEqual(Orientation.Horizontal, sut.Orientation);
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveHelperTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveHelperTests.cs
@@ -22,7 +22,7 @@ public class ResponsiveHelperTests
 	public void When_Resolving_AllLayout()
 	{
 		var layout = DefaultLayout;
-		var options = Enum.GetValues<Layout>();
+		var options = new[] { Layout.Narrowest, Layout.Narrow, Layout.Normal, Layout.Wide, Layout.Widest };
 
 		Assert.AreEqual(Layout.Narrowest, ResponsiveHelper.ResolveLayoutCore(layout, 149, options), "149");
 		Assert.AreEqual(Layout.Narrowest, ResponsiveHelper.ResolveLayoutCore(layout, 150, options), "150"); // breakpoint=Narrowest

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveViewTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveViewTests.cs
@@ -22,183 +22,162 @@ internal class ResponsiveViewTests
 	[TestMethod]
 	public async Task ResponsiveView_NarrowContent_TextBlock()
 	{
-		using (ResponsiveHelper.UsingDebuggableInstance())
-		{
-			ResponsiveHelper.SetDebugSize(new Size(300, 400));
+		var host = XamlHelper.LoadXaml<ResponsiveView>("""
+			<utu:ResponsiveView>
+				<utu:ResponsiveView.NarrowTemplate>
+					<DataTemplate>
+						<TextBlock Text="Narrow" />
+					</DataTemplate>
+				</utu:ResponsiveView.NarrowTemplate>
+				<utu:ResponsiveView.WideTemplate>
+					<DataTemplate>
+						<TextBlock Text="Wide" />
+					</DataTemplate>
+				</utu:ResponsiveView.WideTemplate>
+			</utu:ResponsiveView>
+		""");
+		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
-			var host = XamlHelper.LoadXaml<ResponsiveView>("""
-				<utu:ResponsiveView>
-					<utu:ResponsiveView.NarrowTemplate>
-						<DataTemplate>
-							<TextBlock Text="Narrow" />
-						</DataTemplate>
-					</utu:ResponsiveView.NarrowTemplate>
-					<utu:ResponsiveView.WideTemplate>
-						<DataTemplate>
-							<TextBlock Text="Wide" />
-						</DataTemplate>
-					</utu:ResponsiveView.WideTemplate>
-				</utu:ResponsiveView>
-			""");
-
-			await UnitTestUIContentHelperEx.SetContentAndWait(host);
-
-			var element = (TextBlock)host.Content;
-
-			Assert.AreEqual("Narrow", element.Text);
-		}
+		host.ForceResponsiveSize(new Size(300, 400));
+		Assert.AreEqual("Narrow", (host.Content as TextBlock)?.Text);
 	}
 
 	[TestMethod]
 	public async Task ResponsiveView_NormalContent_Rectangle()
 	{
-		using (ResponsiveHelper.UsingDebuggableInstance())
-		{
-			ResponsiveHelper.SetDebugSize(new Size(600, 400));
+		var host = XamlHelper.LoadXaml<ResponsiveView>("""
+			<utu:ResponsiveView>
+				<utu:ResponsiveView.NarrowTemplate>
+					<DataTemplate>
+						<TextBlock Text="Narrow" />
+					</DataTemplate>
+				</utu:ResponsiveView.NarrowTemplate>
+				<utu:ResponsiveView.NormalTemplate>
+					<DataTemplate>
+						<Rectangle Width="400" Height="400" />
+					</DataTemplate>
+				</utu:ResponsiveView.NormalTemplate>
+				<utu:ResponsiveView.WideTemplate>
+					<DataTemplate>
+						<TextBlock Text="Wide" />
+					</DataTemplate>
+				</utu:ResponsiveView.WideTemplate>
+			</utu:ResponsiveView>
+		""");
+		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
-			var host = XamlHelper.LoadXaml<ResponsiveView>("""
-				<utu:ResponsiveView>
-					<utu:ResponsiveView.NarrowTemplate>
-						<DataTemplate>
-							<TextBlock Text="Narrow" />
-						</DataTemplate>
-					</utu:ResponsiveView.NarrowTemplate>
-					<utu:ResponsiveView.NormalTemplate>
-						<DataTemplate>
-							<Rectangle Width="400" Height="400" />
-						</DataTemplate>
-					</utu:ResponsiveView.NormalTemplate>
-					<utu:ResponsiveView.WideTemplate>
-						<DataTemplate>
-							<TextBlock Text="Wide" />
-						</DataTemplate>
-					</utu:ResponsiveView.WideTemplate>
-				</utu:ResponsiveView>
-			""");
-
-			await UnitTestUIContentHelperEx.SetContentAndWait(host);
-
-			Assert.AreEqual(typeof(Rectangle), host.Content.GetType());
-		}
+		host.ForceResponsiveSize(new Size(600, 400));
+		Assert.AreEqual(typeof(Rectangle), host.Content?.GetType());
 	}
 
 	[TestMethod]
 	public async Task ResponsiveView_NormalContent_ResponsiveLayout()
 	{
-		using (ResponsiveHelper.UsingDebuggableInstance())
-		{
-			ResponsiveHelper.SetDebugSize(new Size(322, 400));
+		var host = XamlHelper.LoadXaml<ResponsiveView>("""
+			<utu:ResponsiveView>
+				<!--
+				<utu:ResponsiveView.ResponsiveLayout>
+					<utu:ResponsiveLayout Narrowest="350"
+										  Narrow="450"
+										  Normal="800"
+										  Wide="1200"
+										  Widest="1500" />
+				</utu:ResponsiveView.ResponsiveLayout>
+				-->
 
-			var host = XamlHelper.LoadXaml<ResponsiveView>("""
-				<utu:ResponsiveView>
-					<utu:ResponsiveView.ResponsiveLayout>
-						<utu:ResponsiveLayout>
-							<utu:ResponsiveLayout.Narrowest>350</utu:ResponsiveLayout.Narrowest>
-							<utu:ResponsiveLayout.Narrow>450</utu:ResponsiveLayout.Narrow>
-							<utu:ResponsiveLayout.Normal>800</utu:ResponsiveLayout.Normal>
-							<utu:ResponsiveLayout.Wide>1200</utu:ResponsiveLayout.Wide>
-							<utu:ResponsiveLayout.Widest>1500</utu:ResponsiveLayout.Widest>
-						</utu:ResponsiveLayout>
-					</utu:ResponsiveView.ResponsiveLayout>
-					<utu:ResponsiveView.NarrowestTemplate>
-						<DataTemplate>
-							<Ellipse Width="100" Height="100" />
-						</DataTemplate>
-					</utu:ResponsiveView.NarrowestTemplate>
-					<utu:ResponsiveView.NarrowTemplate>
-						<DataTemplate>
-							<Rectangle Width="100" Height="100" />
-						</DataTemplate>
-					</utu:ResponsiveView.NarrowTemplate>
-					<utu:ResponsiveView.WideTemplate>
-						<DataTemplate>
-							<TextBlock Text="Wide" />
-						</DataTemplate>
-					</utu:ResponsiveView.WideTemplate>
-				</utu:ResponsiveView>
-			""");
+				<utu:ResponsiveView.NarrowestTemplate>
+					<DataTemplate>
+						<Ellipse Width="100" Height="100" />
+					</DataTemplate>
+				</utu:ResponsiveView.NarrowestTemplate>
+				<utu:ResponsiveView.NarrowTemplate>
+					<DataTemplate>
+						<Rectangle Width="100" Height="100" />
+					</DataTemplate>
+				</utu:ResponsiveView.NarrowTemplate>
+				<utu:ResponsiveView.WideTemplate>
+					<DataTemplate>
+						<TextBlock Text="Wide" />
+					</DataTemplate>
+				</utu:ResponsiveView.WideTemplate>
+			</utu:ResponsiveView>
+		""");
+		host.ResponsiveLayout =
+			// somehow neither attribute or member syntax work on windows...
+			// The attachable property 'Narrowest' was not found in type 'ResponsiveLayout'. [Line: 4 Position: 6]'
+			ResponsiveLayout.Create(350, 450, 800, 1200, 1500);
+		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
-			await UnitTestUIContentHelperEx.SetContentAndWait(host);
-
-			Assert.AreEqual(typeof(Ellipse), host.Content.GetType());
-		}
+		host.ForceResponsiveSize(new Size(322, 400));
+		Assert.AreEqual(typeof(Ellipse), host.Content?.GetType());
 	}
 
 	[TestMethod]
 	public async Task ResponsiveView_WidestContent_Ellipse()
 	{
-		using (ResponsiveHelper.UsingDebuggableInstance())
-		{
-			ResponsiveHelper.SetDebugSize(new Size(2000, 400));
+		var host = XamlHelper.LoadXaml<ResponsiveView>("""
+			<utu:ResponsiveView>
+				<utu:ResponsiveView.NarrowTemplate>
+					<DataTemplate>
+						<TextBlock Text="Narrow" />
+					</DataTemplate>
+				</utu:ResponsiveView.NarrowTemplate>
+				<utu:ResponsiveView.NormalTemplate>
+					<DataTemplate>
+						<Rectangle Width="400" Height="400" />
+					</DataTemplate>
+				</utu:ResponsiveView.NormalTemplate>
+				<utu:ResponsiveView.WideTemplate>
+					<DataTemplate>
+						<TextBlock Text="Wide" />
+					</DataTemplate>
+				</utu:ResponsiveView.WideTemplate>
+				<utu:ResponsiveView.WidestTemplate>
+					<DataTemplate>
+						<Ellipse Width="400" Height="400" />
+					</DataTemplate>
+				</utu:ResponsiveView.WidestTemplate>
+			</utu:ResponsiveView>
+		""");
+		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
-			var host = XamlHelper.LoadXaml<ResponsiveView>("""
-				<utu:ResponsiveView>
-					<utu:ResponsiveView.NarrowTemplate>
-						<DataTemplate>
-							<TextBlock Text="Narrow" />
-						</DataTemplate>
-					</utu:ResponsiveView.NarrowTemplate>
-					<utu:ResponsiveView.NormalTemplate>
-						<DataTemplate>
-							<Rectangle Width="400" Height="400" />
-						</DataTemplate>
-					</utu:ResponsiveView.NormalTemplate>
-					<utu:ResponsiveView.WideTemplate>
-						<DataTemplate>
-							<TextBlock Text="Wide" />
-						</DataTemplate>
-					</utu:ResponsiveView.WideTemplate>
-					<utu:ResponsiveView.WidestTemplate>
-						<DataTemplate>
-							<Ellipse Width="400" Height="400" />
-						</DataTemplate>
-					</utu:ResponsiveView.WidestTemplate>
-				</utu:ResponsiveView>
-			""");
-
-			await UnitTestUIContentHelperEx.SetContentAndWait(host);
-
-			Assert.AreEqual(typeof(Ellipse), host.Content.GetType());
-		}
+		host.ForceResponsiveSize(new Size(2000, 400));
+		Assert.AreEqual(typeof(Ellipse), host.Content?.GetType());
 	}
 
 	[TestMethod]
 	public async Task ResponsiveView_WideContent_SizeChanged()
 	{
-		using (ResponsiveHelper.UsingDebuggableInstance())
-		{
-			ResponsiveHelper.SetDebugSize(new Size(150, 400));
+		var host = XamlHelper.LoadXaml<ResponsiveView>("""
+			<utu:ResponsiveView>
+				<utu:ResponsiveView.NarrowTemplate>
+					<DataTemplate>
+						<TextBlock Text="Narrow" />
+					</DataTemplate>
+				</utu:ResponsiveView.NarrowTemplate>
+				<utu:ResponsiveView.NormalTemplate>
+					<DataTemplate>
+						<Rectangle Width="400" Height="400" />
+					</DataTemplate>
+				</utu:ResponsiveView.NormalTemplate>
+				<utu:ResponsiveView.WideTemplate>
+					<DataTemplate>
+						<TextBox Text="Wide" />
+					</DataTemplate>
+				</utu:ResponsiveView.WideTemplate>
+				<utu:ResponsiveView.WidestTemplate>
+					<DataTemplate>
+						<Ellipse Width="400" Height="400" />
+					</DataTemplate>
+				</utu:ResponsiveView.WidestTemplate>
+			</utu:ResponsiveView>
+		""");
+		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
-			var host = XamlHelper.LoadXaml<ResponsiveView>("""
-				<utu:ResponsiveView>
-					<utu:ResponsiveView.NarrowTemplate>
-						<DataTemplate>
-							<TextBlock Text="Narrow" />
-						</DataTemplate>
-					</utu:ResponsiveView.NarrowTemplate>
-					<utu:ResponsiveView.NormalTemplate>
-						<DataTemplate>
-							<Rectangle Width="400" Height="400" />
-						</DataTemplate>
-					</utu:ResponsiveView.NormalTemplate>
-					<utu:ResponsiveView.WideTemplate>
-						<DataTemplate>
-							<TextBox Text="Wide" />
-						</DataTemplate>
-					</utu:ResponsiveView.WideTemplate>
-					<utu:ResponsiveView.WidestTemplate>
-						<DataTemplate>
-							<Ellipse Width="400" Height="400" />
-						</DataTemplate>
-					</utu:ResponsiveView.WidestTemplate>
-				</utu:ResponsiveView>
-			""");
+		host.ForceResponsiveSize(new Size(150, 400));
+		Assert.AreEqual(typeof(TextBlock), host.Content?.GetType());
 
-			await UnitTestUIContentHelperEx.SetContentAndWait(host);
-			Assert.AreEqual(typeof(TextBlock), host.Content.GetType());
-
-			ResponsiveHelper.SetDebugSize(new Size(800, 400));
-			Assert.AreEqual(typeof(TextBox), host.Content.GetType());
-		}
+		host.ForceResponsiveSize(new Size(800, 400));
+		Assert.AreEqual(typeof(TextBox), host.Content?.GetType());
 	}
 }

--- a/src/Uno.Toolkit.UI/Helpers/ResponsiveHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/ResponsiveHelper.cs
@@ -1,12 +1,7 @@
-#if HAS_UNO
-#define UNO14502_WORKAROUND // https://github.com/unoplatform/uno/issues/14502
-#endif
-
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Windows.Foundation;
-using Uno.Disposables;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -17,10 +12,7 @@ using Windows.UI.Core;
 
 namespace Uno.Toolkit.UI;
 
-internal interface IResponsiveCallback
-{
-	void OnSizeChanged(ResponsiveHelper sender);
-}
+public enum Layout { Narrowest, Narrow, Normal, Wide, Widest }
 
 public partial class ResponsiveLayout : DependencyObject
 {
@@ -110,97 +102,31 @@ public partial class ResponsiveLayout : DependencyObject
 		Wide = wide,
 		Widest = widest,
 	};
-	
+
 	public IEnumerable<double> GetBreakpoints() => new[] { Narrowest, Narrow, Normal, Wide, Widest };
 
 	public override string ToString() => "[" + string.Join(",", Narrowest, Narrow, Normal, Wide, Widest) + "]";
 }
 
-public enum Layout { Narrowest, Narrow, Normal, Wide, Widest }
+internal record ResolvedLayout(ResponsiveLayout Layout, Size Size, Layout? Result);
 
-public class ResponsiveHelper
+internal static class ResponsiveHelper
 {
-	private static readonly Lazy<ResponsiveHelper> _instance = new Lazy<ResponsiveHelper>(() => new ResponsiveHelper());
-	private static readonly ResponsiveHelper _debugInstance = new();
-	private static bool UseDebuggableInstance;
+	public static ResponsiveLayout DefaultLayout { get; } = ResponsiveLayout.Create(150, 300, 600, 800, 1080);
 
-	private readonly List<WeakReference> _callbacks = new();
-#if UNO14502_WORKAROUND
-	private readonly List<IResponsiveCallback> _hardCallbackReferences = new();
-#endif
-
-	public ResponsiveLayout Layout { get; private set; } = ResponsiveLayout.Create(150, 300, 600, 800, 1080);
-	public Size WindowSize { get; private set; } = Size.Empty;
-
-	public static ResponsiveHelper GetForCurrentView() => UseDebuggableInstance ? _debugInstance : _instance.Value;
-
-	private ResponsiveHelper() { }
-
-	public void HookupEvent(Window window)
+	internal static ResolvedLayout ResolveLayout(Size size, ResponsiveLayout? layout, IEnumerable<Layout> options)
 	{
-		WindowSize = new Size(window.Bounds.Width, window.Bounds.Height);
+		layout ??= DefaultLayout;
+		var result = ResolveLayoutCore(layout, size.Width, options);
 
-		window.SizeChanged += OnWindowSizeChanged;
-	}
-
-	private void OnWindowSizeChanged(object sender, WindowSizeChangedEventArgs e) => OnWindowSizeChanged(e.Size);
-
-	private void OnWindowSizeChanged(Size size)
-	{
-		WindowSize = size;
-
-		// Clean up collected references
-		_callbacks.RemoveAll(reference => !reference.IsAlive);
-
-		foreach (var reference in _callbacks.ToArray())
-		{
-			if (reference.Target is IResponsiveCallback callback)
-			{
-#if UNO14502_WORKAROUND
-				// Note: In ResponsiveExtensionsSamplePage, if we are using SamplePageLayout with the template,
-				// it seems to keep the controls (_weakTarget) alive, even if we navigate out and back (new page).
-				// However, if we remove the SamplePageLayout, and add the template as a child instead,
-				// the controls will be properly collected.
-
-				// We are using a hard reference to keep the markup extension alive.
-				// We need to check if its reference target is still alive. If it is not, then it should be removed.
-				if (callback is ResponsiveExtension { TargetWeakRef: { IsAlive: false } })
-				{
-					_hardCallbackReferences.Remove(callback);
-					_callbacks.Remove(reference);
-
-					continue;
-				}
-#endif
-				callback.OnSizeChanged(this);
-			}
-		}
-	}
-
-	internal void Register(IResponsiveCallback host)
-	{
-#if UNO14502_WORKAROUND
-		// The workaround is only needed for ResponsiveExtension (MarkupExtension)
-		if (host is ResponsiveExtension)
-		{
-			_hardCallbackReferences.Add(host);
-		}
-#endif
-
-		var wr = new WeakReference(host);
-		_callbacks.Add(wr);
-	}
-
-	internal (ResponsiveLayout Layout, Size Size, Layout? Result) ResolveLayout(ResponsiveLayout? layout, IEnumerable<Layout> options)
-	{
-		layout ??= Layout;
-		var result = ResolveLayoutCore(layout, WindowSize.Width, options);
-
-		return (layout, WindowSize, result);
+		return new(layout, size, result);
 	}
 
 	internal static Layout? ResolveLayoutCore(ResponsiveLayout layout, double width, IEnumerable<Layout> options)
 	{
+		// note: Tests call this function, so keep this pure and stateless.
+		// ResponsiveView and ResponsiveExtension calls are routed from ResolveLayout.
+
 		return options
 			.Concat(new Layout[] { (Layout)int.MaxValue }) // used to get the +inf for the last one's upper-boundary
 			.ZipSkipOne()
@@ -215,22 +141,13 @@ public class ResponsiveHelper
 
 		double GetThreshold(Layout x) => x switch
 		{
-			UI.Layout.Narrowest => layout.Narrowest,
-			UI.Layout.Narrow => layout.Narrow,
-			UI.Layout.Normal => layout.Normal,
-			UI.Layout.Wide => layout.Wide,
-			UI.Layout.Widest => layout.Widest,
+			Layout.Narrowest => layout.Narrowest,
+			Layout.Narrow => layout.Narrow,
+			Layout.Normal => layout.Normal,
+			Layout.Wide => layout.Wide,
+			Layout.Widest => layout.Widest,
 
 			_ => double.PositiveInfinity,
 		};
 	}
-
-	internal static IDisposable UsingDebuggableInstance()
-	{
-		UseDebuggableInstance = true;
-
-		return Disposable.Create(() => UseDebuggableInstance = false);
-	}
-
-	internal static void SetDebugSize(Size size) => _debugInstance.OnWindowSizeChanged(size);
 }

--- a/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
+++ b/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
@@ -260,16 +260,20 @@ namespace Uno.Toolkit.UI
 				#region Toolkit Control Details
 				if (x is ResponsiveView rv)
 				{
-					yield return $"Responsive: {FormatSize(rv.LastResolved.Size)}@{rv.LastResolved.Layout}->{rv.LastResolved.Result}";
+					yield return rv.LastResolved is { }
+						? $"Responsive: {FormatSize(rv.LastResolved.Size)}@{rv.LastResolved.Layout}->{rv.LastResolved.Result}"
+						: "Responsive: unresolved";
 				}
-#if DEBUG
+#if !WINDOWS_UWP
 				if (ResponsiveExtension.TrackedInstances.Where(y => y.Owner.Target == x).ToArray() is { Length: > 0 } instances)
 				{
 					foreach (var item in instances)
 					{
 						if (item.Extension.Target is ResponsiveExtension re)
 						{
-							yield return $"{item.Property}@Responsive: {FormatSize(re.LastResolved.Size)}@{re.LastResolved.Layout}->{re.LastResolved.Result}\\{re.CurrentValue}";
+							yield return re.LastResolved is { }
+								? $"{item.Property}@Responsive: {FormatSize(re.LastResolved.Size)}@{re.LastResolved.Layout}->{re.LastResolved.Result}\\{re.CurrentValue}"
+								: $"{item.Property}@Responsive: unresolved";
 						}
 					}
 				}

--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.not-supported.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.not-supported.cs
@@ -1,0 +1,32 @@
+﻿#if WINDOWS_UWP
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+using Uno.Logging;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Markup;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Markup;
+#endif
+
+namespace Uno.Toolkit.UI;
+
+public partial class ResponsiveExtension : MarkupExtension
+{
+	private static readonly ILogger _logger = typeof(ResponsiveExtension).Log();
+
+	/// <inheritdoc/>
+	protected override object? ProvideValue()
+	{
+		_logger.WarnIfEnabled(() => "This xaml markup extension is not supported on UWP. Consider upgrading to WinUI.");
+		return null;
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #942

## PR Type
What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
## What is the new behavior?
removed the needs of ResponsiveHelper.HookEvent, and adjusted the docs around that part.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [x] UWP
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [x] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [x] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.