### PR TITLE
fix: primarycommand text theme changing

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -141,36 +141,29 @@ namespace Uno.Toolkit.UI
 			}
 			else
 			{
-				var iconOrContent = element.Icon ?? element.Content;
-				switch (iconOrContent)
+				var iconOrContent = element.Icon ?? element.Content ?? element.Label;
+
+				if (iconOrContent is string || (iconOrContent is FrameworkElement fe && fe.Visibility == Visibility.Visible))
 				{
-					case string text:
+					if (_appBarButtonWrapper is { } wrapper)
+					{
+						wrapper.Child = element;
+
+						// Restore the original parent if any, as we
+						// want the DataContext to flow properly from the
+						// CommandBar.
+						element.SetParent(_elementParent);
+
 						native.SetIcon(null);
-						native.SetActionView(null);
-						native.SetTitle(text);
-						break;
-
-					case FrameworkElement fe:
-						if (fe.Visibility == Visibility.Visible && _appBarButtonWrapper is { } wrapper)
-						{
-							wrapper.Child = element;
-
-							//Restore the original parent if any, as we
-							// want the DataContext to flow properly from the
-							// CommandBar.
-							element.SetParent(_elementParent);
-
-							native.SetIcon(null);
-							native.SetActionView(wrapper);
-							native.SetTitle(null);
-						}
-						break;
-
-					default:
-						native.SetIcon(null);
-						native.SetActionView(null);
+						native.SetActionView(wrapper);
 						native.SetTitle(null);
-						break;
+					}
+				}
+				else
+				{
+					native.SetIcon(null);
+					native.SetActionView(null);
+					native.SetTitle(null);
 				}
 			}
 

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.Android.cs
@@ -135,9 +135,8 @@ namespace Uno.Toolkit.UI
 
 			if (_isInOverflow)
 			{
-				native.SetTitle(null);
 				native.SetActionView(null);
-				native.SetIcon(null);
+				native.SetTitle(null);
 			}
 			else
 			{
@@ -154,18 +153,26 @@ namespace Uno.Toolkit.UI
 						// CommandBar.
 						element.SetParent(_elementParent);
 
-						native.SetIcon(null);
+						if (iconOrContent is string text)
+						{
+							wrapper.Child = (UIElement)native.SetTitle(text);
+						}
+						else
+						{
+							native.SetTitle(null);
+						}
+
 						native.SetActionView(wrapper);
-						native.SetTitle(null);
 					}
 				}
 				else
 				{
-					native.SetIcon(null);
 					native.SetActionView(null);
 					native.SetTitle(null);
 				}
 			}
+
+			native.SetIcon(null);
 
 			// IsEnabled
 			native.SetEnabled(element.IsEnabled);

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/AppBarButtonRenderer.iOS.cs
@@ -117,16 +117,12 @@ namespace Uno.Toolkit.UI
 			var native = Native;
 			var element = Element ?? throw new InvalidOperationException("Element is null.");
 
-			var iconOrContent = element.Icon ?? element.Content;
-			switch (iconOrContent)
-			{
-				case string text:
-					native.Image = null;
-					native.ClearCustomView();
-					native.Title = text;
-					break;
+			var iconOrContent = element.Icon ?? element.Content ?? element.Label;
 
-				case FrameworkElement fe:
+			if (iconOrContent is string || (iconOrContent is FrameworkElement fe && fe.Visibility == Visibility.Visible))
+			{
+				if (_appBarButtonWrapper is { } wrapper)
+				{
 					var currentParent = element.Parent;
 					_appBarButtonWrapper.Child = element;
 
@@ -136,19 +132,19 @@ namespace Uno.Toolkit.UI
 					element.SetParent(currentParent);
 
 					native.Image = null;
-					native.CustomView = fe.Visibility == Visibility.Visible ? _appBarButtonWrapper : null;
+					native.CustomView = _appBarButtonWrapper;
 					// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
 					// We default to an empty string to ensure it is added, in order to support late-bound Content.
-					native.Title = string.Empty;
-					break;
-
-				default:
-					native.Image = null;
-					native.ClearCustomView();
-					// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
-					// We default to an empty string to ensure it is added.
-					native.Title = string.Empty;
-					break;
+					native.Title = iconOrContent is string text ? text : string.Empty;
+				}
+			}
+			else
+			{
+				native.Image = null;
+				native.ClearCustomView();
+				// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
+				// We default to an empty string to ensure it is added.
+				native.Title = string.Empty;
 			}
 
 			// Label


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1341

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

The following code was tested:

```xml
<utu:NavigationBar.PrimaryCommands>
	<AppBarButton Label="More" Style="{StaticResource DefaultAppBarButtonStyle}" />
	<AppBarButton Content="More" Style="{StaticResource DefaultAppBarButtonStyle}" />
</utu:NavigationBar.PrimaryCommands>
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See linked issue for video. PrimaryCommands weren't being invalidated when they only contained text (label or content).

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

Setting the `ActionView` that the PrimaryCommand displays allows them to be invalidated on a theme change.

## Android:

https://github.com/user-attachments/assets/fb28b85b-9a7e-4f1a-9be7-f8c847eb2b67

## iOS:

https://github.com/user-attachments/assets/ec74e15a-a741-4c17-9b27-fb8d55727815

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [x] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
