### PR TITLE
fix(responsive): invalid initial value being returned

### DIFF
--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
@@ -75,9 +75,7 @@ public partial class ResponsiveExtension : MarkupExtension
 			TrackedInstances.Add((_targetWeakRef, pvtp.Name, new WeakReference(this)));
 
 			// try to return a somewhat valid value for now
-			return _propertyType?.IsValueType == true
-				? Activator.CreateInstance(_propertyType)
-				: default;
+			return GetValueFor(GetAvailableLayoutOptions().FirstOrNull());
 		}
 		else
 		{

--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
@@ -113,7 +113,7 @@ public partial class ResponsiveExtension : MarkupExtension
 		var resolved = ResponsiveHelper.ResolveLayout(size, GetAppliedLayout(), GetAvailableLayoutOptions());
 		UpdateBinding(resolved, forceApplyValue: true);
 	}
-	
+
 	private void UpdateBinding(XamlRoot root, bool forceApplyValue = false)
 	{
 		var resolved = ResponsiveHelper.ResolveLayout(root.Size, GetAppliedLayout(), GetAvailableLayoutOptions());
@@ -142,13 +142,18 @@ public partial class ResponsiveExtension : MarkupExtension
 	{
 		try
 		{
+			if (type.IsEnum && Enum.TryParse(type, value as string, out var parsed))
+			{
+				return parsed;
+			}
+
 			return XamlBindingHelper.ConvertValue(type, value);
 		}
-		catch (Exception)
+		catch (Exception e)
 		{
 			if (_logger.IsEnabled(LogLevel.Error))
 			{
-				_logger.LogError($"Failed to convert value from '{value.GetType().Name}' to '{type.Name}'");
+				_logger.LogError(e, $"Failed to convert value from '{value.GetType().Name}' to '{type.Name}'");
 			}
 
 			return value;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #998

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
ResponsiveExtension (binding) is returning the initial default value created by Activator.CreateInstance when the size is not available. This can cause a problem where the default value of said type is not a valid value, such as a the case for Grid.RowSpan.
User defined enums cannot be parsed.

## What is the new behavior?
The initial default value returned will now be the first member defined within: Narrowest...Widest. The reasoning being that, if it is defined it has to be more valid than just the `default(T)`.
User defined enums can now be parsed by ResponsiveExtension correctly.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.