### PR TITLE
Dev/xygu/20250619/skia-mobile-navbar-flicker

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
@@ -93,6 +93,8 @@ namespace Uno.Toolkit.UI
 #if HAS_NATIVE_NAVBAR
 			_isNativeTemplate = _presenter is NativeNavigationBarPresenter;
 #endif
+
+			SafeArea.PreApplySafeArea(this);
 		}
 
 		internal bool TryPerformMainCommand()
@@ -107,7 +109,7 @@ namespace Uno.Toolkit.UI
 				if (page.Frame is { Visibility: Visibility.Visible } frame
 					&& frame.CurrentSourcePageType == page.GetType())
 				{
-					
+
 					if (frame.CanGoBack == false && _popupHost is { })
 					{
 						// If we are within a Page that is hosted within a Popup and the BackStack is empty:
@@ -134,15 +136,15 @@ namespace Uno.Toolkit.UI
 		}
 
 #region Event Raising
-		internal void RaiseClosingEvent(object e) 
+		internal void RaiseClosingEvent(object e)
 			=> Closing?.Invoke(this, e);
 
-		internal void RaiseClosedEvent(object e) 
+		internal void RaiseClosedEvent(object e)
 			=> Closed?.Invoke(this, e);
-		
+
 		internal void RaiseOpeningEvent(object e)
 			=> Opening?.Invoke(this, e);
-		
+
 		internal void RaiseOpenedEvent(object e)
 			=> Opened?.Invoke(this, e);
 

--- a/src/Uno.Toolkit.UI/Extensions/TwoDExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/TwoDExtensions.cs
@@ -6,14 +6,19 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.Foundation;
-using Windows.UI.WebUI;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+#else
+using Windows.UI.Xaml;
+#endif
 
 namespace Uno.Toolkit.UI;
 
-internal static partial class TwoDExtensions // Point Mathematics
+internal static partial class TwoDExtensions;
+
+partial class TwoDExtensions // Point arithmetics
 {
 	public static Point ToPoint(this Size x) => new Point(x.Width, x.Height);
 	public static Point ToPoint(this Vector2 x) => new Point(x.X, x.Y);
@@ -30,7 +35,7 @@ internal static partial class TwoDExtensions // Point Mathematics
 	public static Point DivideBy(this Point x, double scale) => new Point(x.X / scale, x.Y / scale);
 }
 
-internal static partial class TwoDExtensions // Size Mathematics
+partial class TwoDExtensions // Size arithmetics
 {
 	public static Size ToSize(this Point x) => new Size(x.X, x.Y);
 	public static Size ToSize(this Vector2 x) => new Size(x.X, x.Y);
@@ -39,3 +44,10 @@ internal static partial class TwoDExtensions // Size Mathematics
 	public static Size MultiplyBy(this Size x, double scaleX, double scaleY) => new Size(x.Width * scaleX, x.Width * scaleY);
 	public static Size DivideBy(this Size x, double scale) => new Size(x.Width / scale, x.Height / scale);
 }
+
+partial class TwoDExtensions // Thickness arithmetics
+{
+	public static Thickness Add(this Thickness x, Thickness y) => new Thickness(x.Left + y.Left, x.Top + y.Top, x.Right + y.Right, x.Bottom + y.Bottom);
+	public static Thickness Subtract(this Thickness x, Thickness y) => new Thickness(x.Left - y.Left, x.Top - y.Top, x.Right - y.Right, x.Bottom - y.Bottom);
+}
+


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno#20446

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
NavBar flicker on skia-mobile on first load

## What is the new behavior?
^ no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [x] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.