### PR TITLE
fix: adjust opacity brushes from themes breaking change

### DIFF
--- a/doc/controls/ChipAndChipGroup.md
+++ b/doc/controls/ChipAndChipGroup.md
@@ -111,7 +111,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 | `ChipBackgroundPointerOver`            | `SolidColorBrush` | `SystemControlTransparentBrush`     |
 | `ChipBackgroundFocused`                | `SolidColorBrush` | `SystemControlTransparentBrush`     |
 | `ChipBackgroundPressed`                | `SolidColorBrush` | `SystemControlTransparentBrush`     |
-| `ChipBackgroundDisabled`               | `SolidColorBrush` | `OnSurfaceDisabledLowBrush`         |
+| `ChipBackgroundDisabled`               | `SolidColorBrush` | `OnSurfaceDisabledBrush`            |
 | `ChipBackgroundChecked`                | `SolidColorBrush` | `SecondaryContainerBrush`           |
 | `ChipBackgroundCheckedPointerOver`     | `SolidColorBrush` | `SecondaryContainerBrush`           |
 | `ChipBackgroundCheckedFocused`         | `SolidColorBrush` | `SystemControlTransparentBrush`     |
@@ -143,7 +143,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 | `ChipBorderBrushPointerOver`           | `SolidColorBrush` | `OutlineBrush`                      |
 | `ChipBorderBrushFocused`               | `SolidColorBrush` | `SystemControlTransparentBrush`     |
 | `ChipBorderBrushPressed`               | `SolidColorBrush` | `OutlineBrush`                      |
-| `ChipBorderBrushDisabled`              | `SolidColorBrush` | `OnSurfaceVariantDisabledLowBrush`  |
+| `ChipBorderBrushDisabled`              | `SolidColorBrush` | `OnSurfaceVariantDisabledBrush`     |
 | `ChipBorderBrushChecked`               | `SolidColorBrush` | `OutlineBrush`                      |
 | `ChipBorderBrushCheckedPointerOver`    | `SolidColorBrush` | `OutlineBrush`                      |
 | `ChipBorderBrushCheckedFocused`        | `SolidColorBrush` | `SystemControlTransparentBrush`     |

--- a/doc/controls/TabBarAndTabBarItem.md
+++ b/doc/controls/TabBarAndTabBarItem.md
@@ -574,7 +574,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 | `FabTabBarItemBackgroundPointerOver`                               | `SolidColorBrush` | OnPrimaryContainerHoverBrush                 |
 | `FabTabBarItemBackgroundFocused`                                   | `SolidColorBrush` | OnPrimaryContainerFocusedBrush               |
 | `FabTabBarItemBackgroundPressed`                                   | `SolidColorBrush` | OnPrimaryContainerPressedBrush               |
-| `FabTabBarItemBackgroundDisabled`                                  | `SolidColorBrush` | OnSurfaceDisabledLowBrush                    |
+| `FabTabBarItemBackgroundDisabled`                                  | `SolidColorBrush` | OnSurfaceDisabledBrush                    |
 | `FabTabBarItemBackgroundSelected`                                  | `SolidColorBrush` | SystemControlTransparentBrush                |
 | `FabTabBarItemBackgroundSelectedPointerOver`                       | `SolidColorBrush` | SystemControlTransparentBrush                |
 | `FabTabBarItemBackgroundSelectedPressed`                           | `SolidColorBrush` | SystemControlTransparentBrush                |

--- a/doc/material-migration.md
+++ b/doc/material-migration.md
@@ -37,7 +37,7 @@ Along with the above list of new resource keys, below is a list of the resource 
 | `MaterialChipCornerRadius`                    | `ChipCornerRadius`              | 8                                                                 |
 | `MaterialChipIconSize`                        | `ChipIconSize`                  | 18                                                                |
 | `MaterialChipElevation`                       | `ChipElevation`                 | 4                                                                 |
-| `M3MateriaChipCheckGlyphSize`                 | **_REMOVED_**                   | 20                                                                |
+| `M3MateriaChipCheckGlyphSize`                 | ***REMOVED***                   | 20                                                                |
 | `MaterialChipBorderThickness`                 | `ChipBorderThickness`           | 1                                                                 |
 | `MaterialChipDeleteIconLength`                | `ChipDeleteIconLength`          | 11                                                                |
 | `MaterialChipDeleteIconContainerLength`       | `ChipDeleteIconContainerLength` | 18                                                                |
@@ -49,21 +49,21 @@ Along with the above list of new resource keys, below is a list of the resource 
 | `MaterialChipDisabledForeground`              | `ChipForegroundDisabled`        | `OnSurfaceDisabledBrush`                                          |
 | `MaterialChipIconDisabledForeground`          | `ChipIconForegroundDisabled`    | `OnSurfaceDisabledBrush`                                          |
 | `MaterialChipIconForeground`                  | `ChipIconForeground`            | `PrimaryBrush`                                                    |
-| `MaterialChipSelectedPressedForeground`       | **_REMOVED_**                   | `OnSecondaryContainerBrush`                                       |
-| `MaterialChipSelectedFocusedForeground`       | **_REMOVED_**                   | `OnSecondaryContainerBrush`                                       |
-| `MaterialChipSelectedPointerOverForeground`   | **_REMOVED_**                   | `OnSecondaryContainerBrush`                                       |
-| `MaterialChipSelectedForeground`              | **_REMOVED_**                   | `OnSecondaryContainerBrush`                                       |
+| `MaterialChipSelectedPressedForeground`       | ***REMOVED***                   | `OnSecondaryContainerBrush`                                       |
+| `MaterialChipSelectedFocusedForeground`       | ***REMOVED***                   | `OnSecondaryContainerBrush`                                       |
+| `MaterialChipSelectedPointerOverForeground`   | ***REMOVED***                   | `OnSecondaryContainerBrush`                                       |
+| `MaterialChipSelectedForeground`              | ***REMOVED***                   | `OnSecondaryContainerBrush`                                       |
 | `MaterialChipPressedForeground`               | `ChipForegroundPressed`         | `OnSurfaceVariantBrush`                                           |
 | `MaterialChipFocusedForeground`               | `ChipForegroundFocused`         | `OnSurfaceVariantBrush` -> `SystemControlTransparentBrush`        |
 | `MaterialChipPointerOverForeground`           | `ChipForegroundPointerOver`     | `OnSurfaceVariantBrush`                                           |
 | `MaterialChipForeground`                      | `ChipForeground`                | `OnSurfaceVariantBrush`                                           |
-| `MaterialChipSelectedPressedStateOverlay`     | **_REMOVED_**                   | `OnSecondaryContainerSelectedBrush`                               |
-| `MaterialChipSelectedFocusedStateOverlay`     | **_REMOVED_**                   | `OnSecondaryContainerFocusedBrush`                                |
-| `MaterialChipSelectedPointerOverStateOverlay` | **_REMOVED_**                   | `OnSecondaryContainerHoverBrush`                                  |
+| `MaterialChipSelectedPressedStateOverlay`     | ***REMOVED***                   | `OnSecondaryContainerSelectedBrush`                               |
+| `MaterialChipSelectedFocusedStateOverlay`     | ***REMOVED***                   | `OnSecondaryContainerFocusedBrush`                                |
+| `MaterialChipSelectedPointerOverStateOverlay` | ***REMOVED***                   | `OnSecondaryContainerHoverBrush`                                  |
 | `MaterialChipPressedStateOverlay`             | `ChipStateOverlayPressed`       | `OnSurfaceVariantPressedBrush`                                    |
 | `MaterialChipFocusedStateOverlay`             | `ChipStateOverlayFocused`       | `OnSurfaceVariantFocusedBrush` -> `SystemControlTransparentBrush` |
 | `MaterialChipPointerOverStateOverlay`         | `ChipStateOverlayPointerOver`   | `OnSurfaceVariantHoverBrush`                                      |
-| `MaterialChipSelectedBackground`              | **_REMOVED_**                   | `SecondaryContainerBrush`                                         |
+| `MaterialChipSelectedBackground`              | ***REMOVED***                   | `SecondaryContainerBrush`                                         |
 | `MaterialChipBackground`                      | `ChipBackground`                | `SystemControlTransparentBrush`                                   |
 
 ### Divider
@@ -118,7 +118,7 @@ Along with the new Material Design 3 styles, our Material Toolkit NuGet packages
 > In order to continue using the v1 styles, some changes are required in your `App.xaml`.
 
 <!-- TODO: Use xref link. For some reason, it currently doesn't work. -->
-Since the Material Toolkit has a dependency on the Uno Material library, it is required to first follow the steps in the **_Continue Using v1 Styles_** section of the [Uno Material v2 migration documentation](https://platform.uno/docs/articles/external/uno.themes/doc/material-migration.html).
+Since the Material Toolkit has a dependency on the Uno Material library, it is required to first follow the steps in the ***Continue Using v1 Styles*** section of the [Uno Material v2 migration documentation](https://platform.uno/docs/articles/external/uno.themes/doc/material-migration.html).
 
 The Material Toolkit v2 NuGet package contains both sets of v1 and v2 styles. Within your `App.xaml`, you will need to replace the reference to `MaterialToolkitResources` with `MaterialToolkitResourcesV1`.
 

--- a/doc/material-migration.md
+++ b/doc/material-migration.md
@@ -4,6 +4,22 @@ uid: Toolkit.Migration.Material2.0
 
 # Updating Material Toolkit Version
 
+## Updating to Material Toolkit v6
+
+Material Toolkit v6 contains a dependency on [Uno Material](Uno.Themes.Material.GetStarted) which, as of its v5 release, introduces breaking changes that can affect applications using the Material Toolkit. Refer to the [Uno Material v5 migration documentation](xref:Uno.Themes.Material.Migration#updating-to-unothemes-v50) for further information.
+
+### Opacity and brushes
+
+The opacity values of certain brushes have been adjusted in Uno Material v5. The following table shows the changes in opacity values:
+
+| Opacity variant | Old Value | New Value |
+|-----------------|-----------|-----------|
+| Medium          | 0.54      | 0.64      |
+| Disabled        | 0.38      | 0.12      |
+| DisabledLow     | 0.12      | *removed* |
+
+Existing explicit references to `-DisabledLow` resources have been updated to use `-Disabled`.
+
 ## Updating to Material Toolkit v4
 
 Material Toolkit v4 introduces support for [Lightweight Styling](lightweight-styling.md) and, as a result, many resource keys have been added as well as renamed. For a list of all the new resource keys, please refer to the [Lightweight Styling documentation](lightweight-styling.md#resource-keys).

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Chip.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Chip.xaml
@@ -37,7 +37,7 @@
 			<StaticResource x:Key="ChipBackgroundPressed"
 							ResourceKey="SystemControlTransparentBrush" />
 			<StaticResource x:Key="ChipBackgroundDisabled"
-							ResourceKey="OnSurfaceDisabledLowBrush" />
+							ResourceKey="OnSurfaceDisabledBrush" />
 			<StaticResource x:Key="ChipBackgroundChecked"
 							ResourceKey="SecondaryContainerBrush" />
 			<StaticResource x:Key="ChipBackgroundCheckedPointerOver"
@@ -105,7 +105,7 @@
 			<StaticResource x:Key="ChipBorderBrushPressed"
 							ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="ChipBorderBrushDisabled"
-							ResourceKey="OnSurfaceVariantDisabledLowBrush" />
+							ResourceKey="OnSurfaceVariantDisabledBrush" />
 			<StaticResource x:Key="ChipBorderBrushChecked"
 							ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="ChipBorderBrushCheckedPointerOver"
@@ -172,7 +172,7 @@
 			<StaticResource x:Key="ChipBackgroundPressed"
 							ResourceKey="SystemControlTransparentBrush" />
 			<StaticResource x:Key="ChipBackgroundDisabled"
-							ResourceKey="OnSurfaceDisabledLowBrush" />
+							ResourceKey="OnSurfaceDisabledBrush" />
 			<StaticResource x:Key="ChipBackgroundChecked"
 							ResourceKey="SecondaryContainerBrush" />
 			<StaticResource x:Key="ChipBackgroundCheckedPointerOver"
@@ -240,7 +240,7 @@
 			<StaticResource x:Key="ChipBorderBrushPressed"
 							ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="ChipBorderBrushDisabled"
-							ResourceKey="OnSurfaceVariantDisabledLowBrush" />
+							ResourceKey="OnSurfaceVariantDisabledBrush" />
 			<StaticResource x:Key="ChipBorderBrushChecked"
 							ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="ChipBorderBrushCheckedPointerOver"

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
@@ -101,7 +101,7 @@
 			<StaticResource x:Key="FabTabBarItemBackgroundPointerOver" ResourceKey="OnPrimaryContainerHoverBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundFocused" ResourceKey="OnPrimaryContainerFocusedBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundPressed" ResourceKey="OnPrimaryContainerPressedBrush" />
-			<StaticResource x:Key="FabTabBarItemBackgroundDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+			<StaticResource x:Key="FabTabBarItemBackgroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />
@@ -297,7 +297,7 @@
 			<StaticResource x:Key="FabTabBarItemBackgroundPointerOver" ResourceKey="OnPrimaryContainerHoverBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundFocused" ResourceKey="OnPrimaryContainerFocusedBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundPressed" ResourceKey="OnPrimaryContainerPressedBrush" />
-			<StaticResource x:Key="FabTabBarItemBackgroundDisabled" ResourceKey="OnSurfaceDisabledLowBrush" />
+			<StaticResource x:Key="FabTabBarItemBackgroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundSelected" ResourceKey="SystemControlTransparentBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundSelectedPointerOver" ResourceKey="SystemControlTransparentBrush" />
 			<StaticResource x:Key="FabTabBarItemBackgroundSelectedPressed" ResourceKey="SystemControlTransparentBrush" />


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.toolkit.ui/issues/1086

Adjust brush usages now that https://github.com/unoplatform/Uno.Themes/pull/1369 has merged into Themes. Change usages of `-DisabledLowBrush` to `-DisableBrush`