### PR TITLE
test: reduce tabbar uitest wait time

### DIFF
--- a/src/Uno.Toolkit.UITest/Controls/TabBar/Given_TabBar.cs
+++ b/src/Uno.Toolkit.UITest/Controls/TabBar/Given_TabBar.cs
@@ -15,7 +15,9 @@ namespace Uno.Toolkit.UITest.Controls.TabBar
 	public class Given_TabBar : TestBase
 	{
 		protected override string SampleName => "TabBar";
-		private string[] _sections = new[] { "Home", "Search", "Support", "About" };
+
+		private static readonly TimeSpan MaxTabBarSwitchTime = TimeSpan.FromSeconds(10);
+		private static readonly string[] Sections = new[] { "Home", "Search", "Support", "About" };
 
 		[Test]
 		[AutoRetry]
@@ -27,10 +29,10 @@ namespace Uno.Toolkit.UITest.Controls.TabBar
 			NavigateToNestedSample("M3MaterialTopBarSampleNestedPage");
 			App.WaitForElementWithMessage("TopTabBar");
 
-			foreach (var section in _sections)
+			foreach (var section in Sections)
 			{
 				App.FastTap($"{TabBarItemPrefix}{section}");
-				App.WaitForElementWithMessage($"{FlipViewItemTextPrefix}{section}", timeout: TimeSpan.FromMinutes(5));
+				App.WaitForElementWithMessage($"{FlipViewItemTextPrefix}{section}", timeout: MaxTabBarSwitchTime);
 			}
 		}
 
@@ -44,10 +46,10 @@ namespace Uno.Toolkit.UITest.Controls.TabBar
 			NavigateToNestedSample("M3MaterialBottomBarSampleNestedPage");
 			App.WaitForElementWithMessage("BottomTabBar");
 
-			foreach (var section in _sections)
+			foreach (var section in Sections)
 			{
 				App.FastTap($"{TabBarItemPrefix}{section}");
-				App.WaitForElementWithMessage($"{FlipViewItemTextPrefix}{section}", timeout: TimeSpan.FromMinutes(5));
+				App.WaitForElementWithMessage($"{FlipViewItemTextPrefix}{section}", timeout: MaxTabBarSwitchTime);
 			}
 		}
 
@@ -61,10 +63,10 @@ namespace Uno.Toolkit.UITest.Controls.TabBar
 			NavigateToNestedSample("M3MaterialVerticalBarSampleNestedPage");
 			App.WaitForElementWithMessage("VerticalTabBar");
 
-			foreach (var section in _sections)
+			foreach (var section in Sections)
 			{
 				App.FastTap($"{TabBarItemPrefix}{section}");
-				App.WaitForElementWithMessage($"{FlipViewItemTextPrefix}{section}", timeout: TimeSpan.FromMinutes(5));
+				App.WaitForElementWithMessage($"{FlipViewItemTextPrefix}{section}", timeout: MaxTabBarSwitchTime);
 			}
 		}
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Build or CI related changes

## What is the current behavior?
## What is the new behavior?
reduce tabbar uitest wait time

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.