### PR TITLE
Version bump after 8.0 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "8.0-dev.{height}",
+  "version": "8.1-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
Bump version to 8.0 for breaking change introduced by https://github.com/unoplatform/uno.toolkit.ui/pull/1417
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/8.0, based on #1423