### PR TITLE
fix(drawer): attached property crash

### DIFF
--- a/build/workflow/cspell.json
+++ b/build/workflow/cspell.json
@@ -2,6 +2,7 @@
 	"version": "0.2",
 	"language": "en",
 	"words": [
+		"autoplay",
 		"Avalonia",
 		"ambiently",
 		"binlog",

--- a/doc/helpers/StatusBar-extensions.md
+++ b/doc/helpers/StatusBar-extensions.md
@@ -17,7 +17,6 @@ Provides two attached properties on `Page` to control the visuals of the status 
     </iframe>
 </div>
 
-
 ## Remarks
 
 The attached properties do nothing on platforms other than iOS and Android.

--- a/src/Uno.Toolkit.UI/Behaviors/DrawerControlBehavior.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/DrawerControlBehavior.cs
@@ -41,10 +41,10 @@ namespace Uno.Toolkit.UI
 			new PropertyMetadata(default(Brush)));
 
 		[DynamicDependency(nameof(SetDrawerBackground))]
-		public static Brush GetDrawerBackground(DrawerControl obj) => (Brush)obj.GetValue(DrawerBackgroundProperty);
+		public static Brush GetDrawerBackground(DependencyObject obj) => (Brush)obj.GetValue(DrawerBackgroundProperty);
 
 		[DynamicDependency(nameof(GetDrawerBackground))]
-		public static void SetDrawerBackground(DrawerControl obj, Brush value) => obj.SetValue(DrawerBackgroundProperty, value);
+		public static void SetDrawerBackground(DependencyObject obj, Brush value) => obj.SetValue(DrawerBackgroundProperty, value);
 
 		#endregion
 		#region DependencyProperty: OpenDirection
@@ -127,9 +127,9 @@ namespace Uno.Toolkit.UI
 			new PropertyMetadata(DrawerControl.DefaultValues.FitToDrawerContent));
 
 		[DynamicDependency(nameof(SetFitToDrawerContent))]
-		public static bool GetFitToDrawerContent(DrawerControl obj) => (bool)obj.GetValue(FitToDrawerContentProperty);
+		public static bool GetFitToDrawerContent(DependencyObject obj) => (bool)obj.GetValue(FitToDrawerContentProperty);
 		[DynamicDependency(nameof(GetFitToDrawerContent))]
-		public static void SetFitToDrawerContent(DrawerControl obj, bool value) => obj.SetValue(FitToDrawerContentProperty, value);
+		public static void SetFitToDrawerContent(DependencyObject obj, bool value) => obj.SetValue(FitToDrawerContentProperty, value);
 
 		#endregion
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1055

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
using certain DrawerControlBehavior attached properties on a NavigationView would result in a compilation error:
- DrawerBackground
- FitToDrawerContent

## What is the new behavior?
^ should not happen

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.