### PR TITLE
fix: skia+wasm shadow-container hitbox

### DIFF
--- a/src/Uno.Toolkit.Skia.WinUI/Themes/Generic.xaml
+++ b/src/Uno.Toolkit.Skia.WinUI/Themes/Generic.xaml
@@ -26,6 +26,7 @@
 							VerticalAlignment="{TemplateBinding VerticalAlignment}">
 
 						<Canvas x:Name="PART_Canvas"
+								IsHitTestVisible="False"
 								HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
 								VerticalAlignment="{TemplateBinding VerticalAlignment}"/>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1139, closes #1184

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On skia and wasm, the hitbox of ShadowContainer is much larger than its visual/content (depending on the shadows used), often prevent neighboring elements from receiving pointer events.

## What is the new behavior?
The shadow layer is now `IsHitTestVisible=False`, and no longer interferes with _clickability_ of neighboring elements.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI
	- [x] iOS
	- [x] Android
	- [x] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
from observation, this issue seems to only impact skia and wasm. windows, android and ios are unaffected.
