### PR TITLE
fix: Get the correct file path

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.crossruntime.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.crossruntime.cs
@@ -255,6 +255,12 @@ namespace Uno.Toolkit.UI
 #pragma warning restore SYSLIB0044 // Type or member is obsolete
 			if (codebase is not null)
 			{
+#if WINDOWS
+				// Need to unescape the path to get the actual path
+				// `codebase` returns a string with 'file:\' as a prefix which prevents the file from being found
+				UriBuilder uri = new UriBuilder(codebase);
+				codebase = Uri.UnescapeDataString(uri.Path);
+#endif
 				var manifestPath = Path.Combine(Path.GetDirectoryName(codebase) ?? string.Empty, fileName);
 				if (File.Exists(manifestPath))
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): #1165

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one ore more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
The url being returned is `file:\C:\C\1165\UnoApp1\UnoApp1\bin\Debug\net8.0-windows10.0.19041\AppxManifest.xml`. When `File.Exist` uses that url, it returns false due to the "file" prefix.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
No "file" prefix.
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:
- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [X] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
