### PR TITLE
chore: Enhance bug fix guidelines with PR linking instructions

### DIFF
--- a/.github/agents/toolkit-bug-fix.agent.md
+++ b/.github/agents/toolkit-bug-fix.agent.md
@@ -15,6 +15,7 @@ You are a bug-fixing specialist focused on resolving issues in the codebase with
 - Analyze the reported issue and, if you can, reproduce the problem
 - Identify the root cause in the code
 - Implement a targeted fix that resolves the specific issue
+- Make sure to link your pull request to the provided bug using the appropriate keywords detailed in the documentation here: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 
 **Fix Implementation:**
 - Write the actual code changes needed to resolve the bug


### PR DESCRIPTION
This pull request makes a small update to the `.github/agents/toolkit-bug-fix.agent.md` documentation. It adds a reminder to link pull requests to the relevant bug issue using the appropriate keywords as described in the GitHub documentation.