### PR TITLE
fix: AppBarButton inside NavigationBar keeps rendering on every click

### DIFF
--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/FluentNavigationBarSampleNestedPage1.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/FluentNavigationBarSampleNestedPage1.xaml
@@ -17,6 +17,7 @@
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Content="First Page"
 						   MainCommandMode="Action"
+						   AutomationProperties.AutomationId="FluentPage1NavBar"
 						   Style="{StaticResource DefaultNavigationBar}">
 			<utu:NavigationBar.MainCommand>
 				<AppBarButton Click="NavigateBack"
@@ -42,6 +43,11 @@
 						<BitmapIcon UriSource="ms-appx:///Assets/AppleIcon_Small.png" />
 					</AppBarButton.Icon>
 				</AppBarButton>
+				<AppBarButton Click="NavigateToNextPage"
+							  Label="Page2"
+							  AutomationProperties.AutomationId="FluentPage1NavBarPrimaryCommand3"
+							  Style="{StaticResource DefaultAppBarButtonStyle}"
+							  Icon="Favorite" />
 			</utu:NavigationBar.PrimaryCommands>
 			<utu:NavigationBar.SecondaryCommands>
 				<AppBarButton Command="{Binding Secondary1CountCommand}"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/FluentNavigationBarSampleNestedPage2.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/FluentNavigationBarSampleNestedPage2.xaml
@@ -14,6 +14,7 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Content="Second Page"
+						   AutomationProperties.AutomationId="FluentPage2NavBar"
 						   Style="{StaticResource DefaultNavigationBar}">
 			<utu:NavigationBar.PrimaryCommands>
 				<AppBarButton Label="More"

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -96,8 +96,6 @@ namespace Uno.Toolkit.UI
 					new[] { AppBarButton.LabelProperty },
 					new[] { AppBarButton.IconProperty },
 					new[] { AppBarButton.IconProperty, BitmapIcon.UriSourceProperty },
-					new[] { AppBarButton.IconProperty, IconElement.ForegroundProperty },
-					new[] { AppBarButton.IconProperty, IconElement.ForegroundProperty, SolidColorBrush.ColorProperty },
 					new[] { AppBarButton.ContentProperty },
 					new[] { AppBarButton.ContentProperty, FrameworkElement.VisibilityProperty },
 					new[] { AppBarButton.OpacityProperty },

--- a/src/Uno.Toolkit.UITest/Controls/NavigationBar/Given_NavigationBar.cs
+++ b/src/Uno.Toolkit.UITest/Controls/NavigationBar/Given_NavigationBar.cs
@@ -107,5 +107,19 @@ namespace Uno.Toolkit.UITest.Controls.NavigationBar
 
 			App.WaitForNoElement("M3Page2NavBar", "Timed out waiting for no Page 2 Nav Bar");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void NavBar_AppBarButton_With_Icon_Click()
+		{
+			NavigateToNestedSample("FluentNavigationBarSampleNestedPage");
+
+			PlatformHelpers.On(
+				iOS: () => App.Tap("FluentPage1NavBarPrimaryCommand3"),
+				Android: () => App.Tap("FluentPage1NavBarPrimaryCommand3")
+			);
+
+			App.WaitForElement("FluentPage2NavBar", "Timed out waiting for Page 2 Nav Bar");
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/18506

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In Fluent theme, clicking on an `AppBarButton` inside a `NavigationBar` with any kind of `Icon` set makes it unresponsive. The Click event never fires because the `AppBarButton`'s `Icon` is rendered at every click, since the Color is changing opacity.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

`AppBarButton` click works in both Fluent and Material theme.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [x] iOS
	- [x] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.