### PR TITLE
workaround for regressions caused by ItemsPanelRoot resolution timing

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
@@ -195,6 +195,14 @@ namespace Uno.Toolkit.UI
 			UpdateOrientation();
 		}
 
+		internal void OnItemsPanelConnected(TabBarListPanel panel)
+		{
+			System.Diagnostics.Debug.Assert(ItemsPanelRoot != null, "ItemsPanelRoot is expected to be already set in here.");
+
+			SynchronizeInitialSelection();
+			UpdateOrientation();
+		}
+
 		private void OnTabBarItemClick(object sender, RoutedEventArgs e)
 		{
 			if (_isSynchronizingSelection)
@@ -441,7 +449,7 @@ namespace Uno.Toolkit.UI
 			return null;
 		}
 
-		private bool IsReady => _isLoaded && HasItems;
+		private bool IsReady => _isLoaded && HasItems && ItemsPanelRoot is { };
 
 		private bool HasItems => this.GetItems().Any();
 	}

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarListPanel.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarListPanel.cs
@@ -17,6 +17,7 @@ namespace Uno.Toolkit.UI
 {
 	public partial class TabBarListPanel : Panel
 	{
+		#region Orientation
 		public Orientation Orientation
 		{
 			get { return (Orientation)GetValue(OrientationProperty); }
@@ -28,6 +29,20 @@ namespace Uno.Toolkit.UI
 			typeof(Orientation),
 			typeof(TabBarListPanel),
 			new PropertyMetadata(Orientation.Horizontal, (s, e) => ((TabBarListPanel)s).OnPropertyChanged(e)));
+		#endregion
+
+		public TabBarListPanel()
+		{
+			this.Loaded += OnLoaded;
+		}
+
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			var owner = this.FindFirstParent<TabBar>();
+
+			// workaround for #1287 ItemsPanelRoot resolution timing related issue
+			owner?.OnItemsPanelConnected(this);
+		}
 
 		private void OnPropertyChanged(DependencyPropertyChangedEventArgs args)
 		{

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarListPanel.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarListPanel.cs
@@ -17,18 +17,20 @@ namespace Uno.Toolkit.UI
 {
 	public partial class TabBarListPanel : Panel
 	{
-		#region Orientation
-		public Orientation Orientation
-		{
-			get { return (Orientation)GetValue(OrientationProperty); }
-			set { SetValue(OrientationProperty, value); }
-		}
+		#region DependencyProperty: Orientation
 
 		public static DependencyProperty OrientationProperty { get; } = DependencyProperty.Register(
 			nameof(Orientation),
 			typeof(Orientation),
 			typeof(TabBarListPanel),
-			new PropertyMetadata(Orientation.Horizontal, (s, e) => ((TabBarListPanel)s).OnPropertyChanged(e)));
+			new PropertyMetadata(default(Orientation), OnOrientationChanged));
+
+		public Orientation Orientation
+		{
+			get => (Orientation)GetValue(OrientationProperty);
+			set => SetValue(OrientationProperty, value);
+		}
+
 		#endregion
 
 		public TabBarListPanel()
@@ -44,11 +46,11 @@ namespace Uno.Toolkit.UI
 			owner?.OnItemsPanelConnected(this);
 		}
 
-		private void OnPropertyChanged(DependencyPropertyChangedEventArgs args)
+		private static void OnOrientationChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
 		{
-			if (args.Property == OrientationProperty)
+			if (sender is TabBar owner)
 			{
-				InvalidateMeasure();
+				owner.InvalidateMeasure();
 			}
 		}
 
@@ -147,6 +149,6 @@ namespace Uno.Toolkit.UI
 			return finalSize;
 		}
 
-		private bool IsVisible(UIElement x) => x.Visibility == Visibility.Visible;
+		private static bool IsVisible(UIElement x) => x.Visibility == Visibility.Visible;
 	}
 }

--- a/src/Uno.Toolkit.UI/Extensions/ItemsControlExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/ItemsControlExtensions.cs
@@ -56,14 +56,6 @@ namespace Uno.Toolkit.UI
 		/// <remarks>An empty enumerable will returned if the <see cref="ItemsControl.ItemsPanelRoot"/> and the containers have not been materialized.</remarks>
 		public static IEnumerable<T> GetItemContainers<T>(this ItemsControl itemsControl) =>
 			itemsControl.ItemsPanelRoot?.Children.OfType<T>() ??
-			// #1281 workaround: ItemsPanelRoot would not be resolved until ItemsPanel is loaded,
-			// which will be the case between the ItemsControl::Loaded and ItemsPanel::Loaded.
-			// This is normally not a problem, as the container is typically created after that with ItemsSource.
-			// However, for xaml-defined items, this could cause a problem with initial selection synchronization,
-			// which happens on ItemsControl::Loaded. For this case, we will resort to using ItemsControl::Items.
-			(itemsControl.ItemsSource is null && itemsControl.Items is { }
-				? itemsControl.Items.OfType<T>()
-				: null) ??
 			Enumerable.Empty<T>();
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1287, closes #1293

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Various dp handler and initialization method for chips and tabbar are affected by the unavailability of ItemsPanelRoot at during Loaded time.

## What is the new behavior?
These methods are called again when ItemsPanelRoot becomes available.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [x] Skia
- [ ] Updated the documentation as needed:
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.