### PR TITLE
fix(drawer): DrawerControl.IsOpen exceptions

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/DrawerTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/DrawerTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.Extensions;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
+#else
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+internal class DrawerTests
+{
+	[TestMethod]
+#if __IOS__
+	[Ignore("Opacity is not supposed to be modified from non ui-thread")]
+#endif
+	public async Task IsOpen_FromNonUIThread()
+	{
+		var drawer = new DrawerControl
+		{
+			Content = new Grid()
+		};
+
+		// don't wait for loaded, start the task immediately
+		UIHelper.Content = drawer;
+		await Task.Run(async () =>
+		{
+			drawer.IsOpen = true;
+
+			await UIHelper.WaitForLoaded(drawer);
+			await UIHelper.WaitForIdle();
+			await UnitTestUIContentHelperEx.WaitFor(() => drawer.AnimationStoryboard?.GetCurrentState() == ClockState.Stopped);
+
+			drawer.IsOpen = false;
+		});
+
+		// leave time for IsOpen=false (animation or not) to finish (if it doesn't throw)
+		await UIHelper.WaitForIdle();
+		await UnitTestUIContentHelperEx.WaitFor(() => drawer.AnimationStoryboard?.GetCurrentState() == ClockState.Stopped);
+
+		var lightDismissOverlay = drawer.FindFirstDescendant<Border>(x => x.Name == DrawerControl.TemplateParts.LightDismissOverlayName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.LightDismissOverlayName}");
+
+		await UnitTestUIContentHelperEx.WaitFor(
+			() => lightDismissOverlay.Opacity == 0,
+			message: $"Expected lightDismissOverlay.Opacity to be 0, got {lightDismissOverlay.Opacity}");
+	}
+}

--- a/src/Uno.Toolkit.UI/Helpers/DispatcherCompat.cs
+++ b/src/Uno.Toolkit.UI/Helpers/DispatcherCompat.cs
@@ -51,6 +51,8 @@ internal class DispatcherCompat
 		_ => throw new ArgumentOutOfRangeException($"Invalid value: ({priority:d}){priority}"),
 	};
 
+	public bool HasThreadAccess => _impl.HasThreadAccess;
+
 	public void Invoke(_Handler handler) => Invoke(default, handler);
 	public void Invoke(Priority priority, _Handler handler)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.toolkit.ui#1162

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
fixed a couple exceptions related to DrawerControl.IsOpen

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.