### PR TITLE
fix: Adjust `NativeFramePresenter` to work with new `TemplatedParent`

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.Android.cs
@@ -45,12 +45,13 @@ namespace Uno.Toolkit.UI
 		public NativeFramePresenter()
 		{
 			_pageStack = this;
+
+			this.Loaded += OnLoaded;
 		}
 
-		protected override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
+		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
-			base.OnTemplatedParentChanged(e);
-			Initialize(TemplatedParent as Frame);
+			Initialize(this.FindFirstParent<Frame>());
 		}
 
 		private void Initialize(Frame? frame)

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeFramePresenter.iOS.cs
@@ -107,12 +107,12 @@ namespace Uno.Toolkit.UI
 			SizeChanged += NativeFramePresenter_SizeChanged;
 			// Hide the NavigationBar by default. Only show if navigating to a Page that contains a NavigationBar.
 			NavigationController.NavigationBarHidden = true;
+			this.Loaded += OnLoaded;
 		}
 
-		protected override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
+		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
-			base.OnTemplatedParentChanged(e);
-			InitializeController(TemplatedParent as Frame);
+			InitializeController(this.FindFirstParent<Frame>());
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/18401

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

`OnTemplatedParentChanged` no longer triggers

## What is the new behavior?

Use `Loaded` event instead

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
