### PR TITLE
fix(splash): apply workaround for layered background bug

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.xaml
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.xaml
@@ -3,8 +3,8 @@
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:utu="using:Uno.Toolkit.UI"
-					mc:Ignorable="d">
-
+					xmlns:void="used for quickly commenting out node or attribute"
+					mc:Ignorable="d void">
 
 	<ResourceDictionary.ThemeDictionaries>
 		<ResourceDictionary x:Key="Dark">
@@ -14,8 +14,6 @@
 			<x:String x:Key="DefaultExtendedSplashScreenAnimationDuration">00:00:00.083</x:String>
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
-
-
 
 	<Style x:Key="DefaultExtendedSplashScreen"
 		   TargetType="utu:ExtendedSplashScreen">
@@ -36,8 +34,8 @@
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="LoadingStates">
 								<VisualStateGroup.Transitions>
-									<VisualTransition From="Loading"
-													  To="Loaded">
+									<void:VisualTransition From="Loading" To="Loaded">
+										<!-- uno#16725 woarkaround: disabled due partial opacity not working well with multiple opaque colored layers -->
 										<Storyboard>
 											<DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
 																		   Storyboard.TargetProperty="Opacity">
@@ -55,7 +53,7 @@
 																	  Value="0" />
 											</DoubleAnimationUsingKeyFrames>
 										</Storyboard>
-									</VisualTransition>
+									</void:VisualTransition>
 								</VisualStateGroup.Transitions>
 								<VisualState x:Name="Loading">
 									<VisualState.Setters>
@@ -67,6 +65,10 @@
 									<VisualState.Setters>
 										<Setter Target="ContentPresenter.Opacity"
 												Value="1" />
+										<Setter Target="SplashScreenPresenter.Opacity"
+												Value="0" />
+										<Setter Target="LoadingContentPresenter.Opacity"
+												Value="0" />
 										<Setter Target="SplashScreenPresenter.Content"
 												Value="{x:Null}" />
 										<Setter Target="LoadingContentPresenter.Content"

--- a/src/Uno.Toolkit.UI/Extensions/EnumerableExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/EnumerableExtensions.cs
@@ -71,4 +71,25 @@ internal static class EnumerableExtensions
 		return result;
 	}
 
+	/// <summary>
+	/// ToDictionary that allows for duplicated keys where later ones override previous.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <typeparam name="TKey"></typeparam>
+	/// <typeparam name="TValue"></typeparam>
+	/// <param name="source"></param>
+	/// <param name="keySelector"></param>
+	/// <param name="valueSelector"></param>
+	/// <returns></returns>
+	public static Dictionary<TKey, TValue> ToDictionarySafe<T, TKey, TValue>(this IEnumerable<T> source, Func<T, TKey> keySelector, Func<T, TValue> valueSelector)
+		where TKey : notnull
+	{
+		var dict = new Dictionary<TKey, TValue>();
+		foreach (var element in source)
+		{
+			dict[keySelector(element)] = valueSelector(element);
+		}
+
+		return dict;
+	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno#16725

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
Opacity applied from fade out animation caused multiple colors layers to be displayed in splash screen.

## What is the new behavior?
Workarounded by disabling the animation.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Background existing in both resizetizer generated splashscreen image and in the wrapping grid.