### PR TITLE
chore: Adjust hint for crosstargeting override after move to net9

### DIFF
--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -20,10 +20,10 @@
 		<!-- <TargetFrameworkOverride Condition="''!='hint: UWP'">uap10.0.19041;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
 		<!-- <TargetFrameworkOverride Condition="''!='hint: WinUI'">net9.0-windows10.0.19041;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
 		<!-- <TargetFrameworkOverride Condition="''!='hint: WASM, Skia'">net9.0;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
-		<!-- <TargetFrameworkOverride Condition="''!='hint: .NET 8.0 iOS'">net9.0-ios;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
-		<!-- <TargetFrameworkOverride Condition="''!='hint: .NET 8.0 Android'">net9.0-android;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
-		<!-- <TargetFrameworkOverride Condition="''!='hint: .NET 8.0 macOS Catalyst'">net9.0-maccatalyst;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
-		<!-- <TargetFrameworkOverride Condition="''!='hint: .NET 8.0 macOS AppKit'">net9.0-macos;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
+		<!-- <TargetFrameworkOverride Condition="''!='hint: .NET 9.0 iOS'">net9.0-ios;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
+		<!-- <TargetFrameworkOverride Condition="''!='hint: .NET 9.0 Android'">net9.0-android;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
+		<!-- <TargetFrameworkOverride Condition="''!='hint: .NET 9.0 macOS Catalyst'">net9.0-maccatalyst;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
+		<!-- <TargetFrameworkOverride Condition="''!='hint: .NET 9.0 macOS AppKit'">net9.0-macos;$(TargetFrameworkOverride)</TargetFrameworkOverride> -->
 
 		<!-- DO NOT COMMENT OUT: net9.0 is a required tfm in all cases -->
 		<TargetFrameworkOverride Condition="'$(TargetFrameworkOverride)'!='' AND !$(TargetFrameworkOverride.Contains('net9.0;'))">net9.0;$(TargetFrameworkOverride)</TargetFrameworkOverride>


### PR DESCRIPTION
Adjust hint for crosstargeting override file after move to net9