### PR TITLE
Prevent AutoLayout from causing an invalidation loop on WinUI

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -503,7 +503,7 @@ internal class AutoLayoutTest
 
 		var border2 = new Border()
 		{
-			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Background = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
 			MaxHeight = 100,
 			MaxWidth = 100,
 		};
@@ -547,7 +547,7 @@ internal class AutoLayoutTest
 
 		var border2 = new Border()
 		{
-			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255)),
+			Background = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
 			MinHeight = 25,
 		};
 

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Properties.cs
@@ -96,7 +96,7 @@ partial class AutoLayout
 		"PrimaryAlignment",
 		typeof(AutoLayoutPrimaryAlignment),
 		typeof(AutoLayout),
-		new PropertyMetadata(default(AutoLayoutPrimaryAlignment), propertyChangedCallback: InvalidateArrangeCallback));
+		new PropertyMetadata(default(AutoLayoutPrimaryAlignment), propertyChangedCallback: InvalidateParentAutoLayoutArrangeCallback));
 
 	[DynamicDependency(nameof(GetPrimaryAlignment))]
 	public static void SetPrimaryAlignment(DependencyObject element, AutoLayoutPrimaryAlignment value)
@@ -116,7 +116,7 @@ partial class AutoLayout
         "CounterAlignment",
 		typeof(AutoLayoutAlignment),
 		typeof(AutoLayout),
-		new PropertyMetadata(default(AutoLayoutAlignment), propertyChangedCallback: InvalidateArrangeCallback));
+		new PropertyMetadata(default(AutoLayoutAlignment), propertyChangedCallback: InvalidateParentAutoLayoutArrangeCallback));
 
 	[DynamicDependency(nameof(GetCounterAlignment))]
 	public static void SetCounterAlignment(DependencyObject element, AutoLayoutAlignment value)
@@ -203,6 +203,13 @@ partial class AutoLayout
 		if (d is UIElement element)
 		{
 			element.InvalidateArrange();
+		}
+	}
+	private static void InvalidateParentAutoLayoutArrangeCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	{
+		if (d is FrameworkElement { Parent: AutoLayout al })
+		{
+			al.InvalidateArrange();
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno.toolkit.ui/issues/1131

# Bugfix

## What is the current behavior?
In some situations, it was possible to crash the UI in WinUI, launching an invalidation loop.

## What is the new behavior?
Now works properly on both WinUI and Uno. Child elements are not remeasured during arrange phase, we're just using their desired size to layout them.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [X] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
	- [X] Skia
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [X] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
