### PR TITLE
fix(CommandExtensions): parameter resolution & add support for Selector

### DIFF
--- a/doc/helpers/command-extensions.md
+++ b/doc/helpers/command-extensions.md
@@ -8,28 +8,31 @@ Provides Command/CommandParameter attached properties for common scenarios.
 
 ## Attached Properties
 
-| Property           | Type       | Description                                                     |
-|--------------------|------------|-----------------------------------------------------------------|
+| Property           | Type       | Description                                                      |
+|--------------------|------------|------------------------------------------------------------------|
 | `Command`          | `ICommand` | Sets the command to execute when interacting with the control.\* |
-| `CommandParameter` | `object`   | Sets the parameter to pass to the Command property.             |
+| `CommandParameter` | `object`   | Sets the parameter to pass to the Command property.              |
 
 ### Remarks
 
 - `Command` is executed on:
   - `ListViewBase.ItemClick`
+  - `Selector.SelectionChanged` (except for `ListView` which uses `ItemClick`)
   - `NavigationView.ItemInvoked`
   - `ItemsRepeater` item tapped
   - `TextBox` and `PasswordBox` when the Enter key is pressed
   - any `UIElement` tapped
-- For Command, the relevant parameter is also provided for the `CanExecute` and `Execute` call:
-  > Unless CommandParameter is set, which replaces the following.
-  - `TextBox.Text`
-  - `PasswordBox.Password`
+- For `Command`, the relevant parameter is also provided for the `CanExecute` and `Execute` call:
+  > `CommandParameter` can be set, on the item-container or item-template's root for collection-type control, or control itself for other controls, to replace the following.
   - `ItemClickEventArgs.ClickedItem` from `ListView.ItemClick`
+  - `Selector.SelectedItem`
   - `NavigationViewItemInvokedEventArgs.InvokedItem` from `NavigationView.ItemInvoked`
   - `ItemsRepeater`'s item root's DataContext
-- Command on `TextBox`/`PasswordBox`\*: Having this set will also cause the keyboard to dismiss on enter.
-- Command on `ListView`\*: [`IsItemClickEnabled`](https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase.isitemclickenabled) must also be set to true for this to work.
+  - `TextBox.Text`
+  - `PasswordBox.Password`
+  - `UIElement` itself
+- `Command` on `TextBox`/`PasswordBox`\*: Having this set will also cause the keyboard to dismiss on enter.
+- `Command` on `ListView`\*: [`IsItemClickEnabled`](https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase.isitemclickenabled) must also be set to true for this to work.
 
 ## Usage
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml
@@ -27,10 +27,10 @@
 						<!-- ListView[Command] example -->
 						<StackPanel Spacing="8">
 							<TextBlock Text="- ListView item click:" />
-							<TextBlock Text="{Binding SelectionDebugText}" />
+							<TextBlock Text="{Binding ListViewDebugText}" />
 							<ListView ItemsSource="123"
 									  IsItemClickEnabled="True"
-									  utu:CommandExtensions.Command="{Binding DebugSelectionCommand}">
+									  utu:CommandExtensions.Command="{Binding DebugListViewCommand}">
 								<ListView.ItemTemplate>
 									<DataTemplate>
 										<Border BorderThickness="1"
@@ -43,6 +43,21 @@
 									</DataTemplate>
 								</ListView.ItemTemplate>
 							</ListView>
+						</StackPanel>
+
+						<!-- Selector[Command] example -->
+						<StackPanel Spacing="8">
+							<TextBlock Text="- Selector selection changed: (excluding ListView)" />
+							<TextBlock Text="{Binding SelectorDebugText}" />
+							<ComboBox ItemsSource="{Binding Fruits}" utu:CommandExtensions.Command="{Binding DebugSelectorCommand}">
+								<ComboBox.ItemTemplate>
+									<DataTemplate>
+										<TextBlock Text="{Binding}"
+												   Height="30"
+												   utu:CommandExtensions.CommandParameter="asd" />
+									</DataTemplate>
+								</ComboBox.ItemTemplate>
+							</ComboBox>
 						</StackPanel>
 
 						<!-- NavigationView[Command] example -->

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/CommandExtensionsSamplePage.xaml.cs
@@ -25,20 +25,25 @@ namespace Uno.Toolkit.Samples.Content.Controls
 
 		public class CommandExtensionsSamplePageVM : ViewModelBase
 		{
+			public string[] Fruits { get; } = new[] { "Apple", "Banana", "Cactus" };
+
 			public string InputDebugText { get => GetProperty<string>(); set => SetProperty(value); }
-			public string SelectionDebugText { get => GetProperty<string>(); set => SetProperty(value); }
+			public string ListViewDebugText { get => GetProperty<string>(); set => SetProperty(value); }
+			public string SelectorDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string NavigationDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string ItemsRepeaterDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string ElementDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 
 			public ICommand DebugInputCommand => new Command(DebugInput);
-			public ICommand DebugSelectionCommand => new Command(DebugSelection);
+			public ICommand DebugListViewCommand => new Command(DebugListView);
+			public ICommand DebugSelectorCommand => new Command(DebugSelector);
 			public ICommand DebugNavigationCommand => new Command(DebugNavigation);
 			public ICommand DebugItemsRepeaterCommand => new Command(DebugItemsRepeater);
 			public ICommand DebugElementTappedCommand => new Command(DebugElement);
 
 			private void DebugInput(object parameter) => InputDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
-			private void DebugSelection(object parameter) => SelectionDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
+			private void DebugListView(object parameter) => ListViewDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
+			private void DebugSelector(object parameter) => SelectorDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugNavigation(object parameter) => NavigationDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugItemsRepeater(object parameter) => ItemsRepeaterDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugElement(object parameter) => ElementDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");

--- a/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
@@ -46,7 +46,7 @@ namespace Uno.Toolkit.UI
 		///   <item><see cref="ItemsRepeater"/>'s item root's DataContext</item>
 		///   <item><see cref="UIElement"/> itself</item>
 		/// </list>
-		/// <see cref="CommandParameterProperty"/> can be set, on the item-container or item-template's root for collection-type control, or control itself for other controls, to replace the above.
+		/// <see cref="CommandParameterProperty"/> can be set, on the item-container or item-template's root for collection-type controls, or control itself for other controls, to replace the above.
 		/// </remarks>
 		public static DependencyProperty CommandProperty { [DynamicDependency(nameof(GetCommand))] get; } = DependencyProperty.RegisterAttached(
 			"Command",

--- a/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
@@ -13,10 +13,12 @@ using System.Diagnostics.CodeAnalysis;
 #if IS_WINUI
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 #else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
 #endif
@@ -31,7 +33,7 @@ namespace Uno.Toolkit.UI
 
 		/// <summary>
 		/// Backing property for the command to execute when <see cref="TextBox"/>/<see cref="PasswordBox"/> enter key is pressed,
-		/// <see cref="ListViewBase.ItemClick" />, <see cref="NavigationView.ItemInvoked"/>, or <see cref="ItemsRepeater"/> item tapped.
+		/// <see cref="ListViewBase.ItemClick" />, <see cref="Selector.SelectionChanged" />, <see cref="NavigationView.ItemInvoked" />, <see cref="ItemsRepeater" /> item tapped, or <see cref="UIElement.Tapped" />.
 		/// </summary>
 		/// <remarks>
 		/// For Command, the relevant parameter is also provided for the <see cref="ICommand.CanExecute(object)"/> and <see cref="ICommand.Execute(object)"/> call:
@@ -39,10 +41,12 @@ namespace Uno.Toolkit.UI
 		///   <item><see cref="TextBox.Text"/></item>
 		///   <item><see cref="PasswordBox.Password"/></item>
 		///   <item><see cref="ItemClickEventArgs.ClickedItem"/> from <see cref="ListViewBase.ItemClick"/></item>
+		///   <item><see cref="Selector.SelectedItem"/></item>
 		///   <item><see cref="NavigationViewItemInvokedEventArgs.InvokedItem"/> from <see cref="NavigationView.ItemInvoked"/></item>
 		///   <item><see cref="ItemsRepeater"/>'s item root's DataContext</item>
+		///   <item><see cref="UIElement"/> itself</item>
 		/// </list>
-		/// Unless <see cref="CommandParameterProperty"/> is set, which replaces the above.
+		/// <see cref="CommandParameterProperty"/> can be set, on the item-container or item-template's root for collection-type control, or control itself for other controls, to replace the above.
 		/// </remarks>
 		public static DependencyProperty CommandProperty { [DynamicDependency(nameof(GetCommand))] get; } = DependencyProperty.RegisterAttached(
 			"Command",
@@ -100,6 +104,14 @@ namespace Uno.Toolkit.UI
 					lvb.ItemClick += OnListViewItemClick;
 				}
 			}
+			else if (sender is Selector s)
+			{
+				s.SelectionChanged -= OnSelectorSelectionChanged;
+				if (GetCommand(sender) is { } command)
+				{
+					s.SelectionChanged += OnSelectorSelectionChanged;
+				}
+			}
 			else if (sender is NavigationView nv)
 			{
 				nv.ItemInvoked -= OnNavigationViewItemInvoked;
@@ -137,16 +149,54 @@ namespace Uno.Toolkit.UI
 
 			return false;
 		}
+		internal static object? TryGetItemCommandParameter(DependencyObject? container)
+		{
+			if (container is ListViewItem)
+			{
+				// fixme: it doesn't work here, because we came from ListView::ItemClick,
+				// and when that happens the SelectedIndex not yet set.
+				return null;
+			}
+			if (container is { })
+			{
+				// we can have two scenarios here: // where the CommandParameter property can be assigned to
+				// 1. direct (IsItemItsOwnContainerOverride=true) container as items
+				if (GetCommandParameter(container) is { } parameter1)
+				{
+					return parameter1;
+				}
+
+				// 2. root element of item-template
+				if (container is ContentControl && // typically Selector's item-container are all of ContentControl descents: LVI, CBI, LBI...
+					container.GetFirstDescendant<ContentPresenter>(IsTemplateBoundToContent) is { } presenter &&
+					presenter.GetTemplateRoot() is { } root &&
+					GetCommandParameter(root) is { } parameter2)
+				{
+					return parameter2;
+				}
+
+				bool IsTemplateBoundToContent(ContentPresenter presenter) =>
+					presenter.GetBindingExpression(ContentPresenter.ContentProperty) is { ParentBinding.Path.Path: "Content" };
+			}
+
+			return null;
+		}
 
 		private static void OnListViewItemClick(object sender, ItemClickEventArgs e)
 		{
 			if (sender is not ListViewBase host) return;
 
-			TryInvokeCommand(host, GetCommandParameter(host) ?? e.ClickedItem);
+			TryInvokeCommand(host, /*TryGetItemCommandParameter(host.ContainerFromIndex(host.SelectedIndex)) ??*/ e.ClickedItem);
+		}
+		private static void OnSelectorSelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (sender is not Selector host) return;
+
+			TryInvokeCommand(host, TryGetItemCommandParameter(host.ContainerFromIndex(host.SelectedIndex)) ?? host.SelectedItem);
 		}
 		private static void OnNavigationViewItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs e)
 		{
-			TryInvokeCommand(sender, GetCommandParameter(sender) ?? e.InvokedItem);
+			TryInvokeCommand(sender, TryGetItemCommandParameter(e.InvokedItemContainer) ?? e.InvokedItem);
 		}
 		private static void OnUIElementTapped(object sender, TappedRoutedEventArgs e)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
- CommandExtensions.Command is not supported on Selector (except ListView)
- CommandExtensions.CommandParameter resolution for NavigationView and Selector doesnt work on their item-container or item-template's root

## What is the new behavior?
- Command now works on Selector
- CommandParameter now correctly resolves from item-container or item-template's root of NavigationView and Selector (barring ListView)

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [x] Skia
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [x] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->