### PR TITLE
refactor: resp-view

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveViewTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveViewTests.cs
@@ -1,15 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using Windows.Foundation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests;
 using Uno.Toolkit.RuntimeTests.Helpers;
-using Windows.Foundation;
 using Uno.Toolkit.UI;
 
 #if IS_WINUI
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Shapes;
 #else
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Shapes;
 #endif
 
@@ -39,7 +36,7 @@ internal class ResponsiveViewTests
 		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
 		host.ForceResponsiveSize(new Size(300, 400));
-		Assert.AreEqual("Narrow", (host.Content as TextBlock)?.Text);
+		Assert.AreEqual("Narrow", (host.GetResolvedContent() as TextBlock)?.Text);
 	}
 
 	[TestMethod]
@@ -67,7 +64,7 @@ internal class ResponsiveViewTests
 		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
 		host.ForceResponsiveSize(new Size(600, 400));
-		Assert.AreEqual(typeof(Rectangle), host.Content?.GetType());
+		Assert.AreEqual(typeof(Rectangle), host.GetResolvedContent()?.GetType());
 	}
 
 	[TestMethod]
@@ -109,7 +106,7 @@ internal class ResponsiveViewTests
 		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
 		host.ForceResponsiveSize(new Size(322, 400));
-		Assert.AreEqual(typeof(Ellipse), host.Content?.GetType());
+		Assert.AreEqual(typeof(Ellipse), host.GetResolvedContent()?.GetType());
 	}
 
 	[TestMethod]
@@ -142,7 +139,7 @@ internal class ResponsiveViewTests
 		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
 		host.ForceResponsiveSize(new Size(2000, 400));
-		Assert.AreEqual(typeof(Ellipse), host.Content?.GetType());
+		Assert.AreEqual(typeof(Ellipse), host.GetResolvedContent()?.GetType());
 	}
 
 	[TestMethod]
@@ -175,9 +172,9 @@ internal class ResponsiveViewTests
 		await UnitTestUIContentHelperEx.SetContentAndWait(host);
 
 		host.ForceResponsiveSize(new Size(150, 400));
-		Assert.AreEqual(typeof(TextBlock), host.Content?.GetType());
+		Assert.AreEqual(typeof(TextBlock), host.GetResolvedContent()?.GetType());
 
 		host.ForceResponsiveSize(new Size(800, 400));
-		Assert.AreEqual(typeof(TextBox), host.Content?.GetType());
+		Assert.AreEqual(typeof(TextBox), host.GetResolvedContent()?.GetType());
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/ResponsiveView/ResponsiveView.xaml
+++ b/src/Uno.Toolkit.UI/Controls/ResponsiveView/ResponsiveView.xaml
@@ -1,0 +1,13 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:utu="using:Uno.Toolkit.UI">
+	<Style TargetType="utu:ResponsiveView">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="utu:ResponsiveView">
+					<Border x:Name="ResponsiveRoot" />
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+</ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1442

## PR Type
What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
ResponsiveView exposes the Content property which also marked by the [ContentProperty]. This confuses the HotDesign as it treats dynamic content (resolved templated is materialized into Content) as RV's logical child, and incorrectly adds it as RV's Content.

## What is the new behavior?
Resolved template is now materialized under a border that is within the ControlTemplate, so it won't be picked up by HotDesign.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [x] WinUI
	- [x] Desktop
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->