### PR TITLE
fix: ResourceExtensions throwing ArgumentException on windows

### DIFF
--- a/src/Uno.Toolkit.UI/Behaviors/ResourceExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/ResourceExtensions.cs
@@ -36,7 +36,11 @@ namespace Uno.Toolkit.UI
 		{
 			if (d is Control control && e.NewValue is ResourceDictionary newResources)
 			{
+#if !HAS_UNO
+				control.Resources = newResources.DeepClone();
+#else
 				control.Resources = newResources;
+#endif
 			}
 		}
 	}

--- a/src/Uno.Toolkit.UI/Extensions/ResourceDictionaryExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/ResourceDictionaryExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+using Uno.Logging;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+#else
+using Windows.UI.Xaml;
+#endif
+
+namespace Uno.Toolkit.UI;
+
+internal static class ResourceDictionaryExtensions
+{
+	private static readonly ILogger _logger = typeof(ResourceDictionaryExtensions).Log();
+
+	/// <summary>
+	/// Creates a deep clone of the given <see cref="ResourceDictionary"/>.
+	/// </summary>
+	/// <param name="rd">The resource dictionary to clone.</param>
+	/// <returns>A deep clone of the resource dictionary.</returns>
+	/// <remarks>Only the resource dictionary, and its nesting theme and merged dictionaries are deep cloned. Not their values.</remarks>
+	public static ResourceDictionary DeepClone(this ResourceDictionary rd)
+	{
+		try
+		{
+			if (rd.Source is not null) return new ResourceDictionary() { Source = rd.Source };
+
+			var result = new ResourceDictionary();
+
+			if (rd.ThemeDictionaries is { })
+			{
+				foreach (var (key, value) in rd.ThemeDictionaries)
+				{
+					result.ThemeDictionaries[key] = (value as ResourceDictionary)?.DeepClone() ?? value;
+				}
+			}
+			if (rd.MergedDictionaries is { })
+			{
+				foreach (var md in rd.MergedDictionaries)
+				{
+					result.MergedDictionaries.Add(md.DeepClone());
+				}
+			}
+			foreach (var (key, value) in rd)
+			{
+				result[key] = value;
+			}
+
+			return result;
+		}
+		catch (Exception e)
+		{
+			_logger.Error("Failed to clone the resource-dictionary", e);
+			throw;
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Extensions/ResourceDictionaryExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/ResourceDictionaryExtensions.cs
@@ -24,7 +24,7 @@ internal static class ResourceDictionaryExtensions
 	/// </summary>
 	/// <param name="rd">The resource dictionary to clone.</param>
 	/// <returns>A deep clone of the resource dictionary.</returns>
-	/// <remarks>Only the resource dictionary, and its nesting theme and merged dictionaries are deep cloned. Not their values.</remarks>
+	/// <remarks>Only the resource dictionary, its nesting theme, and merged dictionaries are deep-cloned. Not their values.</remarks>
 	public static ResourceDictionary DeepClone(this ResourceDictionary rd)
 	{
 		try


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1187

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
ResourceExtensions.Resource no longer throw ArgumentException on windows when re-using the same resource-dictionary, such as when used in style setter.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.