### PR TITLE
fix: ancestor-binding issues with dynamic installation

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Helpers/UnitTestUIContentHelperEx.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Helpers/UnitTestUIContentHelperEx.cs
@@ -19,6 +19,8 @@ namespace Uno.Toolkit.RuntimeTests.Helpers
 {
 	internal static class UnitTestUIContentHelperEx
 	{
+		public static Task WaitForIdle() => Base.WaitForIdle();
+
 		public static async Task SetContentAndWait(FrameworkElement e)
 		{
 			Base.Content = e;

--- a/src/Uno.Toolkit.RuntimeTests/Tests/AncestorBindingTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AncestorBindingTests.cs
@@ -90,4 +90,25 @@ internal class AncestorBindingTests
 		Assert.AreEqual(true, host.IsChecked);
 		Assert.AreEqual(Visibility.Visible, sut.Visibility);
 	}
+
+	[TestMethod]
+	public async Task Ancestor_Swap_Ancestor()
+	{
+		var setup = new AncestorBindingTest();
+		await UnitTestUIContentHelperEx.SetContentAndWait(setup);
+
+		var sut = setup.GetFirstDescendantOrThrow<TextBlock>("SwapTestSubject");
+		var host1 = setup.GetFirstDescendantOrThrow<Border>("SwapHost1");
+		var host2 = setup.GetFirstDescendantOrThrow<Border>("SwapHost2");
+
+		Assert.AreEqual(host1.Tag, sut.Text, "initial state failed");
+
+		host1.Child = null;
+		await UnitTestUIContentHelperEx.WaitForIdle();
+
+		host2.Child = sut;
+		await UnitTestUIContentHelperEx.WaitForIdle();
+
+		Assert.AreEqual(host2.Tag, sut.Text, "expecting text resolving to SwapHost2.Tag after swapping");
+	}
 }

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TestPages/AncestorBindingTest.xaml
@@ -31,6 +31,10 @@
 														 ConverterParameter='arg1'}" />
 			</StackPanel>
 		</CheckBox>
+		<Border x:Name="SwapHost1" Tag="A">
+			<TextBlock x:Name="SwapTestSubject" Text="{utu:AncestorBinding AncestorType=Border, Path=Tag}" />
+		</Border>
+		<Border x:Name="SwapHost2" Tag="B" />
 
 		<ListView x:Name="TopLevelListView"
 				  ItemsSource="{Binding Items}"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1368, closes #1369

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
- AncestorBinding markup cannot be applied to already loaded element
- AncestorBinding will fail to update itself on visual-tree change

## What is the new behavior?
both fixed

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
	- [ ] Skia
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.