### PR TITLE
ci: fix up test script failures

### DIFF
--- a/build/workflow/scripts/ios-uitest-run.sh
+++ b/build/workflow/scripts/ios-uitest-run.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Ensure this script has no BOM even if it ever gets committed with one again
+# (the BOM only breaks the shebang at exec time, but this is a safety net).
+sed -i '' $'1s/^\xEF\xBB\xBF//' "$0"
+
 
 if [ "$UITEST_TEST_MODE_NAME" == 'Automated' ];
 then
@@ -58,19 +62,35 @@ cp "$UITEST_IOSDEVICE_DATA_PATH/../device.plist" $UNO_UITEST_SCREENSHOT_PATH/_lo
 
 echo "Starting simulator: [$UITEST_IOSDEVICE_ID] ($UNO_UITEST_SIMULATOR_VERSION / $UNO_UITEST_SIMULATOR_NAME)"
 
-# check for the presence of idb, and install it if it's not present
+# Check for the presence of idb, and install it if it's not present
+# NOTE: fb-idb currently breaks under Python 3.14 (asyncio get_event_loop change),
+# so we pin fb-idb to Python 3.12 to avoid "There is no current event loop in thread 'MainThread'".
+# Historical context: prior installs referenced an App Center issue/workaround.
+# https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
 export PATH=$PATH:~/.local/bin
 
-if ! command -v idb &> /dev/null
-then
-	echo "Installing idb"
-	brew install pipx
-	# # https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
-	brew tap facebook/fb
-	brew install idb-companion
-	pipx install fb-idb
+if ! command -v idb >/dev/null 2>&1; then
+  echo "Installing idb (fb-idb + idb-companion) pinned to Python 3.12"
+
+  # 1) Make sure we have a usable python3.12, but don't fail if Homebrew linking conflicts
+  if ! command -v python3.12 >/dev/null 2>&1; then
+    # Install, but ignore link-step failure; we'll use the keg path explicitly
+    brew list --versions python@3.12 >/dev/null 2>&1 || brew install python@3.12 || true
+  fi
+  # Prefer an existing python3.12 on PATH; otherwise use the keg path
+  PY312_BIN="$(command -v python3.12 || echo "$(brew --prefix)/opt/python@3.12/bin/python3.12")"
+  export PIPX_DEFAULT_PYTHON="$PY312_BIN"
+  echo "Using Python for pipx: $PIPX_DEFAULT_PYTHON"
+
+  # 2) Install helpers
+  brew list --versions pipx >/dev/null 2>&1 || brew install pipx
+  brew tap facebook/fb >/dev/null 2>&1 || true
+  brew list --versions idb-companion >/dev/null 2>&1 || brew install idb-companion
+
+  # 3) Install fb-idb under Python 3.12
+  pipx install --force fb-idb
 else
-	echo "Using idb from:" `command -v idb`
+  echo "Using idb from: $(command -v idb)"
 fi
 
 xcrun simctl boot "$UITEST_IOSDEVICE_ID" || true


### PR DESCRIPTION
This pull request updates the `ios-uitest-run.sh` script to improve reliability and compatibility when running iOS UI tests. The most significant change is ensuring that the required `idb` tools are installed and pinned to Python 3.12, addressing compatibility issues with newer Python versions. Additionally, a safety check is added to remove any BOM from the script to prevent execution problems.

**Script reliability and compatibility improvements:**

* Added a command at the top of `ios-uitest-run.sh` to strip any BOM from the script, preventing shebang execution errors if a BOM is present.

**Tool installation and environment setup:**

* Updated the `idb` installation logic to:
  * Pin `fb-idb` to Python 3.12, avoiding issues with Python 3.14 and `asyncio`.
  * Ensure `python3.12` is available, using either an existing binary or the Homebrew keg path.
  * Install dependencies (`pipx`, `idb-companion`) only if not already present.
  * Use `pipx` with the specified Python version to install `fb-idb`, forcing reinstallation if needed.
  * Improved logging and error handling for these steps.