### PR TITLE
chore!: Rename Theme class to ToolkitTheme

### DIFF
--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/Card.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/Card.cs
@@ -5,7 +5,7 @@ using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Toolkit.UI.Markup;
 
-public static partial class Theme
+public static partial class ToolkitTheme
 {
 	public static partial class Card
 	{

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/CardContentControl.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/CardContentControl.cs
@@ -5,7 +5,7 @@ using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Toolkit.UI.Markup;
 
-public static partial class Theme
+public static partial class ToolkitTheme
 {
 	public static partial class CardContentControl
 	{

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/Chip.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/Chip.cs
@@ -5,7 +5,7 @@ using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Toolkit.UI.Markup;
 
-public static partial class Theme
+public static partial class ToolkitTheme
 {
 	public static partial class Chip
 	{

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/ChipGroup.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/ChipGroup.cs
@@ -4,7 +4,7 @@ using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Toolkit.UI.Markup;
 
-public static partial class Theme
+public static partial class ToolkitTheme
 {
 	public static partial class ChipGroup
 	{

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/Divider.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/Divider.cs
@@ -5,7 +5,7 @@ using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Toolkit.UI.Markup;
 
-public static partial class Theme
+public static partial class ToolkitTheme
 {
 	public static partial class Divider
 	{

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/NavigationBar.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/NavigationBar.cs
@@ -6,7 +6,7 @@ using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Toolkit.UI.Markup;
 
-public static partial class Theme
+public static partial class ToolkitTheme
 {
 	public static partial class NavigationBar
 	{

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/TabBar.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/TabBar.cs
@@ -5,7 +5,7 @@ using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Toolkit.UI.Markup;
 
-public static partial class Theme
+public static partial class ToolkitTheme
 {
 	public static partial class TabBar
 	{

--- a/src/library/Uno.Toolkit.WinUI.Markup/Theme/TabBarItem.cs
+++ b/src/library/Uno.Toolkit.WinUI.Markup/Theme/TabBarItem.cs
@@ -5,7 +5,7 @@ using Uno.Extensions.Markup.Internals;
 
 namespace Uno.Toolkit.UI.Markup;
 
-public static partial class Theme
+public static partial class ToolkitTheme
 {
 	public static partial class TabBarItem
 	{


### PR DESCRIPTION
BREAKING CHANGE: Avoid conflicts with Themes Markup library Theme class

closes: https://github.com/unoplatform/uno.toolkit.ui/issues/1087

