### PR TITLE
fix(loadingview): loading-content still blocking user-interaction once loaded

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.xaml
+++ b/src/Uno.Toolkit.UI/Controls/LoadingView/LoadingView.xaml
@@ -50,15 +50,15 @@
 								</VisualStateGroup.Transitions>
 								<VisualState x:Name="Loading">
 									<VisualState.Setters>
+										<Setter Target="ContentPresenter.IsHitTestVisible" Value="False" />
 										<Setter Target="LoadingContentPresenter.(utu:ProgressExtensions.IsActive)" Value="true"/>
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Loaded">
 									<VisualState.Setters>
-										<Setter Target="ContentPresenter.Opacity"
-												Value="1" />
-										<Setter Target="LoadingContentPresenter.Opacity"
-												Value="0" />
+										<Setter Target="ContentPresenter.Opacity" Value="1" />
+										<Setter Target="LoadingContentPresenter.IsHitTestVisible" Value="False" />
+										<Setter Target="LoadingContentPresenter.Opacity" Value="0" />
 										<Setter Target="LoadingContentPresenter.(utu:ProgressExtensions.IsActive)" Value="false"/>
 									</VisualState.Setters>
 								</VisualState>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1460

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
LoadingView.LoadingContent can still receive user-interaction once loaded, and blocks the actual content underneath it.

## What is the new behavior?
^ no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Tested the changes where applicable:
	- [x] Desktop
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
