### PR TITLE
AutoLayout wasn't arranging stretched children when in ScrollViewer

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -446,6 +446,47 @@ internal class AutoLayoutTest
 	}
 
 	[TestMethod]
+	public async Task When_Stretched_PrimaryAlignment_In_ScrollViewer()
+	{
+		var SUT = new AutoLayout()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)),
+			Orientation = Orientation.Vertical,
+		};
+
+		var scrollViewer = new ScrollViewer()
+		{
+			Width = 300,
+			Height = 300,
+			Content = SUT,
+		};
+
+		var border1 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+		};
+
+		var border2 = new Border()
+		{
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			MinHeight = 25,
+		};
+
+		AutoLayout.SetPrimaryAlignment(border1, AutoLayoutPrimaryAlignment.Stretch);
+
+		SUT.Children.Add(border1);
+		SUT.Children.Add(border2);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(scrollViewer);
+
+		var border1Transform = border1.TransformToVisual(SUT).TransformPoint(new Windows.Foundation.Point(0, 0));
+		var border2Transform = border2.TransformToVisual(SUT).TransformPoint(new Windows.Foundation.Point(0, 0));
+
+		border1Transform!.Y.Should().Be(0);
+		border2Transform!.Y.Should().Be(275);
+	}
+
+	[TestMethod]
 	[RequiresFullWindow]
 	[DataRow(Orientation.Vertical, 80, 140, 125, 125)]
 	[DataRow(Orientation.Horizontal, 110, 110, 70, 180)]
@@ -455,7 +496,7 @@ internal class AutoLayoutTest
 		{
 			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)),
 			Padding = new Thickness(150, 20, 100, 50),
-			Spacing = 10, 
+			Spacing = 10,
 			Width = 300,
 			Height = 300,
 			Orientation = orientation,
@@ -648,8 +689,8 @@ internal class AutoLayoutTest
 		var autoLayoutAcutalWidth = SUT.ActualWidth / 2;
 		var textBlockCenter = textBlock.ActualWidth / 2;
 
-		Assert.AreEqual(Math.Ceiling(autoLayoutAcutalWidth - textBlockCenter), Math.Ceiling(textBlockTransform!.X));
-		Assert.AreEqual(Math.Ceiling(SUT.ActualWidth - button.ActualWidth), Math.Ceiling(buttonTransform!.X));
+		textBlockTransform.X.Should().BeApproximately(autoLayoutAcutalWidth - textBlockCenter, precision: 1d);
+		buttonTransform.X.Should().BeApproximately(SUT.ActualWidth - button.ActualWidth, precision: 1d);
 	}
 
 	[TestMethod]
@@ -689,7 +730,7 @@ internal class AutoLayoutTest
 		var autoLayoutAcutalWidth = SUT.ActualWidth / 2;
 		var textBlockCenter = textBlock.ActualWidth / 2;
 
-		Assert.AreEqual(Math.Ceiling(autoLayoutAcutalWidth - textBlockCenter), Math.Ceiling(textBlockTransform!.X));
+		textBlockTransform.X.Should().BeApproximately(autoLayoutAcutalWidth - textBlockCenter, precision: 1d);
 	}
 
 	[TestMethod]
@@ -727,7 +768,7 @@ internal class AutoLayoutTest
 		var autoLayoutAcutalWidth = SUT.ActualWidth / 2;
 		var textBlockCenter = textBlock.ActualWidth / 2;
 
-		Assert.AreEqual(Math.Ceiling(autoLayoutAcutalWidth - textBlockCenter), Math.Ceiling(textBlockTransform!.X));
+		textBlockTransform.X.Should().BeApproximately(autoLayoutAcutalWidth - textBlockCenter, precision: 1d);
 	}
 
 	[TestMethod]

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Arrange.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Arrange.cs
@@ -31,7 +31,7 @@ partial class AutoLayout
 		var borderThicknessLength = borderThickness.GetLength(orientation);
 
 		var totalNonFilledStackedSize = 0d;
-		var totalOfFillMaxSize = 0d; 
+		var totalOfFillMaxSize = 0d;
 		var numberOfFilledChildren = 0;
 		var numberOfFilledChildrenWithMax = 0;
 		var numberOfStackedChildren = 0;
@@ -40,11 +40,21 @@ partial class AutoLayout
 		var startPadding = isHorizontal ? padding.Left : padding.Top;
 		var endPadding = isHorizontal ? padding.Right : padding.Bottom;
 
-		if (_calculatedChildren is null || children.Count != _calculatedChildren.Length)
+		if (_calculatedChildren is null)
 		{
-			// Children list changed, invalidate measure and wait for next pass
+			// If the panel has not been measured yet, we need to measure it now.
 			InvalidateMeasure();
 			return finalSize;
+		}
+
+		if (children.Count != _calculatedChildren.Length
+			|| finalSize != DesiredSize)
+		{
+			// If the number of children has changed, or the final size if different than
+			// what was measured, we need to re-measure the children using the new final size.
+			// This usually happens when the panel is used in a ScrollViewer, and the ScrollViewer
+			// is measuring the panel with an infinite size, and then arranging it with a finite size.
+			MeasureOverride(finalSize);
 		}
 
 		// 1. Calculate the total size of non-filled and filled children


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno.toolkit.ui/issues/1022
# Bugfix

## What is the current behavior?
As described in the issue, a stretched child of an AutoLayout were not properly arranged when inside a ScrollViewer.

## What is the new behavior?
When the `finalSize` is different than the one used to measure the element (which is the case in a ScrollViewer), it was incorrectly using the measured size instread of recalculating it using the `finalSize`.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [X] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [X] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
