### PR TITLE
fix: hot reload ios support for navigationbar

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
@@ -52,12 +52,6 @@ namespace Uno.Toolkit.UI
 
 		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
-			if (GetNavBar() is { } navBar)
-			{
-				NavigationBarHelper.SetNavigationBar(navBar, null);
-				NavigationBarHelper.SetNavigationItem(navBar, null);
-			}
-
 			_statusBarSubscription.Disposable = null;
 			_orientationSubscription.Disposable = null;
 			_mainCommandClickHandler.Disposable = null;

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NativeNavigationBarPresenter.iOS.cs
@@ -52,6 +52,12 @@ namespace Uno.Toolkit.UI
 
 		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
+			if (GetNavBar() is { } navBar)
+			{
+				NavigationBarHelper.SetNavigationBar(navBar, null);
+				NavigationBarHelper.SetNavigationItem(navBar, null);
+			}
+
 			_statusBarSubscription.Disposable = null;
 			_orientationSubscription.Disposable = null;
 			_mainCommandClickHandler.Disposable = null;
@@ -60,13 +66,12 @@ namespace Uno.Toolkit.UI
 		partial void OnOwnerChanged()
 		{
 			// TODO: Find a proper way to decide whether a NavigationBar exists on canvas (within Page), or is mapped to the UINavigationController's NavigationBar.
-
 			_mainCommandClickHandler.Disposable = null;
 
 			if (GetNavBar() is { } navBar)
 			{
 				navBar.MainCommand.Click += OnMainCommandClick;
-				
+
 				_mainCommandClickHandler.Disposable = Disposable.Create(() => navBar.MainCommand.Click -= OnMainCommandClick);
 
 				LayoutNativeNavBar(navBar);
@@ -75,6 +80,21 @@ namespace Uno.Toolkit.UI
 
 		private void LayoutNativeNavBar(NavigationBar navBar)
 		{
+			var page = navBar.FindFirstParent<Page>();
+			var parent = page?.Parent as Page;
+			if (page is not null
+				&& parent?.GetType() == page.GetType())
+			{
+				// Support for Hot Reload
+				// On iOS, the current Page instance is retained and its Content is replaced with a new instance of the Page
+				// If we detect that we have fallen into this scenario, hook up the new NavigationBar from within the new Page instance
+				// to the native UINavigationBar and UINavigationItem instances.
+				var vc = parent.FindViewController();
+
+				NavigationBarHelper.SetNavigationItem(navBar, vc.NavigationItem);
+				NavigationBarHelper.SetNavigationBar(navBar, vc.NavigationController?.NavigationBar);
+			}
+
 			if (navBar.TryGetNative<NavigationBar, NavigationBarRenderer, UINavigationBar>(out var nativeBar)
 				&& nativeBar is { })
 			{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarNavigationItemRenderer.iOS.cs
@@ -114,6 +114,9 @@ namespace Uno.Toolkit.UI
 			var native = Native ?? throw new ArgumentNullException(nameof(Native));
 			var element = Element ?? throw new ArgumentNullException(nameof(Element));
 
+			if (!element.IsLoaded)
+				return;
+
 			// Content
 			var content = element.Content;
 

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
@@ -51,12 +51,22 @@ namespace Uno.Toolkit.UI
 #if __IOS__
 			if (element is FrameworkElement fe)
 			{
-				fe.Unloaded += (s, e) => Dispose();
+				fe.Unloaded += OnElementUnloaded;
+				_subscriptions.Add(() => fe.Unloaded -= OnElementUnloaded);
+
 			}
 #endif
 
 			_element = new WeakReference<TElement>(element);
 		}
+
+#if __IOS__
+
+		private void OnElementUnloaded(object sender, RoutedEventArgs e)
+		{
+			Dispose();
+		}
+#endif
 
 		public TElement? Element
 		{

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
@@ -37,6 +37,9 @@ namespace Uno.Toolkit.UI
 			where TNative : class
 	{
 		private CompositeDisposable _subscriptions = new CompositeDisposable();
+#if __IOS__
+		private SerialDisposable _unloadedSubscription = new SerialDisposable();
+#endif
 		private readonly WeakReference<TElement> _element;
 		private TNative? _native;
 		private bool _isRendering;
@@ -52,8 +55,10 @@ namespace Uno.Toolkit.UI
 			if (element is FrameworkElement fe)
 			{
 				fe.Unloaded += OnElementUnloaded;
-				_subscriptions.Add(() => fe.Unloaded -= OnElementUnloaded);
-
+				_unloadedSubscription.Disposable = Disposable.Create(() =>
+				{
+					fe.Unloaded -= OnElementUnloaded;
+				});
 			}
 #endif
 
@@ -61,9 +66,9 @@ namespace Uno.Toolkit.UI
 		}
 
 #if __IOS__
-
-		private void OnElementUnloaded(object sender, RoutedEventArgs e)
+		private void OnElementUnloaded(object sender, RoutedEventArgs? e)
 		{
+			_unloadedSubscription.Dispose();
 			Dispose();
 		}
 #endif

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/Renderer.cs
@@ -48,6 +48,13 @@ namespace Uno.Toolkit.UI
 				throw new ArgumentNullException(nameof(element));
 			}
 
+#if __IOS__
+			if (element is FrameworkElement uiElement)
+			{
+				uiElement.Unloaded += (s, e) => Dispose();
+			}
+#endif
+
 			_element = new WeakReference<TElement>(element);
 		}
 


### PR DESCRIPTION
fixes https://github.com/unoplatform/private/issues/617
fixes https://github.com/unoplatform/private/issues/645

Handles Hot Reload scenario where the content of a Page is copied over to a new Page instance and is then set as the Content on the original Page instance.

To avoid an invalid re-render of the UINavigationBar, clear the renderer registrations of the original NavigationBar when unloaded. The NativeFrameHelper will automatically re-wire the renderers when the wrapping UIViewController is about to appear.