### PR TITLE
fix: ancestor-binding initial value type incompatibility

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AncestorBindingTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AncestorBindingTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.Extensions;
+using Uno.Toolkit.RuntimeTests.Tests.TestPages;
+
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+internal class AncestorBindingTests
+{
+	[TestMethod]
+	public async Task Ancestor_TopLevel_PageBinding()
+	{
+		var setup = new AncestorBindingTest();
+		await UnitTestUIContentHelperEx.SetContentAndWait(setup);
+
+		var sut = setup.FindFirstDescendant<TextBlock>("TopLevelTextBlock") ?? throw new Exception("Failed to find TopLevelTextBlock");
+		Assert.AreEqual(sut.Text, setup.Tag);
+	}
+
+	[TestMethod]
+	public async Task Ancestor_Nested_PageBinding()
+	{
+		var setup = new AncestorBindingTest();
+		await UnitTestUIContentHelperEx.SetContentAndWait(setup);
+
+		var lv = setup.FindFirstDescendant<ListView>("TopLevelListView") ?? throw new Exception("Failed to find TopLevelListView");
+		var container = lv.ContainerFromIndex(0);
+		var sut = (container as FrameworkElement)?.FindFirstDescendant<TextBlock>("NestedLvTextBlock1") ?? throw new Exception("Failed to find NestedLvTextBlock1");
+
+		Assert.AreEqual(sut.Text, setup.Tag);
+	}
+
+	[TestMethod]
+	public async Task Ancestor_Nested_LvBinding()
+	{
+		var setup = new AncestorBindingTest();
+		await UnitTestUIContentHelperEx.SetContentAndWait(setup);
+
+		var lv = setup.FindFirstDescendant<ListView>("TopLevelListView") ?? throw new Exception("Failed to find TopLevelListView");
+		var container = lv.ContainerFromIndex(0);
+		var sut = (container as FrameworkElement)?.FindFirstDescendant<TextBlock>("NestedLvTextBlock2") ?? throw new Exception("Failed to find NestedLvTextBlock2");
+		Assert.AreEqual(sut.Text, lv.Tag);
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml
@@ -1,0 +1,28 @@
+﻿<Page x:Class="Uno.Toolkit.RuntimeTests.Tests.TestPages.AncestorBindingTest"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.RuntimeTests.Tests.TestPages"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	  Tag="Page Tag">
+
+	<StackPanel>
+		<TextBlock x:Name="TopLevelTextBlock" Text="{utu:AncestorBinding AncestorType=Page, Path=Tag}" />
+
+		<ListView x:Name="TopLevelListView"
+				  ItemsSource="{Binding Items}"
+				  Tag="ListView Tag">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<TextBlock x:Name="NestedLvTextBlock1" Text="{utu:AncestorBinding AncestorType=Page, Path=Tag}" />
+						<TextBlock x:Name="NestedLvTextBlock2" Text="{utu:ItemsControlBindingExtension Path=Tag}" />
+					</StackPanel>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+	</StackPanel>
+</Page>

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests.TestPages;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class AncestorBindingTest : Page
+{
+	public AncestorBindingTest()
+	{
+		this.InitializeComponent();
+		this.DataContext = new
+		{
+			Items = Enumerable.Range(0, 5).Select(x => $"Item {x}").ToArray(),
+		};
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1218, closes #1219

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
AncestorBinding when used on non-reference type dp would cause a COMException. This is due to it returning `null` as initial default value, until the binding came online.

## What is the new behavior?
The current value will now be returned, prevent this COMException.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.