### PR TITLE
fix: remove 1px border on drawer-flyout

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.xaml
@@ -6,7 +6,7 @@
 					mc:Ignorable="todo">
 
 	<Style x:Key="DefaultDrawerFlyoutPresenterStyle" TargetType="utu:DrawerFlyoutPresenter">
-		<Setter Property="BorderThickness" Value="1" />
+		<Setter Property="BorderThickness" Value="0" />
 		<Setter Property="CornerRadius" Value="0" />
 		<Setter Property="LightDismissOverlayBackground" Value="#80808080" />
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1265

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
Remove the border on DrawerFlyoutPresenter, which was inherited from default FlyoutPresenter style.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
previous pr #1393, was also aimed at removing the border, but had a typo that set the BorderThickness to 1 instead of 0...
