### PR TITLE
feat: Add BackNavigationToRoot to TabBarItemExtensions

### DIFF
--- a/doc/helpers/TabBarItem-extensions.md
+++ b/doc/helpers/TabBarItem-extensions.md
@@ -15,9 +15,11 @@ Property|Type|Description
 
 `TBIOnClickBehaviors`\*: Specifies the on-click behaviors of `TabBarItem`:
 
-- `BackNavigation`: Find the first `NavigationView` with back stack to back navigate.
-- `ScrollToTop`: Find the first `ListView` or `ScrollViewer` to reset scroll position.
-- `Auto`: All of above.
+- `BackNavigation`: Find the first `NavigationView` with a back stack to navigate back.  
+- `BackNavigationToRoot`: Find the first `NavigationView` and navigate back to the root.  
+- `ScrollToTop`: Find the first `ListView` or `ScrollViewer` to reset the scroll position.  
+- `Auto`: Includes `BackNavigation` and `ScrollToTop`.  
+
 
 `OnClickBehaviorsTarget`\*: The content host which the on-click behavior is applied is either the target itself or one of its descendent (via deep first search) suitable for the behavior. When omitted, the parent of `TabBar` will serve as the target.
 

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarItemExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarItemExtensionsSamplePage.xaml
@@ -39,6 +39,9 @@
 		<Frame x:Name="NestedNestedFrame"
 			   Grid.Row="1"
 			   Visibility="{Binding ElementName=TabBarItem_Frame, Path=IsSelected}" />
+		<Frame x:Name="NestedNestedFrameRoot"
+			   Grid.Row="1"
+			   Visibility="{Binding ElementName=TabBarItem_Frame_ToRoot, Path=IsSelected}" />
 		<Grid Grid.Row="1"
 			  Visibility="{Binding ElementName=TabBarItem_ListView, Path=IsSelected}">
 			<!-- 20items * 200min-height ~= 4000 -->
@@ -64,10 +67,8 @@
 				</ListView.ItemTemplate>
 				<ListView.ItemContainerStyle>
 					<Style TargetType="ListViewItem">
-						<Setter Property="HorizontalAlignment"
-								Value="Stretch" />
-						<Setter Property="HorizontalContentAlignment"
-								Value="Stretch" />
+						<Setter Property="HorizontalAlignment" Value="Stretch" />
+						<Setter Property="HorizontalContentAlignment" Value="Stretch" />
 					</Style>
 				</ListView.ItemContainerStyle>
 			</ListView>
@@ -140,6 +141,10 @@
 							utu:TabBarItemExtensions.OnClickBehaviors="Auto"
 							Content="Frame"
 							IsSelected="True"
+							Style="{StaticResource BottomTabBarItemStyle}" />
+			<utu:TabBarItem x:Name="TabBarItem_Frame_ToRoot"
+							utu:TabBarItemExtensions.OnClickBehaviors="BackNavigationToRoot"
+							Content="Frame to Root"
 							Style="{StaticResource BottomTabBarItemStyle}" />
 			<utu:TabBarItem x:Name="TabBarItem_ListView"
 							utu:TabBarItemExtensions.OnClickBehaviors="Auto"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarItemExtensionsSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/Controls/TabBarItemExtensionsSamplePage.xaml.cs
@@ -21,6 +21,7 @@ namespace Uno.Toolkit.Samples.Content.Controls
 			this.InitializeComponent();
 
 			NestedNestedFrame.Navigate(typeof(TabBarItemExtensions_NestedPage1));
+			NestedNestedFrameRoot.Navigate(typeof(TabBarItemExtensions_Nested_ToRoot1));
 		}
 
 		private void ScrollTop(object sender, RoutedEventArgs e)

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot1.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot1.xaml
@@ -1,0 +1,20 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.TabBarItemExtensions_Nested_ToRoot1"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<ScrollViewer>
+			<StackPanel Spacing="50">
+				<TextBlock Text="Page 1 (Root)"
+						   FontSize="50" />
+				<Button Content="Navigate to Page2"
+						Click="GotoNestedPage2" />
+			</StackPanel>
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot1.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot1.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+	public sealed partial class TabBarItemExtensions_Nested_ToRoot1 : Page
+	{
+		public TabBarItemExtensions_Nested_ToRoot1()
+		{
+			this.InitializeComponent();
+		}
+
+		private void GotoNestedPage2(object sender, RoutedEventArgs e)
+		{
+			Frame.Navigate(typeof(TabBarItemExtensions_Nested_ToRoot2));
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot2.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot2.xaml
@@ -1,0 +1,22 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.TabBarItemExtensions_Nested_ToRoot2"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<ScrollViewer>
+			<StackPanel Spacing="50">
+				<TextBlock Text="Page 2"
+						   FontSize="50" />
+				<Button Content="Navigate to Page3"
+						Click="GotoNestedPage3" />
+				<Button Content="Go Back"
+					Click="GoBack" />
+			</StackPanel>
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot2.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot2.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+	public sealed partial class TabBarItemExtensions_Nested_ToRoot2 : Page
+	{
+		public TabBarItemExtensions_Nested_ToRoot2()
+		{
+			this.InitializeComponent();
+		}
+
+		private void GotoNestedPage3(object sender, RoutedEventArgs e)
+		{
+			Frame.Navigate(typeof(TabBarItemExtensions_Nested_ToRoot3));
+		}
+
+		private void GoBack(object sender, RoutedEventArgs e)
+		{
+			Frame.GoBack();
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot3.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot3.xaml
@@ -1,0 +1,20 @@
+﻿<Page x:Class="Uno.Toolkit.Samples.Content.NestedSamples.TabBarItemExtensions_Nested_ToRoot3"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.NestedSamples"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<ScrollViewer>
+			<StackPanel Spacing="50">
+				<TextBlock Text="Page 3"
+						   FontSize="50" />
+				<Button Content="Go Back"
+						Click="GoBack" />
+			</StackPanel>
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot3.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Content/NestedSamples/TabBarItemExtensions_Nested_ToRoot3.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.NestedSamples
+{
+	public sealed partial class TabBarItemExtensions_Nested_ToRoot3 : Page
+	{
+		public TabBarItemExtensions_Nested_ToRoot3()
+		{
+			this.InitializeComponent();
+		}
+
+		private void GoBack(object sender, RoutedEventArgs e)
+		{
+			Frame.GoBack();
+		}
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.Shared/Uno.Toolkit.Samples.Shared.projitems
@@ -152,6 +152,15 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\TabBarItemExtensions_NestedPage2.xaml.cs">
       <DependentUpon>TabBarItemExtensions_NestedPage2.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\TabBarItemExtensions_Nested_ToRoot3.xaml.cs">
+      <DependentUpon>TabBarItemExtensions_Nested_ToRoot3.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\TabBarItemExtensions_Nested_ToRoot2.xaml.cs">
+      <DependentUpon>TabBarItemExtensions_Nested_ToRoot2.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\NestedSamples\TabBarItemExtensions_Nested_ToRoot1.xaml.cs">
+      <DependentUpon>TabBarItemExtensions_Nested_ToRoot1.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Content\RuntimeTestRunner.xaml.cs">
       <DependentUpon>RuntimeTestRunner.xaml</DependentUpon>
     </Compile>
@@ -428,6 +437,18 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\StatusBarSample_NestedPage2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\TabBarItemExtensions_Nested_ToRoot3.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\TabBarItemExtensions_Nested_ToRoot2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Content\NestedSamples\TabBarItemExtensions_Nested_ToRoot1.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarItemExtensionTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarItemExtensionTests.cs
@@ -10,17 +10,20 @@ using Uno.Toolkit.UI;
 using Uno.UI.RuntimeTests;
 using Uno.Extensions;
 using Uno.Toolkit.RuntimeTests.Extensions;
-using Microsoft.UI.Xaml.Controls;
+
 using Uno.Toolkit.RuntimeTests.Tests.TestPages;
-using Microsoft.UI.Xaml;
+
 using static Uno.Toolkit.UI.TabBarItemExtensions;
-using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
 
 #if IS_WINUI
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Controls;
 #else
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Controls;
 #endif
 
 namespace Uno.Toolkit.RuntimeTests.Tests;

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarItemExtensionTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarItemExtensionTests.cs
@@ -144,7 +144,6 @@ internal partial class TabBarItemExtensionTests
 		var listView = new ListView();
 		listView.ItemsSource = Enumerable.Range(1, 50).Select(i => $"Item {i}");
 
-		// Optional: Add some styling to make the list more scrollable
 		listView.Height = 300;  // Set a fixed height for scrolling
 
 		var tabBarItem = CreateTabBarItem(TBIOnClickBehaviors.ScrollToTop);
@@ -160,31 +159,36 @@ internal partial class TabBarItemExtensionTests
 
 		await UnitTestUIContentHelperEx.SetContentAndWait(root);
 
+		// Get the Y coordinate of the first item before scrolling
+		var yCoorBeforeScroll = GetItemYCoordinate(listView, 0);
+
 		var item50 = listView.Items[49];
 		listView.ScrollIntoView(item50);
 
 		await Task.Delay(_defaultDelayValue);
 
-		// Ensure the item is visible
-		var isItemVisible = IsItemVisible(listView, item50);
-		Assert.IsTrue(isItemVisible);
+		// Get the Y coordinate of the first item after scrolling
+		var yCoorAfterScroll = GetItemYCoordinate(listView, 0);
+
+		// Ensure it scrolled down
+		Assert.AreNotEqual(yCoorBeforeScroll, yCoorAfterScroll);
 
 		tabBarItem.ExecuteTap();
 
 		await Task.Delay(_defaultDelayValue);
 
-		isItemVisible = IsItemVisible(listView, item50);
+		// Get the Y coordinate of the first item after tapping the TabBarItem
+		var yCoorAfterTap = GetItemYCoordinate(listView, 0);
 
-		Assert.IsFalse(isItemVisible);
+		Assert.AreEqual(yCoorBeforeScroll, yCoorAfterTap);
 	}
 #endif
 
 	#region Helper methods
-	private static bool IsItemVisible(ListView list, object item)
-	{
-		var listViewItem = (ListViewItem)list.ContainerFromItem(item);
-		return listViewItem != null;
-	}
+	private static double? GetItemYCoordinate(ListView listView, int itemIndex) =>
+		listView.ContainerFromItem(listView.Items[itemIndex]) is ListViewItem item
+			? item.TransformToVisual(listView).TransformPoint(default).Y
+			: null;
 
 	private Grid CreateGrid()
 	{

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarItemExtensionTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarItemExtensionTests.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+using Uno.Extensions;
+using Uno.Toolkit.RuntimeTests.Extensions;
+using Microsoft.UI.Xaml.Controls;
+using Uno.Toolkit.RuntimeTests.Tests.TestPages;
+using Microsoft.UI.Xaml;
+using static Uno.Toolkit.UI.TabBarItemExtensions;
+using Microsoft.UI.Xaml.Media;
+using Windows.Foundation;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Data;
+#else
+using Windows.UI.Xaml.Data;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+internal partial class TabBarItemExtensionTests
+{
+	private const int _defaultDelayValue = 500;
+	[TestMethod]
+	public async Task When_TabBarItem_NavigatesBackToRoot()
+	{
+		var root = CreateGrid();
+
+		var frame = new Frame();
+
+		var tabBarItem = CreateTabBarItem(TBIOnClickBehaviors.BackNavigationToRoot);
+
+		TabBarItem[] source = [tabBarItem];
+
+		var tabBar = CreateTabBar(source);
+
+		Grid.SetRow(frame, 0);
+		Grid.SetRow(tabBar, 1);
+
+		root.Children.Add(frame);
+		root.Children.Add(tabBar);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+		NavigateToLastPage(frame);
+
+		// Ensure it navigated to the last page
+		Assert.AreEqual(typeof(NavBarSimplePage), frame.Content.GetType());
+
+		tabBarItem.ExecuteTap();
+
+		Assert.AreEqual(typeof(NavBarFirstPage), frame.Content.GetType());
+	}
+
+	[TestMethod]
+	public async Task When_TabBarItem_NavigatesBack()
+	{
+		var root = CreateGrid();
+
+		var frame = new Frame();
+
+		var tabBarItem = CreateTabBarItem(TBIOnClickBehaviors.BackNavigation);
+
+		TabBarItem[] source = [tabBarItem];
+
+		var tabBar = CreateTabBar(source);
+
+		Grid.SetRow(frame, 0);
+		Grid.SetRow(tabBar, 1);
+
+		root.Children.Add(frame);
+		root.Children.Add(tabBar);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+		NavigateToLastPage(frame);
+
+		// Ensure it navigated to the last page
+		Assert.AreEqual(typeof(NavBarSimplePage), frame.Content.GetType());
+
+		tabBarItem.ExecuteTap();
+
+		Assert.AreEqual(typeof(NavBarSecondPage), frame.Content.GetType());
+	}
+
+	[TestMethod]
+	public async Task When_TabBarItem_ScrollToTop_ScrollViewer()
+	{
+		var root = CreateGrid();
+
+		var scrollViewer = new ScrollViewer();
+
+		// Create some content for the ScrollViewer (StackPanel with buttons)
+		var stackPanel = new StackPanel();
+		for (int i = 0; i < 50; i++)
+		{
+			stackPanel.Children.Add(new Button { Content = $"Button {i + 1}" });
+		}
+
+		scrollViewer.Content = stackPanel;
+
+		var tabBarItem = CreateTabBarItem(TBIOnClickBehaviors.ScrollToTop);
+
+		TabBarItem[] source = [tabBarItem];
+
+		var tabBar = CreateTabBar(source);
+
+		Grid.SetRow(scrollViewer, 0);
+		Grid.SetRow(tabBar, 1);
+		root.Children.Add(scrollViewer);
+		root.Children.Add(tabBar);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+		scrollViewer.ChangeView(0, 100, null, false);
+		await Task.Delay(_defaultDelayValue);
+		// Ensure scrolled down
+		Assert.AreEqual(100, scrollViewer.VerticalOffset);
+
+		tabBarItem.ExecuteTap();
+		await Task.Delay(_defaultDelayValue);
+		Assert.AreEqual(0, scrollViewer.VerticalOffset);
+	}
+
+#if __IOS__ || __ANDROID__ || WINDOWS_WINUI
+	[TestMethod]
+	public async Task When_TabBarItem_ScrollToTop_ListView()
+	{
+		var root = CreateGrid();
+
+		// Create a ListView with some items
+		var listView = new ListView();
+		listView.ItemsSource = Enumerable.Range(1, 50).Select(i => $"Item {i}");
+
+		// Optional: Add some styling to make the list more scrollable
+		listView.Height = 300;  // Set a fixed height for scrolling
+
+		var tabBarItem = CreateTabBarItem(TBIOnClickBehaviors.ScrollToTop);
+
+		TabBarItem[] source = [tabBarItem];
+
+		var tabBar = CreateTabBar(source);
+
+		Grid.SetRow(listView, 0);
+		Grid.SetRow(tabBar, 1);
+		root.Children.Add(listView);
+		root.Children.Add(tabBar);
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+		var item50 = listView.Items[49];
+		listView.ScrollIntoView(item50);
+
+		await Task.Delay(_defaultDelayValue);
+
+		// Ensure the item is visible
+		var isItemVisible = IsItemVisible(listView, item50);
+		Assert.IsTrue(isItemVisible);
+
+		tabBarItem.ExecuteTap();
+
+		await Task.Delay(_defaultDelayValue);
+
+		isItemVisible = IsItemVisible(listView, item50);
+
+		Assert.IsFalse(isItemVisible);
+	}
+#endif
+
+	#region Helper methods
+	private static bool IsItemVisible(ListView list, object item)
+	{
+		var listViewItem = (ListViewItem)list.ContainerFromItem(item);
+		return listViewItem != null;
+	}
+
+	private Grid CreateGrid()
+	{
+		var root = new Grid();
+		root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+		root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+		return root;
+	}
+
+	private static TabBarItem CreateTabBarItem(TBIOnClickBehaviors behavior)
+	{
+		var tabBarItem = new TabBarItem()
+		{
+			Content = "Tab 1"
+		};
+
+		SetOnClickBehaviors(tabBarItem, behavior);
+
+		return tabBarItem;
+	}
+
+	private static TabBar CreateTabBar(TabBarItem[] source)
+		=> new()
+			{
+				ItemsSource = source,
+				SelectedIndex = 0
+			};
+
+	private static void NavigateToLastPage(Frame frame)
+	{
+		frame.Navigate(typeof(NavBarFirstPage));
+		frame.Navigate(typeof(NavBarSecondPage));
+		frame.Navigate(typeof(NavBarSimplePage));
+	}
+	#endregion
+}

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarItemExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarItemExtensions.cs
@@ -178,16 +178,12 @@ namespace Uno.Toolkit.UI
 				case ListView lv: ScrollableHelper.SmoothScrollTop(lv); break;
 				case ScrollViewer sv: sv.ChangeView(0, 0, zoomFactor: default, disableAnimation: false); break;
 				case Frame f:
-					if ((onclickBehavior & TBIOnClickBehaviors.BackNavigationToRoot) != 0)
+					if (f.CanGoBack)
 					{
-						while (f.CanGoBack)
+						do
 						{
 							f.GoBack();
-						}
-					}
-					else if (f.CanGoBack)
-					{
-						f.GoBack();
+						} while (f.CanGoBack && onclickBehavior.HasFlag(TBIOnClickBehaviors.BackNavigationToRoot));
 					}
 					break;
 

--- a/src/Uno.Toolkit.UI/Behaviors/TabBarItemExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/TabBarItemExtensions.cs
@@ -41,6 +41,11 @@ namespace Uno.Toolkit.UI
 			ScrollToTop = 1 << 1,
 
 			/// <summary>
+			/// Navigate all the way back to the root page.
+			/// </summary>
+			BackNavigationToRoot = 1 << 2,
+
+			/// <summary>
 			/// All of above.
 			/// </summary>
 			Auto = BackNavigation | ScrollToTop,
@@ -166,11 +171,25 @@ namespace Uno.Toolkit.UI
 					predicate: IsValidContentHost
 				);
 
+			var onclickBehavior = GetOnClickBehaviors(tbi);
+
 			switch (contentHost)
 			{
 				case ListView lv: ScrollableHelper.SmoothScrollTop(lv); break;
 				case ScrollViewer sv: sv.ChangeView(0, 0, zoomFactor: default, disableAnimation: false); break;
-				case Frame f: if (f.CanGoBack) f.GoBack(); break;
+				case Frame f:
+					if ((onclickBehavior & TBIOnClickBehaviors.BackNavigationToRoot) != 0)
+					{
+						while (f.CanGoBack)
+						{
+							f.GoBack();
+						}
+					}
+					else if (f.CanGoBack)
+					{
+						f.GoBack();
+					}
+					break;
 
 				default:
 					Logger.WarnIfEnabled(() => "No suitable content host found in the visual tree.");


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
TabBarItemExtensions - OnClickBehavior doesn't have an option to navigate to the root.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
TabBarItemExtensions - OnClickBehavior now have an option to navigate to the root.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [X] WinUI
	- [X] iOS
	- [X] Android
	- [X] Skia GTK
	- [X] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [X] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->