### PR TITLE
ci: fail test publish task if file is missing

### DIFF
--- a/build/workflow/stage-uitests-android.yml
+++ b/build/workflow/stage-uitests-android.yml
@@ -73,6 +73,7 @@
       testResultsFormat: 'NUnit'
       testResultsFiles: $(build.sourcesdirectory)/build/$(UNO_TEST_RESULTS_FILE_NAME)
       failTaskOnFailedTests: true
+      failTaskOnMissingResultsFile: true
 
   - task: PublishBuildArtifacts@1
     condition: always()

--- a/build/workflow/stage-uitests-ios.yml
+++ b/build/workflow/stage-uitests-ios.yml
@@ -64,6 +64,7 @@
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(build.sourcesdirectory)/build/$(UNO_TEST_RESULTS_FILE_NAME)'
       failTaskOnFailedTests: true
+      failTaskOnMissingResultsFile: true
 
   - task: PublishBuildArtifacts@1
     condition: always()

--- a/build/workflow/stage-uitests-wasm.yml
+++ b/build/workflow/stage-uitests-wasm.yml
@@ -62,6 +62,7 @@
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(build.sourcesdirectory)/build/$(UNO_TEST_RESULTS_FILE_NAME)'
       failTaskOnFailedTests: true
+      failTaskOnMissingResultsFile: true
 
   - task: PublishBuildArtifacts@1
     retryCountOnTaskFailure: 3


### PR DESCRIPTION
We should be failing the task of publishing the test results if the results file doesn't exist

This will allow us to catch things like [this](https://github.com/unoplatform/Uno.Gallery/issues/1154) earlier