### PR TITLE
feat: add Converter support for AncestorBinding

### DIFF
--- a/doc/helpers/ancestor-itemscontrol-binding.md
+++ b/doc/helpers/ancestor-itemscontrol-binding.md
@@ -20,9 +20,7 @@ This markup extension provides a binding to the closest parent ItemsControl. Thi
 
 ### Properties
 
-| Property   | Type     | Description                     |
-|------------|----------|---------------------------------|
-| `Path`     | `string` | Binding path from the ancestor. |
+> see the Properties section in AncestorBinding.
 
 ### Usage
 
@@ -60,10 +58,13 @@ This markup extension provides a means to bind to an ancestor of a specific type
 
 ### Properties
 
-| Property       | Type     | Description                     |
-|----------------|----------|---------------------------------|
-| `AncestorType` | `Type`   | Type of ancestor to bind from.  |
-| `Path`         | `string` | Binding path from the ancestor. |
+| Property           | Type            | Description                                                                                                                            |
+| ------------------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `AncestorType`     | `Type`          | Type of ancestor to bind from.                                                                                                         |
+| `Path`             | `string`        | Binding path from the ancestor.                                                                                                        |
+| Converter          | IValueConverter | Converter object that is called by the binding engine to modify the data as it is passed between the source and target, or vice versa. |
+| ConverterParameter | object          | Parameter that can be used in the Converter logic.                                                                                     |
+| ConverterLanguage  | string          | value that names the language to pass to any converter specified by the Converter property.                                            |
 
 ### Usage
 

--- a/src/Uno.Toolkit.RuntimeTests/Tests/AncestorBindingTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AncestorBindingTests.cs
@@ -58,4 +58,36 @@ internal class AncestorBindingTests
 		var sut = (container as FrameworkElement)?.GetFirstDescendant<TextBlock>(x => x.Name == "NestedLvTextBlock2") ?? throw new Exception("Failed to find NestedLvTextBlock2");
 		Assert.AreEqual(sut.Text, lv.Tag);
 	}
+
+	[TestMethod]
+	public async Task Ancestor_Converter_InitialValue()
+	{
+		var setup = new AncestorBindingTest();
+		await UnitTestUIContentHelperEx.SetContentAndWait(setup);
+
+		var host = setup.GetFirstDescendantOrThrow<CheckBox>("ConverterTestHost");
+		var sut = setup.GetFirstDescendantOrThrow<Border>("ConverterTestInnerBorder");
+
+		Assert.AreEqual(false, host.IsChecked);
+		Assert.AreEqual(Visibility.Collapsed, sut.Visibility);
+	}
+
+	[TestMethod]
+	public async Task Ancestor_Converter_UpdatedValue()
+	{
+		var setup = new AncestorBindingTest();
+		await UnitTestUIContentHelperEx.SetContentAndWait(setup);
+
+		var host = setup.GetFirstDescendantOrThrow<CheckBox>("ConverterTestHost");
+		var sut = setup.GetFirstDescendantOrThrow<Border>("ConverterTestInnerBorder");
+
+		Assert.AreEqual(false, host.IsChecked);
+		Assert.AreEqual(Visibility.Collapsed, sut.Visibility);
+
+		host.IsChecked = true;
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		Assert.AreEqual(true, host.IsChecked);
+		Assert.AreEqual(Visibility.Visible, sut.Visibility);
+	}
 }

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml
@@ -8,9 +8,29 @@
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 	  Tag="Page Tag">
+	<Page.Resources>
+		<local:AncestorBoolToVisibilityConverter x:Key="AncestorBool2VisConverter" />
+	</Page.Resources>
 
 	<StackPanel>
 		<TextBlock x:Name="TopLevelTextBlock" Text="{utu:AncestorBinding AncestorType=Page, Path=Tag}" />
+		<CheckBox x:Name="ConverterTestHost" IsChecked="False">
+			<StackPanel Orientation="Horizontal"
+						Padding="10"
+						Spacing="10">
+				<Border Background="SkyBlue"
+						Width="40"
+						Height="20" />
+				<Border x:Name="ConverterTestInnerBorder"
+						Background="Pink"
+						Width="40"
+						Height="20"
+						Visibility="{utu:AncestorBinding AncestorType=CheckBox,
+														 Path=IsChecked,
+														 Converter={StaticResource AncestorBool2VisConverter},
+														 ConverterParameter='arg1'}" />
+			</StackPanel>
+		</CheckBox>
 
 		<ListView x:Name="TopLevelListView"
 				  ItemsSource="{Binding Items}"

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml.cs
@@ -1,9 +1,14 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 #if IS_WINUI
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 #else
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
 #endif
 
 namespace Uno.Toolkit.RuntimeTests.Tests.TestPages;
@@ -21,4 +26,15 @@ public sealed partial class AncestorBindingTest : Page
 			Items = Enumerable.Range(0, 5).Select(x => $"Item {x}").ToArray(),
 		};
 	}
+}
+
+public class AncestorBoolToVisibilityConverter : IValueConverter
+{
+	public object Convert(object value, Type targetType, object parameter, string language) =>
+		value as bool? == true
+			? Visibility.Visible
+			: Visibility.Collapsed;
+
+	public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+		throw new NotSupportedException("One-way only");
 }

--- a/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
+++ b/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
@@ -146,6 +146,11 @@ namespace Uno.Toolkit.UI
 			.OfType<T>()
 			.FirstOrDefault(predicate);
 
+		public static T GetFirstDescendantOrThrow<T>(this DependencyObject reference, string name) where T : FrameworkElement => GetDescendants(reference)
+			.OfType<T>()
+			.FirstOrDefault(x => x.Name == name) ??
+			throw new Exception($"Unable to find element: {typeof(T).Name}#{name}");
+
 		/// <summary>
 		/// Returns the first descendant of a specified type that satisfies the <paramref name="predicate"/> whose ancestors (up to <paramref name="reference"/>) satisfy the <paramref name="hierarchyPredicate"/>.
 		/// </summary>

--- a/src/Uno.Toolkit.UI/Markup/AncestorBindingExtension.cs
+++ b/src/Uno.Toolkit.UI/Markup/AncestorBindingExtension.cs
@@ -40,6 +40,21 @@ namespace Uno.Toolkit.UI
 		/// </summary>
 		public Type AncestorType { get; set; } = typeof(object);
 
+		/// <summary>
+		/// Gets or sets the converter object that is called by the binding engine to modify the data as it is passed between the source and target, or vice versa.
+		/// </summary>
+		public IValueConverter? Converter { get; set; }
+
+		/// <summary>
+		/// Gets or sets a parameter that can be used in the Converter logic.
+		/// </summary>
+		public object? ConverterParameter { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value that names the language to pass to any converter specified by the Converter property.
+		/// </summary>
+		public string? ConverterLanguage { get; set; }
+
 		public AncestorBindingExtension()
 		{
 		}
@@ -76,6 +91,9 @@ namespace Uno.Toolkit.UI
 							Path = new PropertyPath(Path),
 							Source = source,
 							Mode = BindingMode.OneWay,
+							Converter = Converter,
+							ConverterLanguage = ConverterLanguage,
+							ConverterParameter = ConverterParameter,
 						};
 						fe.SetBinding(property, binding);
 					}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1283

## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
no Converter support for AncestorBinding

## What is the new behavior?
AncestorBinding now supports Converter, ConverterParameter, ConverterLanguage.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
	- [x] Skia
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [x] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.