### PR TITLE
fix: wasm itemsrepeater multiselection

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/ItemsRepeaterExtensionTests.ISelectionInfo.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ItemsRepeaterExtensionTests.ISelectionInfo.cs
@@ -107,6 +107,19 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			Assert.IsTrue(AreEqual(ItemsRepeaterExtensions.GetSelectedIndexes(SUT), new[] { 1, 3 }));
 		}
 
+		[TestMethod]
+		public async Task When_Preselected_SelectedItems_With_ISelectionInfo()
+		{
+			var preselectedSource = SelectionSource.Create(4, isPreselected: x => x == 2);
+
+			var SUT = SetupItemsRepeater(preselectedSource, Multiple);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			var selectedItems = ItemsRepeaterExtensions.GetSelectedItems(SUT).OfType<SelectionData>().Select(x => x.Value);
+
+			Assert.IsTrue(AreEqual(selectedItems, new[] { 2 }));
+		}
 
 		// Checks equality of two lists based on values, ignoring order
 		private static bool AreEqual(IEnumerable<int> expected, IEnumerable<int> actual)

--- a/src/Uno.Toolkit.UI/Behaviors/ItemsRepeaterExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/ItemsRepeaterExtensions.cs
@@ -354,23 +354,24 @@ public static partial class ItemsRepeaterExtensions
 
 		SynchronizeDefaultSelection(ir);
 
-#if HAS_UNO_WINUI || __WASM__
-		if (GetSelectionIsvInnerSubscription(ir) is not SerialDisposable isvInnerSubscription) return;
-
-		isvInnerSubscription.Disposable = null;
-		if (ir.ItemsSourceView is { } isv)
+		if (RuntimeInfoHelper.IsBrowser)
 		{
-			isv.CollectionChanged += OnItemsSourceViewCollectionChanged;
-			isvInnerSubscription.Disposable = Disposable.Create(() =>
-				ir.ItemsSourceView.CollectionChanged -= OnItemsSourceViewCollectionChanged
-			);
-		}
+			if (GetSelectionIsvInnerSubscription(ir) is not SerialDisposable isvInnerSubscription) return;
 
-		void OnItemsSourceViewCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-		{
-			SynchronizeDefaultSelection(ir);
+			isvInnerSubscription.Disposable = null;
+			if (ir.ItemsSourceView is { } isv)
+			{
+				isv.CollectionChanged += OnItemsSourceViewCollectionChanged;
+				isvInnerSubscription.Disposable = Disposable.Create(() =>
+					ir.ItemsSourceView.CollectionChanged -= OnItemsSourceViewCollectionChanged
+				);
+			}
+
+			void OnItemsSourceViewCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+			{
+				SynchronizeDefaultSelection(ir);
+			}
 		}
-#endif
 	}
 
 	private static void SynchronizeDefaultSelection(ItemsRepeater ir)

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.crossruntime.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Windows.crossruntime.cs
@@ -41,17 +41,12 @@ namespace Uno.Toolkit.UI
 #if WINDOWS_UWP || WINDOWS
 			Platforms.HasFlag(SplashScreenPlatform.Windows);
 #else
-			Platforms.HasFlag(IsBrowser ? SplashScreenPlatform.WebAssembly : SplashScreenPlatform.Skia);
+			Platforms.HasFlag(RuntimeInfoHelper.IsBrowser ? SplashScreenPlatform.WebAssembly : SplashScreenPlatform.Skia);
 #endif
-
-		private static bool IsBrowser { get; } =
-			// Origin of the value : https://github.com/mono/mono/blob/a65055dbdf280004c56036a5d6dde6bec9e42436/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs#L115
-			RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY")) || // Legacy Value (Bootstrapper 1.2.0-dev.29 or earlier).
-			RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
 
 		internal static async Task<FrameworkElement?> GetNativeSplashScreen()
 		{
-			var (source, background) = IsBrowser
+			var (source, background) = RuntimeInfoHelper.IsBrowser
 				? await LoadSplashScreenFromWasmManifest()
 				: await LoadSplashScreenFromPackageManifest();
 

--- a/src/Uno.Toolkit.UI/Helpers/RuntimeInfoHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/RuntimeInfoHelper.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Uno.Toolkit.UI
+{
+	internal static class RuntimeInfoHelper
+	{
+		public static bool IsBrowser { get; } =
+			// Origin of the value : https://github.com/mono/mono/blob/a65055dbdf280004c56036a5d6dde6bec9e42436/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs#L115
+			RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY")) || // Legacy Value (Bootstrapper 1.2.0-dev.29 or earlier).
+			RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1194 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When setting ItemsRepeater with multiselection and preselected items, they are not part of SelectedItems after creation, so they only appear visually selected but not in the code behind.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

There was a delay between setting the ItemsSource and ItemsSourceView, now we set SelectedItems after the ItemsSourceView.CollectionChanged event is triggered.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [x] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
