### PR TITLE
Version bump after 7.0 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,22 +1,21 @@
 {
-    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "7.0-dev.{height}",
-    "versionHeightOffset": 86,
-    "nuGetPackageVersion": {
-        "semVer": 2.0
-    },
-    "publicReleaseRefSpec": [
-        "^refs/heads/main$",
-        "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
-    ],
-    "cloudBuild": {
-        "setAllVariables": true,
-        "buildNumber": {
-            "enabled": true
-        }
-    },
-    "release": {
-        "branchName": "release/stable/{version}",
-        "firstUnstableTag": "dev"
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "7.1-dev.{height}",
+  "nuGetPackageVersion": {
+    "semVer": 2.0
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$",
+    "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "setAllVariables": true,
+    "buildNumber": {
+      "enabled": true
     }
+  },
+  "release": {
+    "branchName": "release/stable/{version}",
+    "firstUnstableTag": "dev"
+  }
 }


### PR DESCRIPTION

This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/7.0, based on #1375