### PR TITLE
fix: wasm splashscreen exception

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/ExtendedSplashScreenTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ExtendedSplashScreenTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.Extensions;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class ExtendedSplashScreenTests
+{
+	[TestMethod]
+#if __ANDROID__ || __IOS__
+	[Ignore]
+#endif
+	public async Task Smoke_Test()
+	{
+		var host = await ExtendedSplashScreen.GetNativeSplashScreen().ConfigureAwait(false) ?? throw new Exception("Failed to load native splash screen");
+
+#if !__MOBILE__ // ignore native platforms impl: ios,droid,macos
+		var sut = host.FindFirstDescendant<Image>() ?? throw new Exception("Failed to find splash image control");
+		var tcs = new TaskCompletionSource<(bool Success, string? Message)>();
+
+		sut.ImageOpened += (s, e) => tcs.SetResult((Success: true, null));
+		sut.ImageFailed += (s, e) => tcs.SetResult((Success: false, e.ErrorMessage));
+#endif
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(host);
+
+#if !__MOBILE__
+		if (await Task.WhenAny(tcs.Task, Task.Delay(2000)) != tcs.Task)
+			throw new TimeoutException("Timed out waiting on image to load");
+
+		if ((await tcs.Task) is { Success: false, Message: var message })
+			throw new Exception($"Failed to load image: {message}");
+#endif
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Android.cs
@@ -219,7 +219,7 @@ public partial class ExtendedSplashScreen
 		return returnedBitmap;
 	}
 
-	private static Task<FrameworkElement?> GetNativeSplashScreen()
+	internal static Task<FrameworkElement?> GetNativeSplashScreen()
 	{
 		try
 		{

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.iOS.cs
@@ -30,7 +30,7 @@ namespace Uno.Toolkit.UI
 	{
 		public bool SplashIsEnabled => (Platforms & SplashScreenPlatform.iOS) != 0;
 
-		private static Task<FrameworkElement?> GetNativeSplashScreen()
+		internal static Task<FrameworkElement?> GetNativeSplashScreen()
 		{
 			try
 			{

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.macOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.macOS.cs
@@ -11,7 +11,7 @@ namespace Uno.Toolkit.UI;
 
 public partial class ExtendedSplashScreen
 {
-	private static Task<FrameworkElement?> GetNativeSplashScreen()
+	internal static Task<FrameworkElement?> GetNativeSplashScreen()
 	{
 		return Task.FromResult<FrameworkElement?>(null);
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1185

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
wasm splashscreenn should no longer throw

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [x] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
regression from: #1151