### PR TITLE
fix: workaround for tabbar&chip initial selection being discarded

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/ChipGroupTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ChipGroupTests.cs
@@ -266,4 +266,26 @@ internal class ChipGroupTests
 	}
 
 	#endregion
+
+	#region Misc
+
+	[TestMethod]
+	public async Task Initial_Selection()
+	{
+		var setup = XamlHelper.LoadXaml<ChipGroup>("""
+			<utu:ChipGroup>
+				<utu:Chip Content="Uno" IsChecked="True"/>
+				<utu:Chip Content="Deux" />
+				<utu:Chip Content="Three" />
+			</utu:ChipGroup>
+		""");
+		await UnitTestUIContentHelperEx.SetContentAndWait(setup);
+
+		var selected = setup.ContainerFromIndex(0) as Chip ?? throw new Exception("Container#0 not found");
+
+		Assert.AreEqual(selected, setup.SelectedItem, "SelectedItem is expected to be container#0");
+		Assert.AreEqual(true, selected.IsChecked, "Container#0 should be selected");
+	}
+
+	#endregion
 }

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
@@ -34,7 +34,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 {
 	[TestClass]
 	[RunsOnUIThread]
-	internal class TabBarTests
+	internal partial class TabBarTests // test cases
 	{
 		[TestMethod]
 		[DataRow(new int[0], null)]
@@ -278,7 +278,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 				return orientation switch
 				{
 					Orientation.Horizontal => padding[1] + padding[3] + tabBarItem.ActualHeight,
-					Orientation.Vertical =>  padding[0] + padding[2] + tabBarItem.ActualWidth,
+					Orientation.Vertical => padding[0] + padding[2] + tabBarItem.ActualWidth,
 					_ => throw new ArgumentOutOfRangeException(nameof(orientation))
 				};
 			}
@@ -500,7 +500,31 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			// Assert the second item is not selected
 			Assert.AreNotSame(SUT.SelectedItem, source[1]);
 		}
+		
+		[TestMethod]
+		public async Task Initial_Selection()
+		{
+			var setup = XamlHelper.LoadXaml<TabBar>("""
+				<utu:TabBar>
+					<utu:TabBar.Items>
+						<utu:TabBarItem Content="Tab Uno" IsSelected="True"/>
+						<utu:TabBarItem Content="Tab Deux" />
+						<utu:TabBarItem Content="Tab Three" />
+					</utu:TabBar.Items>
+				</utu:TabBar>
+			""");
+			await UnitTestUIContentHelperEx.SetContentAndWait(setup);
 
+			var selected = setup.ContainerFromIndex(0) as TabBarItem ?? throw new Exception("Container#0 not found");
+
+			Assert.AreEqual(0, setup.SelectedIndex, "SelectedIndex is expected to be 0");
+			Assert.AreEqual(selected, setup.SelectedItem, "SelectedItem is expected to be container#0");
+			Assert.AreEqual(true, selected.IsSelected, "Container#0 should be selected");
+		}
+	}
+	
+	internal partial class TabBarTests // supporting classes/methods
+	{
 		private class SelectedIndexTestViewModel : INotifyPropertyChanged
 		{
 			private int _p;

--- a/src/Uno.Toolkit.UI/Extensions/ItemsControlExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/ItemsControlExtensions.cs
@@ -56,6 +56,14 @@ namespace Uno.Toolkit.UI
 		/// <remarks>An empty enumerable will returned if the <see cref="ItemsControl.ItemsPanelRoot"/> and the containers have not been materialized.</remarks>
 		public static IEnumerable<T> GetItemContainers<T>(this ItemsControl itemsControl) =>
 			itemsControl.ItemsPanelRoot?.Children.OfType<T>() ??
+			// #1281 workaround: ItemsPanelRoot would not be resolved until ItemsPanel is loaded,
+			// which will be the case between the ItemsControl::Loaded and ItemsPanel::Loaded.
+			// This is normally not a problem, as the container is typically created after that with ItemsSource.
+			// However, for xaml-defined items, this could cause a problem with initial selection synchronization,
+			// which happens on ItemsControl::Loaded. For this case, we will resort to using ItemsControl::Items.
+			(itemsControl.ItemsSource is null && itemsControl.Items is { }
+				? itemsControl.Items.OfType<T>()
+				: null) ??
 			Enumerable.Empty<T>();
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1281

## PR Type
- Bugfix

## What is the current behavior?
xaml-defined TabBar and ChipGroup initial selection is being discarded.

## What is the new behavior?
^ should no longer happen.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable: skia
- [ ] Updated the documentation as needed: n/a
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
shadowing #1286