### PR TITLE
feat: ToggleSwitch support for CommandExtensions

### DIFF
--- a/doc/helpers/command-extensions.md
+++ b/doc/helpers/command-extensions.md
@@ -21,6 +21,7 @@ Provides Command/CommandParameter attached properties for common scenarios.
   - `NavigationView.ItemInvoked`
   - `ItemsRepeater` item tapped
   - `TextBox` and `PasswordBox` when the Enter key is pressed
+  - `ToggleSwitch` toggled
   - any `UIElement` tapped
 - For `Command`, the relevant parameter is also provided for the `CanExecute` and `Execute` call:
   > `CommandParameter` can be set, on the item-container or item-template's root for collection-type control, or control itself for other controls, to replace the following.
@@ -29,6 +30,7 @@ Provides Command/CommandParameter attached properties for common scenarios.
   - `NavigationViewItemInvokedEventArgs.InvokedItem` from `NavigationView.ItemInvoked`
   - `ItemsRepeater`'s item root's DataContext
   - `TextBox.Text`
+  - `ToggleSwitch.IsOn`
   - `PasswordBox.Password`
   - `UIElement` itself
 - `Command` on `TextBox`/`PasswordBox`\*: Having this set will also cause the keyboard to dismiss on enter.
@@ -46,6 +48,9 @@ xmlns:utu="using:Uno.Toolkit.UI"
 
 <!-- Execute command on enter -->
 <PasswordBox utu:CommandExtensions.Command="{Binding Login}" />
+
+<!-- Execute command on toggle -->
+<ToggleSwitch utu:CommandExtensions.Command="{Binding SetDarkMode}" />
 
 <!-- ListView item click-->
 <ListView ItemsSource="123"

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples/Content/Controls/CommandExtensionsSamplePage.xaml
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples/Content/Controls/CommandExtensionsSamplePage.xaml
@@ -24,6 +24,13 @@
 							<TextBox utu:CommandExtensions.Command="{Binding DebugInputCommand}" />
 						</StackPanel>
 
+						<!-- ToggleSwitch[Command] example -->
+						<StackPanel Spacing="8">
+							<TextBlock Text="- ToggleSwitch toggled:" />
+							<TextBlock Text="{Binding ToggleSwitchText}" />
+							<ToggleSwitch utu:CommandExtensions.Command="{Binding DebugToggleSwitchCommand}" />
+						</StackPanel>
+
 						<!-- ListView[Command] example -->
 						<StackPanel Spacing="8">
 							<TextBlock Text="- ListView item click:" />

--- a/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples/Content/Controls/CommandExtensionsSamplePage.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Uno.Toolkit.Samples/Content/Controls/CommandExtensionsSamplePage.xaml.cs
@@ -17,6 +17,7 @@ namespace Uno.Toolkit.Samples.Content.Controls
 			public string[] Fruits { get; } = new[] { "Apple", "Banana", "Cactus" };
 
 			public string InputDebugText { get => GetProperty<string>(); set => SetProperty(value); }
+			public string ToggleSwitchText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string ListViewDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string SelectorDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 			public string NavigationDebugText { get => GetProperty<string>(); set => SetProperty(value); }
@@ -24,6 +25,7 @@ namespace Uno.Toolkit.Samples.Content.Controls
 			public string ElementDebugText { get => GetProperty<string>(); set => SetProperty(value); }
 
 			public ICommand DebugInputCommand => new Command(DebugInput);
+			public ICommand DebugToggleSwitchCommand => new Command(DebugToggleSwitch);
 			public ICommand DebugListViewCommand => new Command(DebugListView);
 			public ICommand DebugSelectorCommand => new Command(DebugSelector);
 			public ICommand DebugNavigationCommand => new Command(DebugNavigation);
@@ -31,6 +33,7 @@ namespace Uno.Toolkit.Samples.Content.Controls
 			public ICommand DebugElementTappedCommand => new Command(DebugElement);
 
 			private void DebugInput(object parameter) => InputDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
+			private void DebugToggleSwitch(object parameter) => ToggleSwitchText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugListView(object parameter) => ListViewDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugSelector(object parameter) => SelectorDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");
 			private void DebugNavigation(object parameter) => NavigationDebugText = Invariant($"{DateTime.Now:HH:mm:ss}: parameter={parameter}");

--- a/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/CommandExtensions.cs
@@ -33,7 +33,7 @@ namespace Uno.Toolkit.UI
 
 		/// <summary>
 		/// Backing property for the command to execute when <see cref="TextBox"/>/<see cref="PasswordBox"/> enter key is pressed,
-		/// <see cref="ListViewBase.ItemClick" />, <see cref="Selector.SelectionChanged" />, <see cref="NavigationView.ItemInvoked" />, <see cref="ItemsRepeater" /> item tapped, or <see cref="UIElement.Tapped" />.
+		/// <see cref="ListViewBase.ItemClick" />, <see cref="Selector.SelectionChanged" />, <see cref="NavigationView.ItemInvoked" />, <see cref="ItemsRepeater" /> item tapped, <see cref="ToggleSwitch.Toggled"/> or <see cref="UIElement.Tapped" />.
 		/// </summary>
 		/// <remarks>
 		/// For Command, the relevant parameter is also provided for the <see cref="ICommand.CanExecute(object)"/> and <see cref="ICommand.Execute(object)"/> call:
@@ -44,6 +44,7 @@ namespace Uno.Toolkit.UI
 		///   <item><see cref="Selector.SelectedItem"/></item>
 		///   <item><see cref="NavigationViewItemInvokedEventArgs.InvokedItem"/> from <see cref="NavigationView.ItemInvoked"/></item>
 		///   <item><see cref="ItemsRepeater"/>'s item root's DataContext</item>
+		///   <item><see cref="ToggleSwitch.IsOn"/></item>
 		///   <item><see cref="UIElement"/> itself</item>
 		/// </list>
 		/// <see cref="CommandParameterProperty"/> can be set, on the item-container or item-template's root for collection-type controls, or control itself for other controls, to replace the above.
@@ -118,6 +119,14 @@ namespace Uno.Toolkit.UI
 				if (GetCommand(sender) is { } command)
 				{
 					nv.ItemInvoked += OnNavigationViewItemInvoked;
+				}
+			}
+			else if (sender is ToggleSwitch ts)
+			{
+				ts.Toggled -= OnToggleSwitchToggled;
+				if (GetCommand(sender) is { } command)
+				{
+					ts.Toggled += OnToggleSwitchToggled;
 				}
 			}
 			else if (sender is UIElement uie)
@@ -197,6 +206,12 @@ namespace Uno.Toolkit.UI
 		private static void OnNavigationViewItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs e)
 		{
 			TryInvokeCommand(sender, TryGetItemCommandParameter(e.InvokedItemContainer) ?? e.InvokedItem);
+		}
+		private static void OnToggleSwitchToggled(object sender, RoutedEventArgs e)
+		{
+			if (sender is not ToggleSwitch host) return;
+
+			TryInvokeCommand(host, host.IsOn);
 		}
 		private static void OnUIElementTapped(object sender, TappedRoutedEventArgs e)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1309, closes #1391
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
## What is the new behavior?
CommandExtensions.Command now support ToggleSwitch which triggers on Toggled.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
	- [x] Skia
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [x] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.