### PR TITLE
chore: bump uno.winui.markup to 5.2

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Uno.Cupertino.WinUI" Version="4.2.0-dev.17" />
     <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.1.4" />
     <PackageVersion Include="Uno.SourceGenerationTasks" Version="4.2.0" />
-    <PackageVersion Include="Uno.WinUI.Markup" Version="5.1.4" />
+    <PackageVersion Include="Uno.WinUI.Markup" Version="5.2.0-dev.61" />
     <PackageVersion Include="Uno.Material" Version="4.2.0-dev.17" />
     <PackageVersion Include="Uno.Material.WinUI" Version="4.2.0-dev.17" />
     <PackageVersion Include="Uno.UI" Version="5.0.154" />


### PR DESCRIPTION
closes #1080 