### PR TITLE
feat: CommandExtensions.Command on any control

### DIFF
--- a/doc/helpers/command-extensions.md
+++ b/doc/helpers/command-extensions.md
@@ -10,7 +10,7 @@ Provides Command/CommandParameter attached properties for common scenarios.
 
 | Property           | Type       | Description                                                     |
 |--------------------|------------|-----------------------------------------------------------------|
-| `Command`          | `ICommand` | Sets the command to execute when interacted with the control.\* |
+| `Command`          | `ICommand` | Sets the command to execute when interacting with the control.\* |
 | `CommandParameter` | `object`   | Sets the parameter to pass to the Command property.             |
 
 ### Remarks
@@ -19,7 +19,7 @@ Provides Command/CommandParameter attached properties for common scenarios.
   - `ListViewBase.ItemClick`
   - `NavigationView.ItemInvoked`
   - `ItemsRepeater` item tapped
-  - `TextBox` and `PasswordBox` when Enter key is pressed
+  - `TextBox` and `PasswordBox` when the Enter key is pressed
   - any `UIElement` tapped
 - For Command, the relevant parameter is also provided for the `CanExecute` and `Execute` call:
   > Unless CommandParameter is set, which replaces the following.
@@ -28,7 +28,7 @@ Provides Command/CommandParameter attached properties for common scenarios.
   - `ItemClickEventArgs.ClickedItem` from `ListView.ItemClick`
   - `NavigationViewItemInvokedEventArgs.InvokedItem` from `NavigationView.ItemInvoked`
   - `ItemsRepeater`'s item root's DataContext
-- Command on `TextBox`/`PasswordBox`\*: Having this set will also cause the keyboard dismiss on enter.
+- Command on `TextBox`/`PasswordBox`\*: Having this set will also cause the keyboard to dismiss on enter.
 - Command on `ListView`\*: [`IsItemClickEnabled`](https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase.isitemclickenabled) must also be set to true for this to work.
 
 ## Usage

--- a/doc/helpers/command-extensions.md
+++ b/doc/helpers/command-extensions.md
@@ -8,16 +8,19 @@ Provides Command/CommandParameter attached properties for common scenarios.
 
 ## Attached Properties
 
-| Property           | Type       | Description                                                                                                                                                             |
-|--------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Command`          | `ICommand` | Sets the command to execute when `TextBox`/`PasswordBox` enter key is pressed, `ListViewBase.ItemClick`, `NavigationView.ItemInvoked`, and `ItemsRepeater` item tapped. |
-| `CommandParameter` | `object` | Sets the parameter to pass to the Command property.                                                                                                                     |
-
-Command on `TextBox`/`PasswordBox`\*: Having this set will also cause the keyboard dismiss on enter.
-Command on `ListView`\*: [`IsItemClickEnabled`](https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase.isitemclickenabled) must also be set to true for this to work.
+| Property           | Type       | Description                                                     |
+|--------------------|------------|-----------------------------------------------------------------|
+| `Command`          | `ICommand` | Sets the command to execute when interacted with the control.\* |
+| `CommandParameter` | `object`   | Sets the parameter to pass to the Command property.             |
 
 ### Remarks
 
+- `Command` is executed on:
+  - `ListViewBase.ItemClick`
+  - `NavigationView.ItemInvoked`
+  - `ItemsRepeater` item tapped
+  - `TextBox` and `PasswordBox` when Enter key is pressed
+  - any `UIElement` tapped
 - For Command, the relevant parameter is also provided for the `CanExecute` and `Execute` call:
   > Unless CommandParameter is set, which replaces the following.
   - `TextBox.Text`
@@ -25,6 +28,8 @@ Command on `ListView`\*: [`IsItemClickEnabled`](https://learn.microsoft.com/uwp/
   - `ItemClickEventArgs.ClickedItem` from `ListView.ItemClick`
   - `NavigationViewItemInvokedEventArgs.InvokedItem` from `NavigationView.ItemInvoked`
   - `ItemsRepeater`'s item root's DataContext
+- Command on `TextBox`/`PasswordBox`\*: Having this set will also cause the keyboard dismiss on enter.
+- Command on `ListView`\*: [`IsItemClickEnabled`](https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase.isitemclickenabled) must also be set to true for this to work.
 
 ## Usage
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml
@@ -47,7 +47,7 @@
 
 						<!-- NavigationView[Command] example -->
 						<StackPanel>
-							<TextBlock Text="- NavigationView item invoke" />
+							<TextBlock Text="- NavigationView item invoke:" />
 							<TextBlock Text="{Binding NavigationDebugText}" />
 							<NavigationView utu:CommandExtensions.Command="{Binding DebugNavigationCommand}">
 								<NavigationView.MenuItems>
@@ -60,7 +60,7 @@
 
 						<!-- ItemsRepeater[Command] example -->
 						<StackPanel>
-							<TextBlock Text="- ItemsRepeater item tapped" />
+							<TextBlock Text="- ItemsRepeater item tapped:" />
 							<TextBlock Text="{Binding ItemsRepeaterDebugText}" />
 							<muxc:ItemsRepeater ItemsSource="123" utu:CommandExtensions.Command="{Binding DebugItemsRepeaterCommand}">
 								<muxc:ItemsRepeater.ItemTemplate>
@@ -76,6 +76,25 @@
 								</muxc:ItemsRepeater.ItemTemplate>
 							</muxc:ItemsRepeater>
 						</StackPanel>
+
+						<!-- UIElement[Command] example -->
+						<StackPanel>
+							<TextBlock Text="- any UIElement tapped:" />
+							<TextBlock Text="{Binding ElementDebugText}" />
+
+							<StackPanel Spacing="5">
+								<TextBlock Text="TextBlock"
+										   utu:CommandExtensions.Command="{Binding DebugElementTappedCommand}"
+										   utu:CommandExtensions.CommandParameter="TextBlock"
+										   HorizontalAlignment="Center" />
+								<Grid Background="SkyBlue"
+									  Width="50"
+									  Height="50"
+									  utu:CommandExtensions.Command="{Binding DebugElementTappedCommand}"
+									  utu:CommandExtensions.CommandParameter="Grid" />
+							</StackPanel>
+						</StackPanel>
+
 					</StackPanel>
 				</DataTemplate>
 			</sample:SamplePageLayout.DesignAgnosticTemplate>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml.cs
@@ -29,16 +29,19 @@ namespace Uno.Toolkit.Samples.Content.Controls
 			public string SelectionDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string NavigationDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string ItemsRepeaterDebugText { get => GetProperty<string>(); set => SetProperty(value); }
+			public string ElementDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 
 			public ICommand DebugInputCommand => new Command(DebugInput);
 			public ICommand DebugSelectionCommand => new Command(DebugSelection);
 			public ICommand DebugNavigationCommand => new Command(DebugNavigation);
 			public ICommand DebugItemsRepeaterCommand => new Command(DebugItemsRepeater);
+			public ICommand DebugElementTappedCommand => new Command(DebugElement);
 
 			private void DebugInput(object parameter) => InputDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugSelection(object parameter) => SelectionDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugNavigation(object parameter) => NavigationDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugItemsRepeater(object parameter) => ItemsRepeaterDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
+			private void DebugElement(object parameter) => ElementDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
@@ -108,6 +108,14 @@ namespace Uno.Toolkit.UI
 					nv.ItemInvoked += OnNavigationViewItemInvoked;
 				}
 			}
+			else if (sender is UIElement uie)
+			{
+				uie.Tapped -= OnUIElementTapped;
+				if (GetCommand(sender) is { } command)
+				{
+					uie.Tapped += OnUIElementTapped;
+				}
+			}
 			else
 			{
 				if (_logger.IsEnabled(LogLevel.Warning))
@@ -136,10 +144,15 @@ namespace Uno.Toolkit.UI
 
 			TryInvokeCommand(host, GetCommandParameter(host) ?? e.ClickedItem);
 		}
-
 		private static void OnNavigationViewItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs e)
 		{
 			TryInvokeCommand(sender, GetCommandParameter(sender) ?? e.InvokedItem);
+		}
+		private static void OnUIElementTapped(object sender, TappedRoutedEventArgs e)
+		{
+			if (sender is not  UIElement host) return;
+
+			TryInvokeCommand(host, GetCommandParameter(host) ?? host);
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
@@ -150,7 +150,7 @@ namespace Uno.Toolkit.UI
 		}
 		private static void OnUIElementTapped(object sender, TappedRoutedEventArgs e)
 		{
-			if (sender is not  UIElement host) return;
+			if (sender is not UIElement host) return;
 
 			TryInvokeCommand(host, GetCommandParameter(host) ?? host);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): #1140

## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
CommandExtensions.Command only supports a limited set of controls

## What is the new behavior?
It is now supported on any UIElement.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
	- [x] Skia
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [x] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.