### PR TITLE
fix: ipadOS transitions

### DIFF
--- a/samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml
+++ b/samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml
@@ -1,0 +1,55 @@
+<Page x:Class="Uno.Toolkit.Samples.Content.TestPages.CameraSafeAreaTestPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.Toolkit.Samples.Content.TestPages"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid utu:SafeArea.Insets="VisibleBounds"
+		  Padding="16"
+		  RowSpacing="12">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<TextBlock Grid.Row="0"
+				   Style="{StaticResource SubtitleTextBlockStyle}"
+				   Text="iPad SafeArea modal-dismiss live-lock repro" />
+
+		<TextBlock Grid.Row="1"
+				   TextWrapping="Wrap"
+				   Text="Run on iPad. (1) Tap 'Tap me' a few times — counter increments. (2) Tap 'Present picker' and dismiss it (Cancel or pick a photo). (3) Tap 'Tap me' again — the counter MUST keep incrementing. If it stops, the SafeArea bounds-transition guard is rescheduling on the dispatcher and starving managed input." />
+
+		<Button Grid.Row="2"
+				x:Name="TapButton"
+				AutomationProperties.AutomationId="CameraSafeAreaTestPage_TapButton"
+				Content="Tap me"
+				Click="OnTapClicked" />
+
+		<TextBlock Grid.Row="3"
+				   x:Name="TapCountText"
+				   AutomationProperties.AutomationId="CameraSafeAreaTestPage_TapCountText"
+				   Text="Taps: 0" />
+
+		<Button Grid.Row="4"
+				x:Name="PresentPickerButton"
+				AutomationProperties.AutomationId="CameraSafeAreaTestPage_PresentPickerButton"
+				Content="Present picker (FormSheet)"
+				Click="OnPresentPickerClicked" />
+
+		<TextBlock Grid.Row="5"
+				   x:Name="PickerStatusText"
+				   AutomationProperties.AutomationId="CameraSafeAreaTestPage_PickerStatusText"
+				   TextWrapping="Wrap"
+				   Text="Picker idle" />
+	</Grid>
+</Page>

--- a/samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+#if __IOS__
+using UIKit;
+#endif
+
+namespace Uno.Toolkit.Samples.Content.TestPages
+{
+	[SamplePage(SampleCategory.Tests, "CameraSafeAreaTest", SupportedDesigns = new[] { Design.Material, Design.Cupertino })]
+	public sealed partial class CameraSafeAreaTestPage : Page
+	{
+		private int _tapCount;
+
+		public CameraSafeAreaTestPage()
+		{
+			this.InitializeComponent();
+
+#if !__IOS__
+			PresentPickerButton.IsEnabled = false;
+			PickerStatusText.Text = "Picker is iPad-only — only the 'Tap me' counter is exercised on this platform.";
+#endif
+		}
+
+		private void OnTapClicked(object sender, RoutedEventArgs e)
+		{
+			_tapCount++;
+			TapCountText.Text = $"Taps: {_tapCount}";
+		}
+
+		private void OnPresentPickerClicked(object sender, RoutedEventArgs e)
+		{
+#if __IOS__
+			try
+			{
+				var picker = new UIImagePickerController
+				{
+					SourceType = UIImagePickerControllerSourceType.PhotoLibrary,
+					ModalPresentationStyle = UIModalPresentationStyle.FormSheet,
+				};
+
+				picker.Canceled += (s, args) =>
+				{
+					PickerStatusText.Text = "Picker canceled — now retry the 'Tap me' button.";
+					picker.DismissViewController(true, null);
+				};
+
+				picker.FinishedPickingMedia += (s, args) =>
+				{
+					PickerStatusText.Text = "Picker finished — now retry the 'Tap me' button.";
+					picker.DismissViewController(true, null);
+				};
+
+				var rootVC = ResolveRootViewController();
+				if (rootVC is null)
+				{
+					PickerStatusText.Text = "No root view controller available.";
+					return;
+				}
+
+				PickerStatusText.Text = "Presenting picker...";
+				rootVC.PresentViewController(picker, true, null);
+			}
+			catch (Exception ex)
+			{
+				PickerStatusText.Text = $"Failed to present picker: {ex.Message}";
+			}
+#endif
+		}
+
+#if __IOS__
+		private static UIViewController? ResolveRootViewController()
+		{
+			var keyWindowRoot = UIApplication.SharedApplication.KeyWindow?.RootViewController;
+			if (keyWindowRoot is not null)
+			{
+				return keyWindowRoot;
+			}
+
+			return UIApplication.SharedApplication.ConnectedScenes
+				.OfType<UIWindowScene>()
+				.SelectMany(s => s.Windows)
+				.FirstOrDefault(w => w.IsKeyWindow)?.RootViewController;
+		}
+#endif
+	}
+}

--- a/samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Linq;
 #if __IOS__
+using System.Linq;
 using UIKit;
 #endif
 

--- a/samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml.cs
+++ b/samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml.cs
@@ -70,16 +70,12 @@ namespace Uno.Toolkit.Samples.Content.TestPages
 #if __IOS__
 		private static UIViewController? ResolveRootViewController()
 		{
-			var keyWindowRoot = UIApplication.SharedApplication.KeyWindow?.RootViewController;
-			if (keyWindowRoot is not null)
-			{
-				return keyWindowRoot;
-			}
-
-			return UIApplication.SharedApplication.ConnectedScenes
+			var windows = UIApplication.SharedApplication.ConnectedScenes
 				.OfType<UIWindowScene>()
 				.SelectMany(s => s.Windows)
-				.FirstOrDefault(w => w.IsKeyWindow)?.RootViewController;
+				.ToArray();
+
+			return (windows.FirstOrDefault(w => w.IsKeyWindow) ?? windows.FirstOrDefault())?.RootViewController;
 		}
 #endif
 	}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs
@@ -24,6 +24,7 @@ using Microsoft.UI.Xaml.Navigation;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Windows.UI.ViewManagement;
+using XamlWindow = Microsoft.UI.Xaml.Window;
 #else
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml;
@@ -33,6 +34,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Windows.UI;
 using Windows.UI.ViewManagement;
+using XamlWindow = Windows.UI.Xaml.Window;
 #endif
 
 namespace Uno.Toolkit.RuntimeTests.Tests
@@ -85,7 +87,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			Assert.AreEqual((nameof(grid0), customBounds), effectiveUpdates[0]);
 		}
 
-#if DEBUG && !__ANDROID__
+#if DEBUG && !__ANDROID__ && !WINDOWS_WINUI
 		[TestMethod]
 		[RequiresFullWindow]
 		public async Task BoundsTransitionGuard_NotActive_OnNonAndroid()
@@ -117,7 +119,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 
 			try
 			{
-				var currentBounds = Window.Current?.Bounds ?? default;
+				var currentBounds = XamlWindow.Current?.Bounds ?? default;
 				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = currentBounds;
 				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
 				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = false;

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs
@@ -125,8 +125,11 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = false;
 
 				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
-				await UnitTestUIContentHelperEx.WaitForIdle();
 
+				// The guard sets s_boundsTransitionPending=true synchronously before scheduling
+				// its reschedule, so we assert immediately. Awaiting WaitForIdle() here would hang
+				// the test if the guard ever regresses — the reschedule loop saturates the
+				// dispatcher and idle is never reached (the very symptom this test guards against).
 				Assert.IsFalse(
 					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
 					"Bounds-transition guard must stay gated off on non-Android — otherwise iPad live-locks the managed dispatcher after a FormSheet modal dismisses (see fix/iPadOS.transitions).");

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs
@@ -85,6 +85,59 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			Assert.AreEqual((nameof(grid0), customBounds), effectiveUpdates[0]);
 		}
 
+#if DEBUG && !__ANDROID__
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task BoundsTransitionGuard_NotActive_OnNonAndroid()
+		{
+			// Regression test for the iPad CameraCaptureUI live-lock (fix/iPadOS.transitions).
+			//
+			// PR #1554 added a Bounds/VisibleBounds-mismatch guard in UpdateInsets() that
+			// self-reschedules on the dispatcher when VisibleBounds changes ahead of Window.Bounds.
+			// On iPad, after a UIImagePickerController-style FormSheet/OverFullScreen modal
+			// dismisses, VisibleBounds updates while Window.Bounds stays stable — Bounds NEVER
+			// catches up because the host view stayed attached. Without the Android-only gate,
+			// the guard reschedules indefinitely and starves the managed DispatcherQueue,
+			// freezing taps/buttons/back-nav while UIKit-routed scroll keeps working.
+			//
+			// This test seeds the trap state (prior Bounds matches current; prior VisibleBounds
+			// differs from current) and asserts that on non-Android the guard never engages.
+			var grid = new Grid { Background = new SolidColorBrush(Colors.Red), Width = 200, Height = 200 };
+			SafeArea.SetInsets(grid, SafeArea.InsetMask.VisibleBounds);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(grid);
+			await UnitTestUIContentHelperEx.WaitForIdle();
+
+			var details = SafeArea.SafeAreaDetails.FindInstance(grid)
+				?? throw new InvalidOperationException("SafeAreaDetails not found");
+
+			var savedBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownBounds;
+			var savedVisibleBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds;
+			var savedPending = SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending;
+
+			try
+			{
+				var currentBounds = Window.Current?.Bounds ?? default;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = currentBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = false;
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
+				await UnitTestUIContentHelperEx.WaitForIdle();
+
+				Assert.IsFalse(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"Bounds-transition guard must stay gated off on non-Android — otherwise iPad live-locks the managed dispatcher after a FormSheet modal dismisses (see fix/iPadOS.transitions).");
+			}
+			finally
+			{
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = savedBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = savedVisibleBounds;
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = savedPending;
+			}
+		}
+#endif
+
 #if __ANDROID__
 		[TestMethod]
 		public async Task Translucent_SystemBars()

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -462,8 +462,29 @@ namespace Uno.Toolkit.UI
 					return;
 				}
 
-				// Detect race condition: VisibleBounds updated before Window.Bounds
-				if (!HasSoftInput())
+				// Detect race condition: VisibleBounds updated before Window.Bounds.
+				//
+				// On Android, StatusBar translucency transitions can cause
+				// ApplicationView.VisibleBounds to update before Window.Bounds, which leads
+				// GetWindowInsets() to compute an inflated bottom inset against the stale
+				// Bounds and permanently stretch Auto-sized rows. Deferring the inset
+				// computation until Window.Bounds catches up resolves that.
+				// (See PR #1554 / dispatchscience-private#74.)
+				//
+				// The guard is restricted to Android at runtime because the same shape of
+				// state — VisibleBounds changes while Window.Bounds stays stable — arises
+				// naturally on iPad after a UIImagePickerController-style FormSheet /
+				// OverFullScreen modal dismisses. There, Window.Bounds will never catch up
+				// (iOS keeps the host view attached and the modal did not change Bounds),
+				// so the deferred UpdateInsets call reschedules itself indefinitely on the
+				// DispatcherQueue and live-locks managed input handling — scroll continues
+				// to work because UIKit gesture recognizers route at the native layer, but
+				// taps/buttons/back-nav stop responding.
+				//
+				// `OperatingSystem.IsAndroid()` (vs `#if __ANDROID__`) is required so the
+				// guard remains active for Skia Android builds (`net9.0` TFM without the
+				// `__ANDROID__` define).
+				if (!HasSoftInput() && OperatingSystem.IsAndroid())
 				{
 					var currentBounds = XamlWindow.Current?.Bounds ?? Rect.Empty;
 					var currentVB = ApplicationView.GetForCurrentView().VisibleBounds;

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -293,6 +293,11 @@ namespace Uno.Toolkit.UI
 			internal event TypedEventHandler<SafeAreaDetails, Thickness>? EffectiveInsetsApplied;
 #if DEBUG
 			internal event TypedEventHandler<SafeAreaDetails, Thickness>? InsetsApplied;
+
+			internal static Rect TestHook_LastKnownBounds { get => s_lastKnownBounds; set => s_lastKnownBounds = value; }
+			internal static Rect TestHook_LastKnownVisibleBounds { get => s_lastKnownVisibleBounds; set => s_lastKnownVisibleBounds = value; }
+			internal static bool TestHook_BoundsTransitionPending { get => s_boundsTransitionPending; set => s_boundsTransitionPending = value; }
+			internal void TestHook_InvokeUpdateInsets(bool forceUpdate = false) => UpdateInsets(forceUpdate);
 #endif
 
 			// Track the last-known Window.Bounds and VisibleBounds to detect race conditions


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/kahua-private/issues/458

The bounds-transition guard added in PR #1554 (to fix Android StatusBar translucency inset inflation) fires on iPad after a UIImagePickerController-style FormSheet/OverFullScreen modal dismisses: VisibleBounds transiently differs from Window.Bounds while iOS keeps the host view attached, so Window.Bounds never "catches up" and the deferred UpdateInsets call reschedules itself indefinitely on the DispatcherQueue. That live-lock starves managed input handling — UIKit-level scroll gestures keep working because they route at the native layer, but taps/buttons/back-navigation stop responding.

Restrict the guard to Android via OperatingSystem.IsAndroid() so the original Android race fix is preserved while iOS/macOS/WASM revert to the pre-PR-#1554 control flow. Use the runtime check instead of #if __ANDROID__ so Skia Android (net9.0 TFM, no __ANDROID__ define) is still covered.

Note: Tested this fix on client app and it worked.


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [x] iOS
	- [x] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
