### PR TITLE
fix(responsive): add support for ItemsRepeater.Layout

### DIFF
--- a/doc/helpers/responsive-extension.md
+++ b/doc/helpers/responsive-extension.md
@@ -118,11 +118,14 @@ xmlns:utu="using:Uno.Toolkit.UI"
     <GridLength x:Key="GL150">150</GridLength>
     <SolidColorBrush x:Key="Red">Red</SolidColorBrush>
     <SolidColorBrush x:Key="Green">Green</SolidColorBrush>
-    <SolidColorBrush x:Key="Blue">Blue</SolidColorBrush>
 
 <Grid utu:ResponsiveBehavior.IsEnabled="True">
     <Grid.ColumnDefinitions>
         <ColumnDefinition Width="{utu:Responsive Narrow={StaticResource GL50}, Wide={StaticResource GL150}}" />
+
+<ItemsRepeater utu:ResponsiveBehavior.IsEnabled="True">
+    <ItemsRepeater.Layout>
+        <StackLayout Orientation="{utu:Responsive Narrow=Horizontal, Wide=Horizontal}" />
 
 <TextBlock utu:ResponsiveBehavior.IsEnabled="True">
     <Run Text="asd" Foreground="{utu:Responsive Narrow={StaticResource Red}, Wide={StaticResource Green}}" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Helpers/ResponsiveExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Helpers/ResponsiveExtensionsSamplePage.xaml
@@ -89,6 +89,14 @@
 							</Span>
 						</TextBlock>
 
+						<TextBlock Text="ItemsRepeater.Layout test" />
+						<!-- somewhat related: ItemsControl.ItemPanel is implicitly supported, since the template's panel is a FE -->
+						<ItemsRepeater ItemsSource="{Binding Data.ItemsSource}" utu:ResponsiveBehavior.IsEnabled="True">
+							<ItemsRepeater.Layout>
+								<StackLayout Orientation="{utu:Responsive Narrowest=Vertical, Narrow=Horizontal, Normal=Vertical, Wide=Horizontal,Widest=Vertical}" />
+							</ItemsRepeater.Layout>
+						</ItemsRepeater>
+
 						<!-- layout overriding -->
 						<TextBlock Text="Custom values override" FontWeight="Bold" />
 						<StackPanel>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Helpers/ResponsiveExtensionsSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Helpers/ResponsiveExtensionsSamplePage.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using Uno.Toolkit.Samples.Entities;
+using Uno.Toolkit.Samples.ViewModels;
+
 
 #if IS_WINUI
 using Microsoft.UI.Xaml.Controls;
@@ -8,11 +10,21 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.Toolkit.Samples.Content.Helpers;
 
-[SamplePage(SampleCategory.Helpers, "Responsive Extensions", SourceSdk.UnoToolkit, IconPath = Icons.Helpers.MarkupExtension)]
+[SamplePage(SampleCategory.Helpers, "Responsive Extensions", SourceSdk.UnoToolkit, IconPath = Icons.Helpers.MarkupExtension, DataType = typeof(ViewModel))]
 public sealed partial class ResponsiveExtensionsSamplePage : Page
 {
 	public ResponsiveExtensionsSamplePage()
 	{
 		this.InitializeComponent();
+	}
+
+	private class ViewModel : ViewModelBase
+	{
+		public int[] ItemsSource { get => GetProperty<int[]>(); set => SetProperty(value); }
+
+		public ViewModel()
+		{
+			ItemsSource = new int[] { 1, 2, 3 };
+		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Behaviors/ResponsiveBehavior.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/ResponsiveBehavior.cs
@@ -32,24 +32,19 @@ public static class ResponsiveBehavior
 
 	#endregion
 
-	internal static bool IsChildSupported(DependencyObject? child) => child switch
-	{
-		ColumnDefinition or RowDefinition => true,
-		Inline => true,
-
-		_ => false,
-	};
+	internal static bool IsChildSupported(DependencyObject? child) => child is
+	(
+		ColumnDefinition or RowDefinition or
+		Inline or
+		Microsoft.UI.Xaml.Controls.Layout
+	);
 
 	private static void OnIsEnabledChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
 	{
-		if (sender is Grid g)
-		{
-			g.Loaded += OnGridLoaded;
-		}
-		else if (sender is TextBlock tb)
-		{
-			tb.Loaded += OnTextBlockLoaded;
-		}
+		if (false) { }
+		else if (sender is Grid g) g.Loaded += OnGridLoaded;
+		else if (sender is TextBlock tb) tb.Loaded += OnTextBlockLoaded;
+		else if (sender is ItemsRepeater ir) ir.Loaded += OnItemsRepeaterLoaded;
 		else
 		{
 			throw new NotSupportedException($"ResponsiveBehavior is not supported on '{sender.GetType()}'.");
@@ -82,6 +77,19 @@ public static class ResponsiveBehavior
 			markup.InitializeByProxy(host);
 		}
 	}
+
+	private static void OnItemsRepeaterLoaded(object sender, RoutedEventArgs e)
+	{
+		if (sender is not ItemsRepeater host) return;
+		if (host.Layout is null) return;
+
+		var markups = ResponsiveExtension.GetAllInstancesFor(host.Layout);
+		foreach (var markup in markups)
+		{
+			markup.InitializeByProxy(host);
+		}
+	}
+
 
 	private static IEnumerable<Inline> FlattenInlines(TextBlock tb) => FlattenInlines(tb.Inlines);
 	private static IEnumerable<Inline> FlattenInlines(InlineCollection inlines)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #950

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
ResponsiveExpression now supports ItemsRepeater.Layout

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [x] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.