### PR TITLE
fix: FindDependencyProperty AmbiguousMatchException

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/DependencyObjectExtensionTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/DependencyObjectExtensionTests.cs
@@ -15,11 +15,13 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif
 
+using DependencyObjectExtensions = Uno.Toolkit.UI.DependencyObjectExtensions;
+
 namespace Uno.Toolkit.RuntimeTests.Tests;
 
 [TestClass]
 [RunsOnUIThread]
-internal class DependencyObjectExtensionTests
+internal partial class DependencyObjectExtensionTests
 {
 	[TestMethod]
 	public void When_Type_FindDependencyProperty()
@@ -59,5 +61,41 @@ internal class DependencyObjectExtensionTests
 		var dp = new Grid().FindDependencyProperty<int>(nameof(Grid.RowProperty));
 
 		Assert.AreEqual(Grid.RowProperty, dp);
+	}
+
+	[TestMethod]
+	public void When_FindDependencyProperty_Ambiguous()
+	{
+		var dp = DependencyObjectExtensions.FindDependencyPropertyInfo(typeof(Ambiguity), nameof(Ambiguity.SomeValue))
+			?? throw new Exception("FindDependencyPropertyInfo returned null");
+
+		Assert.AreEqual(Ambiguity.SomeValueProperty, dp.Definition);
+		Assert.AreEqual(typeof(int), dp.PropertyType);
+	}
+}
+
+internal partial class DependencyObjectExtensionTests
+{
+	private partial class AmbiguityBase : DependencyObject
+	{
+		public object? SomeValue { get; set; }
+	}
+	private class Ambiguity : AmbiguityBase
+	{
+		#region DependencyProperty: SomeValue
+
+		public static DependencyProperty SomeValueProperty { get; } = DependencyProperty.Register(
+			nameof(SomeValue),
+			typeof(int),
+			typeof(Ambiguity),
+			new PropertyMetadata(default(int)));
+
+		public new int SomeValue
+		{
+			get => (int)GetValue(SomeValueProperty);
+			set => SetValue(SomeValueProperty, value);
+		}
+
+		#endregion
 	}
 }

--- a/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
@@ -232,7 +232,7 @@ namespace Uno.Toolkit.UI
 					if (dpInfo is { } && GetValue(dpInfo) is DependencyProperty dp)
 					{
 						// DeclaredOnly: Specifies flags that control binding and the way in which the search for members and types is conducted by reflection.
-						// because 'dpInfo.DeclaringType' is the guaranteed type, and we don't want a overridden property from a random base to throw AmbiguousMatchException
+						// because 'dpInfo.DeclaringType' is the guaranteed type, and we don't want an overridden property from a random base to throw AmbiguousMatchException
 						// ex: UIElement::Visibility & [droid]UnoViewGroup::Visibility
 						var holderProperty = dpInfo.DeclaringType?.GetProperty(propertyName, Public | NonPublic | Instance | DeclaredOnly);
 						var propertyType =

--- a/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
@@ -231,7 +231,10 @@ namespace Uno.Toolkit.UI
 				{
 					if (dpInfo is { } && GetValue(dpInfo) is DependencyProperty dp)
 					{
-						var holderProperty = dpInfo.DeclaringType?.GetProperty(propertyName, Public | NonPublic | Instance);
+						// DeclaredOnly: Specifies flags that control binding and the way in which the search for members and types is conducted by reflection.
+						// because 'dpInfo.DeclaringType' is the guaranteed type, and we don't want a overridden property from a random base to throw AmbiguousMatchException
+						// ex: UIElement::Visibility & [droid]UnoViewGroup::Visibility
+						var holderProperty = dpInfo.DeclaringType?.GetProperty(propertyName, Public | NonPublic | Instance | DeclaredOnly);
 						var propertyType =
 							holderProperty?.PropertyType ??
 							dpInfo.DeclaringType?.GetMethod($"Get{propertyName}", Public | NonPublic | Static)?.ReturnType ??


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1198

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
FindDependencyProperty on an overridden property throws:
> System.Reflection.AmbiguousMatchException: 'Ambiguous match found for 'Microsoft.UI.Xaml.UIElement Microsoft.UI.Xaml.Visibility Visibility'.'

## What is the new behavior?
^ No more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [x] Skia
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.