### PR TITLE
fix(AutoLayout): collapsed child would still contribute to item spacing

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/AutoLayoutTest.cs
@@ -63,6 +63,66 @@ internal class AutoLayoutTest
 	}
 
 	[TestMethod]
+	public async Task When_Initially_Collapsed_With_Spacing()
+	{
+		// load 3 50x50 borders with 15px spacing between, and the middle one collapsed
+		const double ItemLength = 50;
+		var SUT = new AutoLayout()
+		{
+			Spacing = 15,
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0))
+		};
+
+		SUT.Children.Add(new Border { Width = ItemLength, Height = ItemLength, Background = new SolidColorBrush(Colors.Red) });
+		SUT.Children.Add(new Border { Width = ItemLength, Height = ItemLength, Background = new SolidColorBrush(Colors.Green), Visibility = Visibility.Collapsed });
+		SUT.Children.Add(new Border { Width = ItemLength, Height = ItemLength, Background = new SolidColorBrush(Colors.Blue) });
+		
+		await UIHelper.Load(SUT);
+		await UIHelper.WaitForIdle();
+
+		var expected =
+			ItemLength + SUT.Spacing +
+			//ItemLength + SUT.Spacing +
+			ItemLength;
+		Assert.AreEqual(expected, SUT.ActualHeight);
+	}
+
+	[TestMethod]
+	public async Task When_Late_Collapsed_With_Spacing()
+	{
+		// load 3 50x50 borders with 15px spacing between
+		const double ItemLength = 50;
+		var SUT = new AutoLayout()
+		{
+			Spacing = 15,
+			Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0))
+		};
+		
+		SUT.Children.Add(new Border { Width = ItemLength, Height = ItemLength, Background = new SolidColorBrush(Colors.Red) });
+		SUT.Children.Add(new Border { Width = ItemLength, Height = ItemLength, Background = new SolidColorBrush(Colors.Green) });
+		SUT.Children.Add(new Border { Width = ItemLength, Height = ItemLength, Background = new SolidColorBrush(Colors.Blue) });
+		
+		await UIHelper.Load(SUT);
+		await UIHelper.WaitForIdle();
+
+		var expected =
+			ItemLength + SUT.Spacing +
+			ItemLength + SUT.Spacing +
+			ItemLength;
+		Assert.AreEqual(expected, SUT.ActualHeight);
+
+		// collapse the middle border
+		SUT.Children[1].Visibility = Visibility.Collapsed;
+		await UIHelper.WaitForIdle();
+		
+		var expected2 =
+			ItemLength + SUT.Spacing +
+			//ItemLength + SUT.Spacing +
+			ItemLength;
+		Assert.AreEqual(expected2, SUT.ActualHeight);
+	}
+
+	[TestMethod]
 	[RequiresFullWindow]
 	[DataRow(Orientation.Vertical, 10, 130, 250)]
 	[DataRow(Orientation.Horizontal, 10, 70, 130)]

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Measure.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Layouting.Measure.cs
@@ -168,6 +168,11 @@ partial class AutoLayout
 				role = AutoLayoutRole.Independent;
 				numberOfStackedChildren--;
 			}
+			else if (child is FrameworkElement { Visibility: Visibility.Collapsed })
+			{
+				role = AutoLayoutRole.Collapsed;
+				numberOfStackedChildren--;
+			}
 			else if (child is FrameworkElement frameworkElement)
 			{
 				var size = frameworkElement.GetPrimaryLength(orientation) is var l and >= 0 and < double.PositiveInfinity
@@ -517,7 +522,8 @@ partial class AutoLayout
 		Hug,
 		Fixed,
 		Filled,
-		Independent
+		Independent,
+		Collapsed
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1026, closes unoplatform/dispatchscience-private#30

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
Collapsed child views under AutoLayout no longer contribute to the total item spacing.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [x] Desktop
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->