### PR TITLE
Dev/xygu/202508022/drawerflyour-ir-workaround

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.cs
@@ -366,6 +366,10 @@ namespace Uno.Toolkit.UI
 			_drawerContentPresenter.Width -= 1;
 #endif
 
+			// normally not needed, but if this was last closed via focus lost, we will need it
+			// because TranslateOffset would reset to last hold-end value (be 0), when any value is assigned...
+			StopRunningAnimation();
+
 			// reset to close position, and animate to open position
 			UpdateOpenness(false);
 			UpdateIsOpen(true, animate: true);

--- a/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -52,10 +53,6 @@ namespace Uno.Toolkit.UI
 	[TemplatePart(Name = TemplateParts.DrawerContentPresenter, Type = typeof(ContentPresenter))]
 	public partial class DrawerFlyoutPresenter : ContentControl
 	{
-#if DEBUG
-		public DebugStates _debugStates;
-#endif
-
 		// template parts
 		private Border _lightDismissOverlay;
 		private ContentPresenter _drawerContentPresenter;
@@ -82,10 +79,6 @@ namespace Uno.Toolkit.UI
 			DefaultStyleKey = typeof(DrawerFlyoutPresenter);
 
 			_dispatcher = this.GetDispatcherCompat();
-
-#if DEBUG
-			_debugStates = new(this);
-#endif
 		}
 
 		protected override void OnApplyTemplate()
@@ -609,12 +602,13 @@ namespace Uno.Toolkit.UI
 		{
 			return Math.Max(Math.Min(value, max), min);
 		}
+	}
 
 #if DEBUG
-		/// <summary>
-		/// Used for debugging, to avoid having to scroll through all the class members.
-		/// </summary>
-		public class DebugStates(DrawerFlyoutPresenter owner)
+	[DebuggerTypeProxy(typeof(DebugProxy))]
+	public partial class DrawerFlyoutPresenter
+	{
+		public class DebugProxy(DrawerFlyoutPresenter owner)
 		{
 			public double? _lastSetOpenness => owner._lastSetOpenness;
 			public Size? _lastMeasuredFlyoutContentSize => owner._lastMeasuredFlyoutContentSize;
@@ -624,6 +618,6 @@ namespace Uno.Toolkit.UI
 			public DrawerOpenDirection OpenDirection => owner.OpenDirection;
 			public ClockState? StoryboardState => owner._storyboard?.GetCurrentState();
 		}
-#endif
 	}
+#endif
 }

--- a/src/Uno.Toolkit.UI/Helpers/PrettyPrint.cs
+++ b/src/Uno.Toolkit.UI/Helpers/PrettyPrint.cs
@@ -52,7 +52,10 @@ internal static class PrettyPrint
 		return $"[{x.Width:0.#}x{x.Height:0.#}@{x.Left:0.#},{x.Top:0.#}]";
 	}
 #endif
+	internal static string FormatPoint(Point p) => FormatPoint(p.X, p.Y);
+	internal static string FormatPoint(double x, double y) => $"{x:0.#},{y:0.#}";
 	internal static string FormatSize(Size size) => $"{size.Width:0.#}x{size.Height:0.#}";
+	internal static string FormatSize(double width, double height) => $"{width:0.#}x{height:0.#}";
 	internal static string FormatBrush(Brush b)
 	{
 		if (b is SolidColorBrush scb) return

--- a/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
+++ b/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
@@ -35,7 +35,7 @@ using _View = Windows.UI.Xaml.DependencyObject;
 #endif
 
 using static System.Reflection.BindingFlags;
-using static Uno.UI.Extensions.PrettyPrint;
+using static Uno.Toolkit.UI.PrettyPrint;
 
 namespace Uno.Toolkit.UI
 {

--- a/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
+++ b/src/Uno.Toolkit.UI/Helpers/VisualTreeHelperEx.cs
@@ -35,7 +35,7 @@ using _View = Windows.UI.Xaml.DependencyObject;
 #endif
 
 using static System.Reflection.BindingFlags;
-using static Uno.Toolkit.UI.PrettyPrint;
+using static Uno.UI.Extensions.PrettyPrint;
 
 namespace Uno.Toolkit.UI
 {
@@ -216,7 +216,7 @@ namespace Uno.Toolkit.UI
 			static IEnumerable<string> GetDetails(object x)
 			{
 				#region Common Details: Layout (high priority)
-#if TREEGRAPH_VERBOSE_LAYOUT
+#if TREEGRAPH_VERBOSE_LAYOUT && false
 #if __IOS__
 				if (x is _View view && view.Superview is { })
 				{
@@ -232,10 +232,12 @@ namespace Uno.Toolkit.UI
 #endif
 				if (x is FrameworkElement fe)
 				{
-					yield return $"Actual={fe.ActualWidth}x{fe.ActualHeight}";
-#if TREEGRAPH_VERBOSE_LAYOUT
+					if (fe.Parent is FrameworkElement parent)
+					{
+						yield return $"XY={FormatPoint(fe.TransformToVisual(parent).TransformPoint(default))}";
+					}
+					yield return $"Actual={FormatSize(fe.ActualWidth, fe.ActualHeight)}";
 					yield return $"Constraints=[{fe.MinWidth},{fe.Width},{fe.MaxWidth}]x[{fe.MinHeight},{fe.Height},{fe.MaxHeight}]";
-#endif
 					yield return $"HV={fe.HorizontalAlignment}/{fe.VerticalAlignment}";
 				}
 				if (x is UIElement uie)
@@ -261,6 +263,10 @@ namespace Uno.Toolkit.UI
 				if (x is ListViewItem lvi)
 				{
 					yield return $"Index={ItemsControl.ItemsControlFromItemContainer(lvi)?.IndexFromContainer(lvi) ?? -1}";
+				}
+				if (x is ContentPresenter cp && cp.Content is string { Length: >0 } cpText)
+				{
+					yield return $"Content=\"{EscapeMultiline(cpText)}\"";
 				}
 				if (x is TextBlock txt && !string.IsNullOrEmpty(txt.Text))
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/dispatchscience-private#26

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
- added workaround for drawer flyout with ItemsRepeater not materializing its items
- fixed drawer flyout would re-open without animation when it was previously dismissed from focus lost

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [x] Desktop
	- [ ] WinUI
	- [ ] iOS
	- [x] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.