### PR TITLE
fix(CupertinoSlidingSegmentedStyle): change height to minheight

### DIFF
--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
@@ -410,7 +410,7 @@
 					<toolkit:ElevatedView Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}"
 					                      Margin="{StaticResource CupertinoSlidingSegmentedItemMargin}"
 										  Background="Transparent"
-										  CornerRadius="{CustomResource CupertinoSlidingSegmentedItemCornerRadius}"
+										  CornerRadius="{StaticResource CupertinoSlidingSegmentedItemCornerRadius}"
 										  Elevation="5"
 										  ShadowColor="#CC94949A">
 						<Rectangle Fill="{ThemeResource SystemBackgroundColor}"

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
@@ -65,7 +65,7 @@
 				Value="{ThemeResource CupertinoTertiarySystemFillBrush}" />
 		<Setter Property="IsTabStop"
 				Value="False" />
-		<Setter Property="Height"
+		<Setter Property="MinHeight"
 				Value="{StaticResource CupertinoSlidingSegmentedControlHeight}" />
 		<Setter Property="SelectionIndicatorTransitionMode"
 				Value="Slide" />

--- a/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
+++ b/src/library/Uno.Toolkit.Cupertino/Styles/Controls/SlidingSegmentedControl.xaml
@@ -50,6 +50,9 @@
 	<x:Double x:Key="CupertinoSlidingSegmentedItemIconWidth">16</x:Double>
 	<Thickness x:Key="CupertinoSlidingSegmentedItemContentMargin">0,0,0,12</Thickness>
 	<Thickness x:Key="CupertinoSlidingSegmentedItemContentOnlyMargin">12,0</Thickness>
+	<Thickness x:Key="CupertinoSlidingSegmentedItemMargin">3</Thickness>
+	<x:Double x:Key="CupertinoSlidingSegmentedItemRadius">6</x:Double>
+	<CornerRadius x:Key="CupertinoSlidingSegmentedItemCornerRadius">6</CornerRadius>
 	<SolidColorBrush x:Key="CupertinoSlidingSegmentedControlItemForegroundPressed"
 					 Color="{ThemeResource LabelColor}"
 					 Opacity="0.2" />
@@ -84,17 +87,16 @@
 			<Setter.Value>
 				<DataTemplate>
 					<toolkit:ElevatedView Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}"
-										  Height="28"
+										  Margin="{StaticResource CupertinoSlidingSegmentedItemMargin}"
 										  Background="Transparent"
-										  CornerRadius="8"
+										  CornerRadius="{StaticResource CupertinoSlidingSegmentedItemCornerRadius}"
 										  Elevation="5"
 										  ShadowColor="#CC94949A">
 						<Rectangle Fill="{ThemeResource SystemBackgroundColor}"
 								   VerticalAlignment="Stretch"
 								   HorizontalAlignment="Stretch"
-								   RadiusX="8"
-								   RadiusY="8"
-								   Height="24"
+								   RadiusX="{StaticResource CupertinoSlidingSegmentedItemRadius}"
+								   RadiusY="{StaticResource CupertinoSlidingSegmentedItemRadius}"
 								   Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth, Converter={StaticResource DeflateWidthConverter}}" />
 					</toolkit:ElevatedView>
 				</DataTemplate>
@@ -406,17 +408,16 @@
 			<Setter.Value>
 				<DataTemplate>
 					<toolkit:ElevatedView Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth}"
-										  Height="28"
+					                      Margin="{StaticResource CupertinoSlidingSegmentedItemMargin}"
 										  Background="Transparent"
-										  CornerRadius="8"
+										  CornerRadius="{CustomResource CupertinoSlidingSegmentedItemCornerRadius}"
 										  Elevation="5"
 										  ShadowColor="#CC94949A">
 						<Rectangle Fill="{ThemeResource SystemBackgroundColor}"
 								   VerticalAlignment="Stretch"
 								   HorizontalAlignment="Stretch"
-								   RadiusX="8"
-								   RadiusY="8"
-								   Height="24"
+								   RadiusX="{StaticResource CupertinoSlidingSegmentedItemRadius}"
+								   RadiusY="{StaticResource CupertinoSlidingSegmentedItemRadius}"
 								   Width="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SelectionIndicatorWidth, Converter={StaticResource DeflateWidthConverter}}" />
 					</toolkit:ElevatedView>
 				</DataTemplate>


### PR DESCRIPTION
GitHub Issue (If applicable):  #1021 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Using TabBar control with CupertinoSlidingSegmentedStyle renders ui with fixed height

## What is the new behavior?

Using TabBar control with CupertinoSlidingSegmentedStyle renders ui with adaptable height

![Screenshot 2024-02-01 at 14 51 18](https://github.com/unoplatform/uno.toolkit.ui/assets/2529808/e91f5f35-7937-4d71-bc1b-6d06d463807b)

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [x] iOS
	- [x] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

Internal Issue (If applicable):
