### PR TITLE
fix: increase pixel diff tolerance for flaky test

### DIFF
--- a/src/Uno.Toolkit.UITest/Controls/ShadowContainer/Given_ShadowContainer2.cs
+++ b/src/Uno.Toolkit.UITest/Controls/ShadowContainer/Given_ShadowContainer2.cs
@@ -29,7 +29,7 @@ namespace Uno.Toolkit.UITest.Controls.ShadowContainer
 			using var screenshot2 = TakeScreenshot("reloaded");
 
 			var rect = GetRectangle("shadowContainer");
-			ImageAssert.AreAlmostEqual(screenshot1, screenshot2, rect);
+			ImageAssert.AreAlmostEqual(screenshot1, screenshot2, rect, permittedPixelError: 10);
 		}
 
 		private Rectangle GetRectangle(string marked)


### PR DESCRIPTION
When_Unloaded_Then_Loaded runs, the test sometimes fails because the pixel color diff between the two screenshots comparison is slightly more than the default tolerance of 5