### PR TITLE
fix: selecteditem logic when itemssource is not tabbaritem

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
@@ -90,6 +90,23 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		}
 
 		[TestMethod]
+		public async Task SetSelectedItem_SimpleSource()
+		{
+			var source = Enumerable.Range(0, 3).ToArray();
+			var SUT = new TabBar
+			{
+				ItemsSource = source,
+				SelectedItem = 1,
+			};
+
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			Assert.AreEqual(source[1], SUT.SelectedItem);
+			Assert.AreEqual(1, SUT.SelectedIndex);
+		}
+
+		[TestMethod]
 		public async Task SetSelectedIndex()
 		{
 			var source = Enumerable.Range(0, 3).Select(x => new TabBarItem { Content = x }).ToArray();

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
@@ -99,7 +99,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 				SelectedItem = 1,
 			};
 
-
 			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
 
 			Assert.AreEqual(source[1], SUT.SelectedItem);

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
@@ -234,7 +234,7 @@ namespace Uno.Toolkit.UI
 				return;
 			}
 
-			var newlySelectedItem = SelectedItem as TabBarItem;
+			var newlySelectedItem = this.FindContainer<TabBarItem>(SelectedItem);
 			if (!IsReady && newlySelectedItem != null)
 			{
 				return;


### PR DESCRIPTION
Fix for case when you are using an ItemsSource that is not a source of TabBarItem directly. 

Setting the SelectedItem would not work previously