### PR TITLE
fix: AutoFocusNext crash on android

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/InputExtensionsTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/InputExtensionsTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if HAS_UNO_WINUI
+using Uno.UI.Xaml.Controls;
+#endif
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class InputExtensionsTests
+	{
+		[TestMethod]
+		public void ReturnType_Property()
+		{
+			var tb = new TextBox();
+			InputExtensions.SetReturnType(tb, InputReturnType.Send);
+			Assert.AreEqual(InputReturnType.Send, InputExtensions.GetReturnType(tb));
+			InputExtensions.SetReturnType(tb, InputReturnType.Next);
+			Assert.AreEqual(InputReturnType.Next,InputExtensions.GetReturnType(tb));
+		}
+
+		[TestMethod]
+		public void AutoDismiss_Property()
+		{
+			var tb = new TextBox();
+			InputExtensions.SetAutoDismiss(tb, true);
+			Assert.IsTrue(InputExtensions.GetAutoDismiss(tb));
+		}
+
+		[TestMethod]
+		public void AutoFocusNext_Property()
+		{
+			var tb = new TextBox();
+			InputExtensions.SetAutoFocusNext(tb, true);
+			Assert.IsTrue(InputExtensions.GetAutoFocusNext(tb));
+		}
+
+		[TestMethod]
+		public void AutoFocusNextElement_Property()
+		{
+			var tb1 = new TextBox();
+			var tb2 = new TextBox();
+			InputExtensions.SetAutoFocusNextElement(tb1, tb2);
+			Assert.AreEqual(tb2, InputExtensions.GetAutoFocusNextElement(tb1));
+		}
+
+		[TestMethod]
+		public void Element_Precendence_Over_Flag()
+		{
+			var tb1 = new TextBox();
+			var tb2 = new TextBox();
+			InputExtensions.SetAutoFocusNext(tb1, true);
+			InputExtensions.SetAutoFocusNextElement(tb1, tb2);
+			Assert.AreEqual(tb2, InputExtensions.GetAutoFocusNextElement(tb1));
+			Assert.IsTrue(InputExtensions.GetAutoFocusNext(tb1));
+		}
+
+	}
+}

--- a/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
@@ -215,7 +215,21 @@ namespace Uno.Toolkit.UI
 			var target = GetAutoFocusNextElement(host);
 			if (GetAutoFocusNext(host) || target != null) // either property can be used to enable this feature
 			{
-				target ??= FocusManager.FindNextElement(FocusNavigationDirection.Next, new FindNextElementOptions { SearchRoot = host }) as Control;
+				if ((host as UIElement)?.XamlRoot?.Content is { } rootContent)
+				{
+					target ??= FocusManager.FindNextElement(FocusNavigationDirection.Next,
+						new FindNextElementOptions
+						{
+							SearchRoot = (host as UIElement)?.XamlRoot?.Content as DependencyObject ?? host
+						}
+					) as Control;
+				}
+				else
+				{
+					_logger.Warn(
+						$"AutoFocusNext: cannot move focus because XamlRoot.Content is null for host={host.GetType().Name}"
+					);
+				}
 
 				target?.Focus(FocusState.Keyboard);
 			}

--- a/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
@@ -226,9 +226,12 @@ namespace Uno.Toolkit.UI
 				}
 				else
 				{
-					_logger.Warn(
-						$"AutoFocusNext: cannot move focus because XamlRoot.Content is null for host={host.GetType().Name}"
-					);
+					if (_logger.IsEnabled(LogLevel.Warning))
+					{
+						_logger.Warn(
+							$"AutoFocusNext: cannot move focus because XamlRoot.Content is null for host={host.GetType().Name}"
+						);
+					}
 				}
 
 				target?.Focus(FocusState.Keyboard);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1418

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Passing `XamlRoot.Content` as SearchRoot so that InputExtensions.AutoFocusNext="True" no longer throws on Android(`System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'Focus navigation directions Next, Previous, and None are not supported when using FindNextElementOptions')`)




## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
