### PR TITLE
chore: fix flaky shadow test

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/TestPages/ShadowContainerTestPage2.WinUI.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/TestPages/ShadowContainerTestPage2.WinUI.xaml
@@ -14,7 +14,7 @@
 		<utu:ShadowContainer x:Name="shadowContainer">
 			<utu:ShadowContainer.Shadows>
 				<utu:ShadowCollection>
-					<utu:Shadow BlurRadius="50" Color="#928F99" Opacity="0.5" />
+					<utu:Shadow  OffsetX="20" OffsetY="20" Color="#00FF00" Opacity="1" />
 				</utu:ShadowCollection>
 			</utu:ShadowContainer.Shadows>
 

--- a/src/Uno.Toolkit.UITest/Controls/ShadowContainer/Given_ShadowContainer2.cs
+++ b/src/Uno.Toolkit.UITest/Controls/ShadowContainer/Given_ShadowContainer2.cs
@@ -19,6 +19,7 @@ namespace Uno.Toolkit.UITest.Controls.ShadowContainer
 		[Test]
 		public void When_Unloaded_Then_Loaded()
 		{
+			App.WaitForElement("shadowContainer");
 			using var screenshot1 = TakeScreenshot("initial");
 
 			var testStatus = App.MarkedAnywhere("testStatus");
@@ -29,7 +30,7 @@ namespace Uno.Toolkit.UITest.Controls.ShadowContainer
 			using var screenshot2 = TakeScreenshot("reloaded");
 
 			var rect = GetRectangle("shadowContainer");
-			ImageAssert.AreAlmostEqual(screenshot1, screenshot2, rect, permittedPixelError: 15);
+			ImageAssert.AreAlmostEqual(screenshot1, screenshot2, rect);
 		}
 
 		private Rectangle GetRectangle(string marked)


### PR DESCRIPTION
Use a fully opaque shadow to compare screenshots with


Before:
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/348b6341-b4fd-4e50-9979-9d27b6655d69">


After:

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/ff7216c6-8e12-4b0b-ac8d-53bf616f7197">
