### PR TITLE
feat: Add Hot Reload support for TabBar selection state

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.HotReload.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.HotReload.cs
@@ -1,0 +1,37 @@
+﻿#if IS_WINUI
+using System;
+using System.Collections.Generic;
+using System.Reflection.Metadata;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+
+[assembly: ElementMetadataUpdateHandlerAttribute(typeof(Uno.Toolkit.UI.TabBar), typeof(Uno.Toolkit.UI.TabBarElementMetadataUpdateHandler))]
+
+namespace Uno.Toolkit.UI;
+internal static class TabBarElementMetadataUpdateHandler
+{
+	private const string SelectedIndexKey = nameof(TabBar) + "." + nameof(TabBar.SelectedIndex);
+
+	public static void CaptureState(FrameworkElement element, IDictionary<string, object> stateDictionary, Type[]? updatedTypes)
+	{
+		if (element is TabBar tabBar)
+		{
+			stateDictionary[SelectedIndexKey] = tabBar.SelectedIndex;
+		}
+	}
+
+	public static Task RestoreState(FrameworkElement element, IDictionary<string, object> stateDictionary, Type[]? updatedTypes)
+	{
+		if (element is TabBar tabBar &&
+		    stateDictionary.TryGetValue(SelectedIndexKey, out var savedIndex) &&
+		    savedIndex is int index and >= 0 &&
+		    index < tabBar.Items.Count &&
+		    tabBar.GetBindingExpression(TabBar.SelectedIndexProperty) is null)
+		{
+			tabBar.SelectedIndex = index;
+		}
+
+		return Task.CompletedTask;
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.extensions/issues/2971

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

HR recreates all `TabBarItems` as new instances, resetting `SelectedIndex` to -1. When `SynchronizeInitialSelection`  https://github.com/unoplatform/uno.toolkit.ui/blob/a4c1d94011986707191fb78e0bac29ee3882d9dd/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs#L217 runs, it selects index 0 with `_previouslySelectedItem=null`, causing `SelectionChanged` to fire. Navigation receives this event and re-navigates, clearing the page content.

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
