### PR TITLE
chore: support attached properties under NativeAOT

### DIFF
--- a/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/InputExtensions.cs
@@ -138,7 +138,12 @@ namespace Uno.Toolkit.UI
 #if false // The property is now forwarded from CommandExtensions.Command
 		#region DependencyProperty: EnterCommand
 
-		public static DependencyProperty EnterCommandProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty EnterCommandProperty
+		{
+			[DynamicDependency(nameof(GetEnterCommand))]
+			[DynamicDependency(nameof(SetEnterCommand))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"EnterCommand",
 			typeof(ICommand),
 			typeof(InputExtensions),

--- a/src/Uno.Toolkit.UI/Behaviors/ProgressExtensions.cs
+++ b/src/Uno.Toolkit.UI/Behaviors/ProgressExtensions.cs
@@ -25,6 +25,8 @@ namespace Uno.Toolkit.UI
 		/// Backing property for a value which recursively sets whether the
 		/// nested progress controls are displaying a loading animation.
 		/// </summary>
+		[DynamicDependency(nameof(GetIsActive))]
+		[DynamicDependency(nameof(SetIsActive))]
 		public static readonly DependencyProperty IsActiveProperty = DependencyProperty.RegisterAttached(
 			"IsActive",
 			typeof(bool),

--- a/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/AutoLayout/AutoLayout.Properties.cs
@@ -104,7 +104,7 @@ partial class AutoLayout
 		element.SetValue(PrimaryAlignmentProperty, value);
 	}
 
-	[DynamicDependency(nameof(GetPrimaryAlignment))]
+	[DynamicDependency(nameof(SetPrimaryAlignment))]
 	public static AutoLayoutPrimaryAlignment GetPrimaryAlignment(DependencyObject element)
 	{
 		return (AutoLayoutPrimaryAlignment)element.GetValue(PrimaryAlignmentProperty);
@@ -124,7 +124,7 @@ partial class AutoLayout
 		element.SetValue(CounterAlignmentProperty, value);
 	}
 
-	//[DynamicDependency(nameof(SetCounterAlignment))]
+	[DynamicDependency(nameof(SetCounterAlignment))]
 	public static AutoLayoutAlignment GetCounterAlignment(DependencyObject element)
 	{
 		return (AutoLayoutAlignment)element.GetValue(CounterAlignmentProperty);

--- a/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerFlyout/DrawerFlyoutPresenter.Properties.cs
@@ -154,7 +154,7 @@ namespace Uno.Toolkit.UI
 		#endregion
 		#region DependencyProperty: IsLightDismissEnabled = true
 
-		public static DependencyProperty IsLightDismissEnabledProperty { [DynamicDependency(nameof(GetIsGestureEnabled))] get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsLightDismissEnabledProperty { [DynamicDependency(nameof(GetIsLightDismissEnabled))] get; } = DependencyProperty.RegisterAttached(
 			nameof(IsLightDismissEnabled),
 			typeof(bool),
 			typeof(DrawerFlyoutPresenter),


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/pull/22017
Context: 1f09dd1c7edf6306d2bfda7c5fac14b14e7bed0e

While running the uno.chefs app on macOS under NativeAOT:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop -bl \
	  Chefs/Chefs.csproj -p:SelfContained=true -p:PublishAot=true -p:IsAotCompatible=true -p:UseSkiaRendering=true \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

Console output would contain the following errors:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Uno.Toolkit.UI:ProgressExtensions.IsActive] property getter does not exist on type [Microsoft.UI.Xaml.Controls.ContentControl]

The `Uno.Toolkit.UI:ProgressExtensions.IsActive` property is an
*attached* property, from `ProgressExtensions.IsActive`:

	static partial class ProgressExtensions {
	  public static readonly DependencyProperty IsActiveProperty = DependencyProperty.RegisterAttached(
	      "IsActive",
	      typeof(bool),
	      typeof(ProgressExtensions),
	      new PropertyMetadata(false, IsActiveChanged));
	  public static bool GetIsActive(FrameworkElement element) => …;
	  public static void SetIsActive(FrameworkElement element, bool value) => …;
	}

Attached properties work by using Reflection to look for methods with
`Get` and `Set` prefixes before the property name, in this case
`GetIsActive()` and `SetIsActive()`.

NativeAOT cannot statically determine that `GetIsActive()` and
`SetIsActive()` are used, and thus doesn't emit any reflection metadata
for these members.  This can be verified by consulting the generated
`Chefs.metadata.csv` file, which only contains these entries for
`GetIsActive` and `SetIsActive`:

	3424256a, ConstantStringValue, "GetIsActive", ""

The [`[DynamicDependency]`][0] custom attribute can be used to inform
NativeAOT of this dependency, by listing the names of members which
should be preserved:

	static partial class ProgressExtensions {
	  [DynamicDependency(nameof(GetIsActive))]
	  [DynamicDependency(nameof(SetIsActive))]
	  public static readonly DependencyProperty IsActiveProperty = DependencyProperty.RegisterAttached(
	      "IsActive",
	      typeof(bool),
	      typeof(ProgressExtensions),
	      new PropertyMetadata(false, IsActiveChanged));
	}

With this change in place, the originating failure message is no
longer emitted, and `Chefs.metadata.csv` contains:

	500b1f0b, Method, "System.Boolean GetIsActive(Microsoft.UI.Xaml.FrameworkElement)", "34141647 56141653 620c0acd"
	500b1f1a, Method, "System.Void SetIsActive(Microsoft.UI.Xaml.FrameworkElement, System.Boolean)", "3414165f 5614166b 620c0acd 6206708f"
	34141647, ConstantStringValue, "GetIsActive", ""
	3414165f, ConstantStringValue, "SetIsActive", ""
	4214168b, CustomAttribute, "System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute.[HasThis]  System.Void .ctor(System.String)(\"GetIsActive\")(ctor: Internal.Metadata.NativeFormat.Handle", "6c1c41df 34141647"
	42141695, CustomAttribute, "System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute.[HasThis]  System.Void .ctor(System.String)(\"SetIsActive\")(ctor: Internal.Metadata.NativeFormat.Handle", "6c1c41df 3414165f"

Review all usage of `DependencyProperty.RegisterAttached()` and add
`[DynamicDependency]` attributes as appropriate.

Of note:

  * Commit 1f09dd1c *commented out* many of the `[DynamicDependency]`
    annotations within `AutoLayout.Properties.cs`.  Some of these
    have already been undone, e.g. f16d514c, and this commit uncomments
    the remaining `[DynamicDependency]` annotations.

  * There are now two separate patterns for providing
    `[DynamicDependency]`:

     1. Provide a `[DynamicDependency]` on the attached property for
        the `Get` method, and then `[DynamicDependency]` on the
        `Get` method (to the `Set` method), and a `[DynamicDependency]`
        on the `Set` method (to the `Get` method):

            partial class DeclType {
              [DynamicDependency(nameof(GetAttached))]
              public static readonly DependencyProperty AttachedProperty = DependencyProperty.RegisterAttached(
                "Attached"
                typeof(T),
                typeof(DeclType),
                new PropertyMetadata(…));

              [DynamicDependency(nameof(SetAttached))]
              public static T    GetAttached(DependencyObject element) => …
              [DynamicDependency(nameof(SetAttached))]
              public static void SetAttached(DependencyObject element, T value) => …
            }

     2. Provide `[DynamicDependency]` for *both* the `Get` and `Set`
        methods on the attached property:

            partial class DeclType {
              [DynamicDependency(nameof(GetAttached))]
              [DynamicDependency(nameof(SetAttached))]
              public static readonly DependencyProperty AttachedProperty = DependencyProperty.RegisterAttached(
                "Attached"
                typeof(T),
                typeof(DeclType),
                new PropertyMetadata(…));

              public static T    GetAttached(DependencyObject element) => …
              public static void SetAttached(DependencyObject element, T value) => …
            }

Both of these are fine, but @jonpryor personally finds the latter
easier to review.  At least one "typo" was found in the current review.

[0]: https://learn.microsoft.comdotnet/api/system.diagnostics.codeanalysis.dynamicdependencyattribute?view=net-10.0