### PR TITLE
fix: CommandExtensions warning on Text/PasswordBox

### DIFF
--- a/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
@@ -83,7 +83,7 @@ namespace Uno.Toolkit.UI
 				// for input controls, this will be implemented in InputExtensions.
 				InputExtensions.OnEnterCommandChanged(sender, e);
 			}
-			if (sender is ItemsRepeater ir)
+			else if (sender is ItemsRepeater ir)
 			{
 				ItemsRepeaterExtensions.OnItemCommandChanged(ir, e);
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
non-sense warning being logged erroneously:
> Uno.Toolkit.UI.CommandExtensions: Warning: CommandExtensions.Command is not supported on 'Microsoft.UI.Xaml.Controls.PasswordBox'.

## What is the new behavior?
^ no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.