### PR TITLE
chore: Remove property for UAP splash entity

### DIFF
--- a/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
+++ b/samples/Uno.Toolkit.WinUI.Samples/Uno.Toolkit.WinUI.Samples.Windows.Desktop/Uno.Toolkit.WinUI.Samples.Windows.Desktop.csproj
@@ -33,8 +33,4 @@
 
 	<Import Project="..\..\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Uno.Toolkit.Samples.Shared.projitems" Label="Shared" />
 
-	<ItemGroup>
-	  <Page Remove="C:\Work\uno.toolkit.ui\samples\Uno.Toolkit.Samples\Uno.Toolkit.Samples.Shared\Content\TestPages\ShadowContainerRectangleTestPage.WinUI.xaml" />
-	</ItemGroup>
-
 </Project>

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Android.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Uno.Extensions;
 using Uno.Logging;
 using Uno.UI;
-using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
 using System.Runtime.InteropServices;
 using Android.OS;
@@ -38,7 +37,7 @@ public partial class ExtendedSplashScreen
 		}
 	}
 
-	private static Task<FrameworkElement?> GetNativeSplashScreen(SplashScreen? splashScreen)
+	private static Task<FrameworkElement?> GetNativeSplashScreen()
 	{
 		try
 		{

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.NetStandard.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
-using Windows.ApplicationModel.Activation;
 using Windows.Graphics.Display;
 using System.Reflection;
 using System.IO;
@@ -51,7 +50,7 @@ namespace Uno.Toolkit.UI
 					RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY")) // Legacy Value (Bootstrapper 1.2.0-dev.29 or earlier).
 					|| RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
 
-		private static async Task<FrameworkElement?> GetNativeSplashScreen(SplashScreen? splashScreen)
+		private static async Task<FrameworkElement?> GetNativeSplashScreen()
 		{
 			// Position of image aligns with WASM Bootstrapper style for splash image
 			// see https://github.com/unoplatform/Uno.Wasm.Bootstrap/blob/7d82af66c7dc587f6d1f6b6382860051fc2d92a0/src/Uno.Wasm.Bootstrap/WasmCSS/uno-bootstrap.css#L21

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Uno.Disposables;
 using Uno.Extensions;
-using Windows.ApplicationModel.Activation;
 #if IS_WINUI
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -30,7 +29,7 @@ public partial class ExtendedSplashScreen : LoadingView
 		new PropertyMetadata(SplashScreenPlatform.All));
 
 	/// <summary>
-	/// Gets or sets the list of platforms where extended splash screen should be used.
+	/// Gets or sets the platform(s) where extended splash screen should be used.
 	/// </summary>
 	public SplashScreenPlatform Platforms
 	{
@@ -38,8 +37,6 @@ public partial class ExtendedSplashScreen : LoadingView
 		set => SetValue(PlatformsProperty, value);
 	}
 	#endregion
-
-	public SplashScreen? SplashScreen { get; set; }
 
 	#region DependencyProperty: SplashScreenContent
 	internal static DependencyProperty SplashScreenContentProperty { get; } = DependencyProperty.Register(
@@ -80,7 +77,7 @@ Window? Window
 
 	private async Task LoadNativeSplashScreen()
 	{
-		var splashScreenContent = await GetNativeSplashScreen(SplashScreen);
+		var splashScreenContent = await GetNativeSplashScreen();
 
 		if (splashScreenContent is not null)
 		{
@@ -92,7 +89,7 @@ Window? Window
 
 
 #if !__ANDROID__ && !__IOS__ && !(WINDOWS || WINDOWS_UWP) && !NETSTANDARD2_0
-	private static Task<FrameworkElement?> GetNativeSplashScreen(SplashScreen? splashScreen)
+	private static Task<FrameworkElement?> GetNativeSplashScreen()
 	{
 		return Task.FromResult<FrameworkElement?>(null);
 	}

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.iOS.cs
@@ -30,7 +30,7 @@ namespace Uno.Toolkit.UI
 	{
 		public bool SplashIsEnabled => (Platforms & SplashScreenPlatform.iOS) != 0;
 
-		private static Task<FrameworkElement?> GetNativeSplashScreen(SplashScreen? splashScreen)
+		private static Task<FrameworkElement?> GetNativeSplashScreen()
 		{
 			try
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

We currently allow users of `ExtendedSplashScreen` to get/set a `SplashScreen` object ([`Windows.ApplicationModel.Activation`](https://learn.microsoft.com/uwp/api/windows.applicationmodel.activation)) which appears to not be implemented for Uno.UI targets.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Remove [`ExtendedSplashScreen.SplashScreen`](https://platform.uno/docs/articles/external/uno.toolkit.ui/doc/controls/ExtendedSplashScreen.html#properties) property
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
