### PR TITLE
 chore: bump uno samples app version to 6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
     "msbuild-sdks": {
-        "Uno.Sdk.Private": "5.6.99",
+        "Uno.Sdk.Private": "6.0.465",
         "MSBuild.Sdk.Extras": "3.0.38"
     },
   "sdk":{

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -5,6 +5,5 @@
 	<ItemGroup>
 		<PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />
 		<PackageVersion Include="Xamarin.TestCloud.Agent" Version="0.23.2" />
-		<PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="3.116.1" />
 	</ItemGroup>
 </Project>

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples/Platforms/Desktop/Program.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples/Platforms/Desktop/Program.cs
@@ -1,4 +1,4 @@
-using Uno.UI.Runtime.Skia;
+using Uno.UI.Hosting;
 
 namespace Uno.Toolkit.Samples;
 public class Program
@@ -8,12 +8,12 @@ public class Program
     {
         App.InitializeLogging();
 
-        var host = SkiaHostBuilder.Create()
+        var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseX11()
             .UseLinuxFrameBuffer()
             .UseMacOS()
-            .UseWindows()
+            .UseWin32()
             .Build();
 
         host.Run();

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.csproj
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples.csproj
@@ -37,7 +37,6 @@
 		<UnoFeatures>
 		</UnoFeatures>
 
-		<SkiaSharpVersion>3.116.1</SkiaSharpVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\src\library\Uno.Toolkit.Cupertino\Uno.Toolkit.WinUI.Cupertino.csproj" />


### PR DESCRIPTION
Fix errors for toolkit sample app on main