### PR TITLE
feat(responsive): add support for non-FrameworkElement

### DIFF
--- a/doc/helpers/responsive-extension.md
+++ b/doc/helpers/responsive-extension.md
@@ -110,6 +110,26 @@ xmlns:utu="using:Uno.Toolkit.UI"
 <TextBlock Background="{utu:Responsive Narrow=Red, Wide=Blue}" Text="Asd" />
 ```
 
+`ResponsiveExpression` does not normally work directly on non-FrameworkElement. We have added some workaround to cover common usages:
+
+```xml
+<Page.Resources>
+    <GridLength x:Key="GL50">50</GridLength>
+    <GridLength x:Key="GL150">150</GridLength>
+    <SolidColorBrush x:Key="Red">Red</SolidColorBrush>
+    <SolidColorBrush x:Key="Green">Green</SolidColorBrush>
+    <SolidColorBrush x:Key="Blue">Blue</SolidColorBrush>
+
+<Grid utu:ResponsiveBehavior.IsEnabled="True">
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="{utu:Responsive Narrow={StaticResource GL50}, Wide={StaticResource GL150}}" />
+
+<TextBlock utu:ResponsiveBehavior.IsEnabled="True">
+    <Run Text="asd" Foreground="{utu:Responsive Narrow={StaticResource Red}, Wide={StaticResource Green}}" />
+```
+
+If you have a setup that is not covered, feel free to [open an issue in the toolkit repo](https://github.com/unoplatform/uno.toolkit.ui/issues/new/choose).
+
 ### Custom thresholds
 
 ```xml

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Helpers/ResponsiveExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Helpers/ResponsiveExtensionsSamplePage.xaml
@@ -14,6 +14,13 @@
 			<sample:SamplePageLayout.DesignAgnosticTemplate>
 				<DataTemplate>
 					<StackPanel Spacing="20">
+						<StackPanel.Resources>
+							<GridLength x:Key="GL50">50</GridLength>
+							<GridLength x:Key="GL150">150</GridLength>
+							<SolidColorBrush x:Key="Red">Red</SolidColorBrush>
+							<SolidColorBrush x:Key="Green">Green</SolidColorBrush>
+							<SolidColorBrush x:Key="Blue">Blue</SolidColorBrush>
+						</StackPanel.Resources>
 
 						<!-- string literal -->
 						<TextBlock Text="Text test" FontWeight="Bold" />
@@ -53,6 +60,35 @@
 							<Border Grid.Column="{utu:Responsive Narrowest=0, Narrow=1, Normal=0, Wide=1, Widest=0}" Background="Pink" />
 						</Grid>
 
+						<!-- non-FE: Grid.Column/RowDefinitions -->
+						<TextBlock Text="Grid.ColumnDefinition test" />
+						<Grid utu:ResponsiveBehavior.IsEnabled="True"
+							  Height="50"
+							  HorizontalAlignment="Left">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="{utu:Responsive Narrow={StaticResource GL150}, Normal={StaticResource GL50}, Wide={StaticResource GL150}, Widest={StaticResource GL50}}" />
+								<ColumnDefinition Width="{utu:Responsive Narrow={StaticResource GL50}, Normal={StaticResource GL150}, Wide={StaticResource GL50}, Widest={StaticResource GL150}}" />
+							</Grid.ColumnDefinitions>
+
+							<Border Grid.Column="0" Background="Pink" />
+							<Border Grid.Column="1" Background="SkyBlue" />
+						</Grid>
+
+						<!-- non-FE: TextBlock.Inlines -->
+						<TextBlock Text="TextBlock.Inlines test" />
+						<TextBlock utu:ResponsiveBehavior.IsEnabled="True">
+							<Run Text="asd" Foreground="{utu:Responsive Narrow={StaticResource Red}, Normal={StaticResource Blue}, Wide={StaticResource Green}, Widest={StaticResource Red}}" />
+							<Run Text="qwe" Foreground="{utu:Responsive Narrow={StaticResource Green}, Normal={StaticResource Red}, Wide={StaticResource Blue}, Widest={StaticResource Green}}" />
+							<Run Text="zxc" Foreground="{utu:Responsive Narrow={StaticResource Blue}, Normal={StaticResource Green}, Wide={StaticResource Red}, Widest={StaticResource Blue}}" />
+							<Span FontStyle="Italic">
+								<Run Text="asd" Foreground="{utu:Responsive Narrow={StaticResource Red}, Normal={StaticResource Blue}, Wide={StaticResource Green}, Widest={StaticResource Red}}" />
+								<Run Text="qwe" Foreground="{utu:Responsive Narrow={StaticResource Green}, Normal={StaticResource Red}, Wide={StaticResource Blue}, Widest={StaticResource Green}}" />
+								<Span>
+									<Run Text="zxc" Foreground="{utu:Responsive Narrow={StaticResource Blue}, Normal={StaticResource Green}, Wide={StaticResource Red}, Widest={StaticResource Blue}}" />
+								</Span>
+							</Span>
+						</TextBlock>
+
 						<!-- layout overriding -->
 						<TextBlock Text="Custom values override" FontWeight="Bold" />
 						<StackPanel>
@@ -83,6 +119,7 @@
 								<TextBlock Text="{utu:Responsive Layout={StaticResource CustomLayout}, Narrowest=Narrowest, Narrow=Narrow, Normal=Normal, Wide=Wide, Widest=Widest}" />
 							</StackPanel>
 						</StackPanel>
+
 					</StackPanel>
 				</DataTemplate>
 			</sample:SamplePageLayout.DesignAgnosticTemplate>

--- a/src/Uno.Toolkit.UI/Behaviors/ResponsiveBehavior.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/ResponsiveBehavior.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Documents;
+#endif
+
+namespace Uno.Toolkit.UI;
+
+public static class ResponsiveBehavior
+{
+	#region DependencyProperty: IsEnabled
+
+	public static DependencyProperty IsEnabledProperty { [DynamicDependency(nameof(GetIsEnabled))] get; } = DependencyProperty.RegisterAttached(
+		"IsEnabled",
+		typeof(bool),
+		typeof(ResponsiveBehavior),
+		new PropertyMetadata(default(bool), OnIsEnabledChanged));
+
+	[DynamicDependency(nameof(SetIsEnabled))]
+	public static bool GetIsEnabled(DependencyObject obj) => (bool)obj.GetValue(IsEnabledProperty);
+	[DynamicDependency(nameof(GetIsEnabled))]
+	public static void SetIsEnabled(DependencyObject obj, bool value) => obj.SetValue(IsEnabledProperty, value);
+
+	#endregion
+
+	internal static bool IsChildSupported(DependencyObject? child) => child switch
+	{
+		ColumnDefinition or RowDefinition => true,
+		Inline => true,
+
+		_ => false,
+	};
+
+	private static void OnIsEnabledChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+	{
+		if (sender is Grid g)
+		{
+			g.Loaded += OnGridLoaded;
+		}
+		else if (sender is TextBlock tb)
+		{
+			tb.Loaded += OnTextBlockLoaded;
+		}
+		else
+		{
+			throw new NotSupportedException($"ResponsiveBehavior is not supported on '{sender.GetType()}'.");
+		}
+	}
+
+	private static void OnGridLoaded(object sender, RoutedEventArgs e)
+	{
+		if (sender is not Grid host) return;
+
+		var markups = Enumerable
+			.Concat<DependencyObject>(host.ColumnDefinitions, host.RowDefinitions)
+			.SelectMany(ResponsiveExtension.GetAllInstancesFor);
+		foreach (var markup in markups)
+		{
+			markup.InitializeByProxy(host);
+		}
+	}
+
+	private static void OnTextBlockLoaded(object sender, RoutedEventArgs e)
+	{
+		if (sender is not TextBlock host) return;
+
+		// There is actually more elements than what's defined in the xaml;
+		// these come from the whitespaces... and, they are fine.
+		var markups = FlattenInlines(host)
+			.SelectMany(ResponsiveExtension.GetAllInstancesFor);
+		foreach (var markup in markups)
+		{
+			markup.InitializeByProxy(host);
+		}
+	}
+
+	private static IEnumerable<Inline> FlattenInlines(TextBlock tb) => FlattenInlines(tb.Inlines);
+	private static IEnumerable<Inline> FlattenInlines(InlineCollection inlines)
+	{
+		foreach (var inline in inlines)
+		{
+			yield return inline;
+
+			if (inline is Span span)
+			{
+				foreach (var nested in FlattenInlines(span.Inlines))
+				{
+					yield return nested;
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.not-supported.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.not-supported.cs
@@ -1,6 +1,7 @@
 ﻿#if WINDOWS_UWP
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -36,5 +37,16 @@ public partial class ResponsiveExtension : MarkupExtension
 		_logger.WarnIfEnabled(() => "This xaml markup extension is not supported on UWP. Consider upgrading to WinUI.");
 		return null;
 	}
+
+	[SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "blank method needed uwp build")]
+	internal void InitializeByProxy(FrameworkElement proxyHost) { }
+}
+public partial class ResponsiveExtension
+{
+	internal static List<(WeakReference Owner, string Property, WeakReference Extension)> TrackedInstances { get; } = new();
+
+	internal static ResponsiveExtension[] GetAllInstancesFor(DependencyObject owner) => Array.Empty<ResponsiveExtension>();
+
+	internal static ResponsiveExtension? GetInstanceFor(DependencyObject owner, string property) => null;
 }
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #950

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the current behavior?
previously ResponsiveExpression didnt support non-FrameworkElement targets such as Grid.ColumnDefinitions or TextBlock.Inlines.

## What is the new behavior?
^ they are now supported.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [x] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [x] Skia
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [x] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.