### PR TITLE
fix: remove 1px border on drawer-flyout

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.xaml
@@ -46,6 +46,7 @@
 	<Style x:Key="DrawerFlyoutPresenterStyle" TargetType="FlyoutPresenter">
 		<Setter Property="utu:DrawerFlyoutPresenter.LightDismissOverlayBackground" Value="#80808080" />
 
+		<Setter Property="BorderThickness" Value="0" />
 		<Setter Property="Margin" Value="0" />
 		<Setter Property="Padding" Value="0" />
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs#1666

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
1px border on drawer-flyout, that a previous fix didnt fully patch

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
	- [x] Desktop (Skia)
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
continuation of #1397
the actual 1px border is inherited from much above, at the FlyoutPresenter level
that is why #1397 failed, as the DrawerFlyoutPresenter style setter value will be overwritten by inherited local value