### PR TITLE
fix: counterAlignment default value set to stretch to keep no breaking change

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Properties.cs
@@ -111,14 +111,14 @@ partial class AutoLayout
 	}
 
 	// -- CounterAlignment Attached Property --
-	//[DynamicDependency(nameof(GetCounterAlignment))]
+	[DynamicDependency(nameof(GetCounterAlignment))]
 	public static readonly DependencyProperty CounterAlignmentProperty = DependencyProperty.RegisterAttached(
         "CounterAlignment",
 		typeof(AutoLayoutAlignment),
 		typeof(AutoLayout),
-		new PropertyMetadata(default(AutoLayoutAlignment), propertyChangedCallback: InvalidateArrangeCallback));
+		new PropertyMetadata(AutoLayoutAlignment.Stretch, propertyChangedCallback: InvalidateArrangeCallback));
 
-	//[DynamicDependency(nameof(GetCounterAlignment))]
+	[DynamicDependency(nameof(GetCounterAlignment))]
 	public static void SetCounterAlignment(DependencyObject element, AutoLayoutAlignment value)
 	{
 		element.SetValue(CounterAlignmentProperty, value);


### PR DESCRIPTION
…g change

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix
## What is the current behavior?

the change in the counterAlignment introduced a breaking change in the default value
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

default value stay stretch 
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [x] Android
	- [x] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
