### PR TITLE
ci: Adjust condition for the "Publish to Uno Dev Feed" step

### DIFF
--- a/build/workflow/templates/nuget-publish-dev.yml
+++ b/build/workflow/templates/nuget-publish-dev.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
     inputs:
       command: 'push'
       packagesToPush: '$(Pipeline.Workspace)/NuGet_Packages/**/*.nupkg'


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## Description

Updated condition to allow publishing for both `master` and `release/stable/*` branches for the Uno Internal Dev Feed, while continuing to skip pull request builds. As manual release review check is done before this step for `release/stable/*` branches anyway: 
https://github.com/unoplatform/uno.toolkit.ui/blob/16e781c82fe9df9f113fad8490602e5c437f5f76/build/workflow/publish/publish-nuget-prod-dev.yml#L4

