### PR TITLE
feat: added inputextensions returntype property

### DIFF
--- a/doc/helpers/Input-extensions.md
+++ b/doc/helpers/Input-extensions.md
@@ -8,12 +8,12 @@ Provides various attached properties for _input controls_, such as `TextBox` and
 
 ## Attached Properties
 
-| Property               | Type         | Description                                                                                                                       |
-|------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `AutoDismiss`          | `bool`       | Whether the soft keyboard will be dismissed when the enter key is pressed.                                                        |
-| `AutoFocusNext`        | `bool`       | Whether the focus will move to the next focusable element when the enter key is pressed.\*                                        |
-| `AutoFocusNextElement` | `Control`    | Sets the next control to focus when the enter key is pressed.\*                                                                   |
-| `ReturnType`           | `ReturnType` | The type of return button on a soft keyboard. It can be one of the following options: __Default, Done, Go, Next, Search, Send__.  |
+| Property               | Type         | Description                                                                                                                                       |
+|------------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `AutoDismiss`          | `bool`       | Whether the soft keyboard will be dismissed when the enter key is pressed.                                                                        |
+| `AutoFocusNext`        | `bool`       | Whether the focus will move to the next focusable element when the enter key is pressed.\*                                                        |
+| `AutoFocusNextElement` | `Control`    | Sets the next control to focus when the enter key is pressed.\*                                                                                   |
+| `ReturnType`           | `ReturnType` | The type of return button on a soft keyboard for Android/iOS. It can be one of the following options: __Default, Done, Go, Next, Search, Send__.  |
 
 `AutoFocusNext` and `AutoFocusNextElement`\*: Having either or both of the two properties set will enable the focus next behavior. `AutoFocusNextElement` will take precedence over `AutoFocusNext` when both are set.
 

--- a/doc/helpers/Input-extensions.md
+++ b/doc/helpers/Input-extensions.md
@@ -8,13 +8,14 @@ Provides various attached properties for _input controls_, such as `TextBox` and
 
 ## Attached Properties
 
-| Property               | Type      | Description                                                                                |
-|------------------------|-----------|--------------------------------------------------------------------------------------------|
-| `AutoDismiss`          | `bool`    | Whether the soft-keyboard will be dismissed when the enter key is pressed.                 |
-| `AutoFocusNext`        | `bool`    | Whether the focus will move to the next focusable element when the enter key is pressed.\* |
-| `AutoFocusNextElement` | `Control` | Sets the next control to focus when the enter key is pressed.\*                            |
+| Property               | Type         | Description                                                                                                                       |
+|------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `AutoDismiss`          | `bool`       | Whether the soft keyboard will be dismissed when the enter key is pressed.                                                        |
+| `AutoFocusNext`        | `bool`       | Whether the focus will move to the next focusable element when the enter key is pressed.\*                                        |
+| `AutoFocusNextElement` | `Control`    | Sets the next control to focus when the enter key is pressed.\*                                                                   |
+| `ReturnType`           | `ReturnType` | The type of return button on a soft keyboard. It can be one of the following options: __Default, Done, Go, Next, Search, Send__.  |
 
-`AutoFocusNext` and `AutoFocusNextElement`\*: Having either or both of the two properties set will enable the focus next behavior. `AutoFocusNextElement` will take precedences over `AutoFocusNext` when both are set.
+`AutoFocusNext` and `AutoFocusNextElement`\*: Having either or both of the two properties set will enable the focus next behavior. `AutoFocusNextElement` will take precedence over `AutoFocusNext` when both are set.
 
 ### Remarks
 
@@ -35,6 +36,9 @@ xmlns:utu="using:Uno.Toolkit.UI"
 <TextBox x:Name="Input3" utu:InputExtensions.AutoFocusNextElement="{Binding ElementName=Input1}" />
 <TextBox x:Name="Input4" utu:InputExtensions.AutoFocusNextElement="{Binding ElementName=Input3}" />
 
-<!-- Dismiss soft-keyboard on enter -->
+<!-- Dismiss soft keyboard on enter -->
 <TextBox utu:InputExtensions.AutoDismiss="True" />
+
+<!-- Soft keyboard with send as return button -->
+<TextBox utu:InputExtensions.ReturnType="Send" />
 ```

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/InputExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/InputExtensionsSamplePage.xaml
@@ -31,8 +31,18 @@
 						</StackPanel>
 
 						<StackPanel Spacing="8">
-							<TextBlock Text="Dismiss soft-keyboard on enter" />
+							<TextBlock Text="Dismiss soft keyboard on enter" />
 							<TextBox utu:InputExtensions.AutoDismiss="True" />
+						</StackPanel>
+
+						<StackPanel Spacing="8">
+							<TextBlock Text="Soft keyboards of different return types" />
+							<TextBox Text="Default" utu:InputExtensions.ReturnType="Default" />
+							<TextBox Text="Done" utu:InputExtensions.ReturnType="Done" />
+							<TextBox Text="Go" utu:InputExtensions.ReturnType="Go" />
+							<TextBox Text="Next" utu:InputExtensions.ReturnType="Next" />
+							<TextBox Text="Search" utu:InputExtensions.ReturnType="Search" />
+							<TextBox Text="Send" utu:InputExtensions.ReturnType="Send" />
 						</StackPanel>
 
 					</StackPanel>

--- a/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
@@ -143,27 +143,31 @@ namespace Uno.Toolkit.UI
 
 		private static void OnReturnTypeChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
 		{
-			if (sender is Control control && (sender is TextBox || sender is PasswordBox) && e.NewValue is ReturnType returnType)
+			if (sender is TextBox || sender is PasswordBox)
 			{
+				if (e.NewValue is not ReturnType returnType)
+				{
+					returnType = ReturnType.Default;
+				}
 #if __ANDROID__
 				ImeAction imeAction = GetImeActionFromReturnType(returnType);
 
-				if (control is TextBox textBox)
+				if (sender is TextBox textBox)
 				{
 					textBox.ImeOptions = imeAction;
 				}
-				else if (control is PasswordBox passwordBox)
+				else if (sender is PasswordBox passwordBox)
 				{
 					passwordBox.ImeOptions = imeAction;
 				}
 #elif __IOS__
 				UIReturnKeyType returnKeyType = GetReturnKeyTypeFromReturnType(returnType);
 
-				if (control is TextBox textBox)
+				if (sender is TextBox textBox)
 				{
 					textBox.ReturnKeyType = returnKeyType;
 				}
-				else if (control is PasswordBox passwordBox)
+				else if (sender is PasswordBox passwordBox)
 				{
 					passwordBox.ReturnKeyType = returnKeyType;
 				}
@@ -241,35 +245,27 @@ namespace Uno.Toolkit.UI
 		}
 
 #if __ANDROID__
-		private static ImeAction GetImeActionFromReturnType(ReturnType returnType)
+		private static ImeAction GetImeActionFromReturnType(ReturnType returnType) => returnType switch
 		{
-			switch (returnType)
-			{
-				case ReturnType.Next: return ImeAction.Next;
-				case ReturnType.Go: return ImeAction.Go;
-				case ReturnType.Search: return ImeAction.Search;
-				case ReturnType.Send: return ImeAction.Send;
-				case ReturnType.Done: return ImeAction.Done;
-				case ReturnType.Default:
-				default: return ImeAction.Unspecified;
-			}
-		}
+			ReturnType.Next => ImeAction.Next,
+			ReturnType.Go => ImeAction.Go,
+			ReturnType.Search => ImeAction.Search,
+			ReturnType.Send => ImeAction.Send,
+			ReturnType.Done => ImeAction.Done,
+			ReturnType.Default or _ => ImeAction.Unspecified
+		};
 #endif
 
 #if __IOS__
-		private static UIReturnKeyType GetReturnKeyTypeFromReturnType(ReturnType returnType)
+		private static UIReturnKeyType GetReturnKeyTypeFromReturnType(ReturnType returnType) => returnType switch
 		{
-			switch (returnType)
-			{
-			    case ReturnType.Next: return UIReturnKeyType.Next;
-				case ReturnType.Go: return UIReturnKeyType.Go;
-				case ReturnType.Search: return UIReturnKeyType.Search;
-				case ReturnType.Send: return UIReturnKeyType.Send;
-				case ReturnType.Done: return UIReturnKeyType.Done;
-				case ReturnType.Default:
-				default: return UIReturnKeyType.Default;
-			}
-		}
+			ReturnType.Next => UIReturnKeyType.Next,
+			ReturnType.Go => UIReturnKeyType.Go,
+			ReturnType.Search => UIReturnKeyType.Search,
+			ReturnType.Send => UIReturnKeyType.Send,
+			ReturnType.Done => UIReturnKeyType.Done,
+			ReturnType.Default or _ => UIReturnKeyType.Default
+		};
 #endif
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1119 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature
- Small sample 
- Documentation addition

## What is the current behavior?

We have to specify `android:ImeOptions="Next"` and `ios:ReturnKeyType="Next"` if we want the return key on soft-keyboards to be Next.

## What is the new behavior?

We only have to add `utu:InputExtensions.ReturnType="Next"` and Toolkit will handle the device specific cases itself.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [x] UWP
	- [x] WinUI
	- [ ] iOS
	- [x] Android
	- [x] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [x] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
