### PR TITLE
fix: navigationbar commandbar staticresources

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBarPresenter.cs
@@ -112,7 +112,6 @@ namespace Uno.Toolkit.UI
 				setBinding(_commandBar, navigationBar, CommandBar.FontFamilyProperty, nameof(navigationBar.FontFamily));
 				setBinding(_commandBar, navigationBar, CommandBar.FontSizeProperty, nameof(navigationBar.FontSize));
 				setBinding(_commandBar, navigationBar, CommandBar.WidthProperty, nameof(navigationBar.Width));
-				setBinding(_commandBar, navigationBar, CommandBar.HeightProperty, nameof(navigationBar.Height));
 				setBinding(_commandBar, navigationBar, CommandBar.UseSystemFocusVisualsProperty, nameof(navigationBar.UseSystemFocusVisuals));
 				setBinding(_commandBar, navigationBar, CommandBarExtensions.MainCommandProperty, nameof(navigationBar.MainCommand));
 

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
@@ -67,16 +67,6 @@
 			<SolidColorBrush x:Key="NavigationBarEllipsisButtonBackground"
 							 Color="Transparent" />
 
-			<not_mobile:StaticResource x:Key="AppBarButtonHeight"
-									   ResourceKey="MaterialXamlNavigationBarHeight" />
-			<not_mobile:StaticResource x:Key="AppBarButtonWidth"
-									   ResourceKey="MaterialXamlNavigationBarHeight" />
-
-			<mobile:StaticResource x:Key="AppBarButtonHeight"
-								   ResourceKey="MaterialNavigationBarHeight" />
-			<mobile:StaticResource x:Key="AppBarButtonWidth"
-								   ResourceKey="MaterialNavigationBarHeight" />
-
 			<x:Double x:Key="MaterialNavigationBarElevation">4</x:Double>
 			<x:Double x:Key="MaterialXamlNavigationBarHeight">64</x:Double>
 			<x:Double x:Key="MaterialNavigationBarHeight">64</x:Double>
@@ -89,10 +79,8 @@
 			<StaticResource x:Key="NavigationBarMaterialEllipsisButtonWidth" ResourceKey="AppBarExpandButtonThemeWidth" />
 
 			<x:Double x:Key="NavBarAppBarButtonContentHeight">16</x:Double>
-			<StaticResource x:Key="AppBarButtonContentHeight" ResourceKey="NavBarAppBarButtonContentHeight" />
 			<x:Double x:Key="NavBarMainCommandAppBarButtonContentHeight">24</x:Double>
 			<x:Double x:Key="NavBarAppBarThemeCompactHeight">64</x:Double>
-			<StaticResource x:Key="AppBarThemeCompactHeight" ResourceKey="NavBarAppBarThemeCompactHeight" />
 			<Thickness x:Key="NavBarAppBarButtonPadding">12,16,12,16</Thickness>
 			<Visibility x:Key="NavBarAppBarButtonHasFlyoutChevronVisibility">Collapsed</Visibility>
 			<x:String x:Key="NavigationBarBackIconData">M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z</x:String>
@@ -136,15 +124,6 @@
 			<SolidColorBrush x:Key="NavigationBarEllipsisButtonBackground"
 							 Color="Transparent" />
 
-			<not_mobile:StaticResource x:Key="AppBarButtonHeight"
-									   ResourceKey="MaterialXamlNavigationBarHeight" />
-			<not_mobile:StaticResource x:Key="AppBarButtonWidth"
-									   ResourceKey="MaterialXamlNavigationBarHeight" />
-
-			<mobile:StaticResource x:Key="AppBarButtonHeight"
-								   ResourceKey="MaterialNavigationBarHeight" />
-			<mobile:StaticResource x:Key="AppBarButtonWidth"
-								   ResourceKey="MaterialNavigationBarHeight" />
 
 			<x:Double x:Key="MaterialNavigationBarElevation">4</x:Double>
 			<x:Double x:Key="MaterialXamlNavigationBarHeight">64</x:Double>
@@ -158,10 +137,8 @@
 			<StaticResource x:Key="NavigationBarMaterialEllipsisButtonWidth" ResourceKey="AppBarExpandButtonThemeWidth" />
 
 			<x:Double x:Key="NavBarAppBarButtonContentHeight">16</x:Double>
-			<StaticResource x:Key="AppBarButtonContentHeight" ResourceKey="NavBarAppBarButtonContentHeight" />
 			<x:Double x:Key="NavBarMainCommandAppBarButtonContentHeight">24</x:Double>
 			<x:Double x:Key="NavBarAppBarThemeCompactHeight">64</x:Double>
-			<StaticResource x:Key="AppBarThemeCompactHeight" ResourceKey="NavBarAppBarThemeCompactHeight" />
 			<Thickness x:Key="NavBarAppBarButtonPadding">12,16,12,16</Thickness>
 			<Visibility x:Key="NavBarAppBarButtonHasFlyoutChevronVisibility">Collapsed</Visibility>
 			<x:String x:Key="NavigationBarBackIconData">M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z</x:String>
@@ -293,6 +270,7 @@
 						<CommandBar x:Name="XamlNavigationBarCommandBar"
 									Content="{TemplateBinding Content}"
 									Margin="{TemplateBinding Padding}"
+									Height="{ThemeResource NavBarAppBarThemeCompactHeight}"
 									Style="{StaticResource MaterialNavigationBarCommandBar}" />
 					</Grid>
 				</ControlTemplate>
@@ -339,7 +317,7 @@
 														  Value="0" />
 								</DoubleAnimationUsingKeyFrames>
 							</Storyboard>
-							<!--<StaticResource x:Key="AppBarButtonContentHeight" ResourceKey="NavBarAppBarButtonContentHeight" />-->
+							<StaticResource x:Key="AppBarButtonContentHeight" ResourceKey="NavBarAppBarButtonContentHeight" />
 							<StaticResource x:Key="AppBarThemeCompactHeight" ResourceKey="NavBarAppBarThemeCompactHeight" />
 							<Style BasedOn="{StaticResource SplitButtonCommandBarStyle}"
 								   TargetType="SplitButton" />
@@ -347,8 +325,17 @@
 								   TargetType="ToggleSplitButton" />
 							<Style BasedOn="{StaticResource MaterialAppBarButtonStyle}"
 								   TargetType="AppBarButton">
-								<!--<Setter Property="Padding" Value="{ThemeResource NavBarAppBarButtonPadding}" />-->
 							</Style>
+
+							<not_mobile:StaticResource x:Key="AppBarButtonHeight"
+									   ResourceKey="MaterialXamlNavigationBarHeight" />
+							<not_mobile:StaticResource x:Key="AppBarButtonWidth"
+									   ResourceKey="MaterialXamlNavigationBarHeight" />
+
+							<mobile:StaticResource x:Key="AppBarButtonHeight"
+								   ResourceKey="MaterialNavigationBarHeight" />
+							<mobile:StaticResource x:Key="AppBarButtonWidth"
+								   ResourceKey="MaterialNavigationBarHeight" />
 						</Grid.Resources>
 						<Grid x:Name="ContentRoot"
 							  Height="{TemplateBinding Height}"
@@ -719,6 +706,7 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
 	<!--#endregion-->
 
 	<!--#region Default Modal Material NavigationBar-->
@@ -763,6 +751,7 @@
 						<CommandBar x:Name="XamlNavigationBarCommandBar"
 									Content="{TemplateBinding Content}"
 									Margin="{TemplateBinding Padding}"
+									Height="{ThemeResource NavBarAppBarThemeCompactHeight}"
 									Style="{StaticResource MaterialPrimaryNavigationBarCommandBar}" />
 					</Grid>
 				</ControlTemplate>
@@ -817,8 +806,17 @@
 								   TargetType="ToggleSplitButton" />
 							<Style BasedOn="{StaticResource MaterialPrimaryAppBarButtonStyle}"
 								   TargetType="AppBarButton">
-								<Setter Property="Padding" Value="{ThemeResource NavBarAppBarButtonPadding}" />
 							</Style>
+
+							<not_mobile:StaticResource x:Key="AppBarButtonHeight"
+									   ResourceKey="MaterialXamlNavigationBarHeight" />
+							<not_mobile:StaticResource x:Key="AppBarButtonWidth"
+									   ResourceKey="MaterialXamlNavigationBarHeight" />
+
+							<mobile:StaticResource x:Key="AppBarButtonHeight"
+								   ResourceKey="MaterialNavigationBarHeight" />
+							<mobile:StaticResource x:Key="AppBarButtonWidth"
+								   ResourceKey="MaterialNavigationBarHeight" />
 						</Grid.Resources>
 						<Grid x:Name="ContentRoot"
 							  Height="{TemplateBinding Height}"


### PR DESCRIPTION
related https://github.com/unoplatform/uno-private/issues/1163

Do not override Fluent CommandBar-related resources globally, set the Height explicitly on the CommandBar