### PR TITLE
fix: android maincommand tint

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationAppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationAppBarButtonRenderer.Android.cs
@@ -135,7 +135,7 @@ namespace Uno.Toolkit.UI
 					if (bitmap.UriSource is { } uriSource)
 					{
 						native.NavigationIcon = DrawableHelper.FromUri(uriSource);
-						if (hasIconColor && native.NavigationIcon is { })
+						if (bitmap.ShowAsMonochrome && hasIconColor && native.NavigationIcon is { })
 						{
 							DrawableCompat.SetTint(native.NavigationIcon, (Android.Graphics.Color)foregroundColor);
 						}


### PR DESCRIPTION
GitHub Issue (If applicable): #closes https://github.com/unoplatform/add-private/issues/30

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The MainCommand on Android is being set a tint on-top, making it appear monochrome.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

The MainCommand will appear monochrome if specified in the BitmapIcon.ShowAsMonochrome property.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
