### PR TITLE
feat: replace hardcoded dimensions with design tokens in toolkit controls

### DIFF
--- a/doc/controls/ChipAndChipGroup.md
+++ b/doc/controls/ChipAndChipGroup.md
@@ -91,22 +91,25 @@ xmlns:utu="using:Uno.Toolkit.UI"
 
 ## Lightweight Styling
 
-| Key                                    | Type              | Value                               |
-|----------------------------------------|-------------------|-------------------------------------|
-| `ChipContentMinHeight`                 | `Double`          | 20                                  |
-| `ChipDeleteIconContainerLength`        | `Double`          | 18                                  |
-| `ChipDeleteIconLength`                 | `Double`          | 11                                  |
-| `ChipElevation`                        | `Double`          | 4                                   |
-| `ChipElevationDisabled`                | `Double`          | 0                                   |
-| `ChipHeight`                           | `Double`          | 32                                  |
-| `ChipIconSize`                         | `Double`          | 18                                  |
-| `ChipSize`                             | `Double`          | 12                                  |
-| `ChipCornerRadius`                     | `CornerRadius`    | 8                                   |
-| `ChipBorderThickness`                  | `Thickness`       | 1                                   |
-| `ChipContentMargin`                    | `Thickness`       | 8,0                                 |
-| `ChipElevationBorderThickness`         | `Thickness`       | 0                                   |
-| `ChipElevationMargin`                  | `Thickness`       | 4                                   |
-| `ChipPadding`                          | `Thickness`       | 8,0                                 |
+> [!TIP]
+> Values marked with a design token name adjust automatically when you change `DefaultDensity` or `DefaultCornerRadius`. See [Design Tokens](../design-tokens.md) for details.
+
+| Key                                    | Type              | Value (Regular) | Design Token                 |
+|----------------------------------------|-------------------|:---------------:|------------------------------|
+| `ChipContentMinHeight`                 | `Double`          | 20              | `Space500`                   |
+| `ChipDeleteIconContainerLength`        | `Double`          | 18              |                              |
+| `ChipDeleteIconLength`                 | `Double`          | 11              |                              |
+| `ChipElevation`                        | `Double`          | 4               |                              |
+| `ChipElevationDisabled`                | `Double`          | 0               |                              |
+| `ChipHeight`                           | `Double`          | 32              | `ControlHeightSmall`         |
+| `ChipIconSize`                         | `Double`          | 18              |                              |
+| `ChipSize`                             | `Double`          | 12              | `Space300`                   |
+| `ChipCornerRadius`                     | `CornerRadius`    | 8               | `Radius200CornerRadius`      |
+| `ChipBorderThickness`                  | `Thickness`       | 1               |                              |
+| `ChipContentMargin`                    | `Thickness`       | 8,0             | `Space200HorizontalThickness`|
+| `ChipElevationBorderThickness`         | `Thickness`       | 0               |                              |
+| `ChipElevationMargin`                  | `Thickness`       | 4               | `Space100Thickness`          |
+| `ChipPadding`                          | `Thickness`       | 8,0             | `Space200HorizontalThickness`|
 | `ChipBackground`                       | `SolidColorBrush` | `SystemControlTransparentBrush`     |
 | `ChipBackgroundPointerOver`            | `SolidColorBrush` | `SystemControlTransparentBrush`     |
 | `ChipBackgroundFocused`                | `SolidColorBrush` | `SystemControlTransparentBrush`     |

--- a/doc/controls/Divider.md
+++ b/doc/controls/Divider.md
@@ -14,16 +14,19 @@ A divider is a thin line that groups content in lists and layouts.
 
 ## Lightweight Styling
 
-| Key                              | Type                 | Value                       |
-|------------------------------------|--------------------|-----------------------------|
-| `DividerForeground`                | `SolidColorBrush`  | `OutlineVariantBrush`       |
-| `DividerSubHeaderForeground`       | `SolidColorBrush`  | `OnSurfaceLowBrush`         |
-| `DividerSubHeaderFontFamily`       | `FontFamily`       | `BodySmallFontFamily`       |
-| `DividerSubHeaderFontWeight`       | `FontWeight`       | `BodySmallFontWeight`       |
-| `DividerSubHeaderFontSize`         | `FontSize`         | `BodySmallFontSize`         |
-| `DividerSubHeaderCharacterSpacing` | `CharacterSpacing` | `BodySmallCharacterSpacing` |
-| `DividerSubHeaderMargin`           | `Thickness`        | `0,4,0,0`                   |
-| `DividerHeight`                    | `Double`           | `1`                         |
+> [!TIP]
+> Values marked with a design token name adjust automatically when you change `DefaultDensity` or `DefaultCornerRadius`. See [Design Tokens](../design-tokens.md) for details.
+
+| Key                              | Type                 | Value (Regular)             | Design Token            |
+|------------------------------------|--------------------|-----------------------------|-------------------------|
+| `DividerForeground`                | `SolidColorBrush`  | `OutlineVariantBrush`       |                         |
+| `DividerSubHeaderForeground`       | `SolidColorBrush`  | `OnSurfaceLowBrush`         |                         |
+| `DividerSubHeaderFontFamily`       | `FontFamily`       | `BodySmallFontFamily`       |                         |
+| `DividerSubHeaderFontWeight`       | `FontWeight`       | `BodySmallFontWeight`       |                         |
+| `DividerSubHeaderFontSize`         | `FontSize`         | `BodySmallFontSize`         |                         |
+| `DividerSubHeaderCharacterSpacing` | `CharacterSpacing` | `BodySmallCharacterSpacing` |                         |
+| `DividerSubHeaderMargin`           | `Thickness`        | `0,4,0,0`                   | `Space100TopThickness`  |
+| `DividerHeight`                    | `Double`           | `1`                         |                         |
 
 ## Usage
 

--- a/doc/controls/NavigationBar.md
+++ b/doc/controls/NavigationBar.md
@@ -412,50 +412,53 @@ Only supports `BitmapImage` on iOS/Android
 
 ## Lightweight Styling
 
-| Key                                                                    | Type              | Value                                   |
-|------------------------------------------------------------------------|-------------------|-----------------------------------------|
-| `NavigationBarCommandBarEllipsisIconForegroundDisabled`                | `SolidColorBrush` | TextFillColorDisabledBrush              |
-| `NavigationBarCommandBarBackgroundCompactOpenUp`                       | `SolidColorBrush` | SurfaceBrush                            |
-| `NavigationBarCommandBarBackgroundCompactOpenDown`                     | `SolidColorBrush` | SurfaceBrush                            |
-| `NavigationBarMainCommandForeground`                                   | `SolidColorBrush` | OnSurfaceBrush                          |
-| `NavigationBarForeground`                                              | `SolidColorBrush` | OnSurfaceBrush                          |
-| `NavigationBarBackground`                                              | `SolidColorBrush` | SurfaceBrush                            |
-| `NavigationBarPadding`                                                 | `Thickness`       | 4,0,0,0                                 |
-| `NavigationBarFontFamily`                                              | `FontFamily`      | TitleLargeFontFamily                    |
-| `NavigationBarFontWeight`                                              | `String`          | TitleLargeFontWeight                    |
-| `NavigationBarFontSize`                                                | `Double`          | TitleLargeFontSize                      |
-| `NavigationBarBackIconData`                                            | `String`          | NavigationBarBackIconData               |
-| `MaterialModalNavigationBarMainCommandForeground`                      | `SolidColorBrush` | OnSurfaceBrush                          |
-| `MaterialModalNavigationBarForeground`                                 | `SolidColorBrush` | OnSurfaceBrush                          |
-| `MaterialModalNavigationBarBackground`                                 | `SolidColorBrush` | SurfaceBrush                            |
-| `MaterialPrimaryNavigationBarCommandBarEllipsisIconForegroundDisabled` | `SolidColorBrush` | TextFillColorDisabledBrush              |
-| `MaterialPrimaryNavigationBarCommandBarBackgroundCompactOpenUp`        | `SolidColorBrush` | PrimaryBrush                            |
-| `MaterialPrimaryNavigationBarCommandBarBackgroundCompactOpenDown`      | `SolidColorBrush` | PrimaryBrush                            |
-| `MaterialPrimaryNavigationBarMainCommandForeground`                    | `SolidColorBrush` | OnPrimaryBrush                          |
-| `MaterialPrimaryNavigationBarForeground`                               | `SolidColorBrush` | OnPrimaryBrush                          |
-| `MaterialPrimaryNavigationBarBackground`                               | `SolidColorBrush` | PrimaryBrush                            |
-| `MaterialPrimaryAppBarButtonForeground`                                | `SolidColorBrush` | OnPrimaryBrush                          |
-| `MaterialPrimaryModalNavigationBarMainCommandForeground`               | `SolidColorBrush` | OnPrimaryBrush                          |
-| `MaterialPrimaryModalNavigationBarForeground`                          | `SolidColorBrush` | OnPrimaryBrush                          |
-| `MaterialPrimaryModalNavigationBarBackground`                          | `SolidColorBrush` | PrimaryBrush                            |
-| `NavigationBarOverflowAppBarButtonForeground`                          | `SolidColorBrush` | OnPrimaryBrush                          |
-| `NavigationBarOverflowAppBarButtonBackground`                          | `SolidColorBrush` | SolidColorBrush { Color = Transparent } |
-| `NavigationBarEllipsisButtonForeground`                                | `SolidColorBrush` | OnSurfaceBrush                          |
-| `NavigationBarEllipsisButtonBackground`                                | `SolidColorBrush` | SolidColorBrush { Color = Transparent } |
-| `MaterialNavigationBarElevation`                                       | `Double`          | 4                                       |
-| `MaterialXamlNavigationBarHeight`                                      | `Double`          | 64                                      |
-| `MaterialNavigationBarHeight`                                          | `Double`          | 48                                      |
-| `MaterialNavigationBarContentMargin`                                   | `Thickness`       | 16,0,0,0                                |
-| `MaterialAppBarEllipsisButtonInnerBorderMargin`                        | `Thickness`       | 2,6,6,6                                 |
-| `NavigationBarMaterialEllipsisButtonFontFamily`                        | `FontFamily`      | MaterialRegularFontFamily               |
-| `NavigationBarMaterialEllipsisButtonFontWeight`                        | `FontWeight`      | SemiBold                                |
-| `NavigationBarMaterialEllipsisButtonFontSize`                          | `Double`          | ControlContentThemeFontSize             |
-| `NavigationBarMaterialEllipsisButtonWidth`                             | `Double`          | AppBarExpandButtonThemeWidth            |
-| `NavBarAppBarButtonContentHeight`                                      | `Double`          | 24                                      |
-| `NavBarMainCommandAppBarButtonContentHeight`                           | `Double`          | 16                                      |
-| `NavBarAppBarThemeCompactHeight`                                       | `Double`          | 56                                      |
-| `NavBarAppBarButtonPadding`                                            | `Thickness`       | 12,16                                   |
-| `NavBarAppBarButtonHasFlyoutChevronVisibility`                         | `Visibility`      | Collapsed                               |
+> [!TIP]
+> Values marked with a design token name adjust automatically when you change `DefaultDensity` or `DefaultCornerRadius`. See [Design Tokens](../design-tokens.md) for details.
+
+| Key                                                                    | Type              | Value (Regular)                         | Design Token                    |
+|------------------------------------------------------------------------|-------------------|-----------------------------------------|---------------------------------|
+| `NavigationBarCommandBarEllipsisIconForegroundDisabled`                | `SolidColorBrush` | TextFillColorDisabledBrush              |                                 |
+| `NavigationBarCommandBarBackgroundCompactOpenUp`                       | `SolidColorBrush` | SurfaceBrush                            |                                 |
+| `NavigationBarCommandBarBackgroundCompactOpenDown`                     | `SolidColorBrush` | SurfaceBrush                            |                                 |
+| `NavigationBarMainCommandForeground`                                   | `SolidColorBrush` | OnSurfaceBrush                          |                                 |
+| `NavigationBarForeground`                                              | `SolidColorBrush` | OnSurfaceBrush                          |                                 |
+| `NavigationBarBackground`                                              | `SolidColorBrush` | SurfaceBrush                            |                                 |
+| `NavigationBarPadding`                                                 | `Thickness`       | 4,0,0,0                                | `Space100LeftThickness`         |
+| `NavigationBarFontFamily`                                              | `FontFamily`      | TitleLargeFontFamily                    |                                 |
+| `NavigationBarFontWeight`                                              | `String`          | TitleLargeFontWeight                    |                                 |
+| `NavigationBarFontSize`                                                | `Double`          | TitleLargeFontSize                      |                                 |
+| `NavigationBarBackIconData`                                            | `String`          | NavigationBarBackIconData               |                                 |
+| `MaterialModalNavigationBarMainCommandForeground`                      | `SolidColorBrush` | OnSurfaceBrush                          |                                 |
+| `MaterialModalNavigationBarForeground`                                 | `SolidColorBrush` | OnSurfaceBrush                          |                                 |
+| `MaterialModalNavigationBarBackground`                                 | `SolidColorBrush` | SurfaceBrush                            |                                 |
+| `MaterialPrimaryNavigationBarCommandBarEllipsisIconForegroundDisabled` | `SolidColorBrush` | TextFillColorDisabledBrush              |                                 |
+| `MaterialPrimaryNavigationBarCommandBarBackgroundCompactOpenUp`        | `SolidColorBrush` | PrimaryBrush                            |                                 |
+| `MaterialPrimaryNavigationBarCommandBarBackgroundCompactOpenDown`      | `SolidColorBrush` | PrimaryBrush                            |                                 |
+| `MaterialPrimaryNavigationBarMainCommandForeground`                    | `SolidColorBrush` | OnPrimaryBrush                          |                                 |
+| `MaterialPrimaryNavigationBarForeground`                               | `SolidColorBrush` | OnPrimaryBrush                          |                                 |
+| `MaterialPrimaryNavigationBarBackground`                               | `SolidColorBrush` | PrimaryBrush                            |                                 |
+| `MaterialPrimaryAppBarButtonForeground`                                | `SolidColorBrush` | OnPrimaryBrush                          |                                 |
+| `MaterialPrimaryModalNavigationBarMainCommandForeground`               | `SolidColorBrush` | OnPrimaryBrush                          |                                 |
+| `MaterialPrimaryModalNavigationBarForeground`                          | `SolidColorBrush` | OnPrimaryBrush                          |                                 |
+| `MaterialPrimaryModalNavigationBarBackground`                          | `SolidColorBrush` | PrimaryBrush                            |                                 |
+| `NavigationBarOverflowAppBarButtonForeground`                          | `SolidColorBrush` | OnPrimaryBrush                          |                                 |
+| `NavigationBarOverflowAppBarButtonBackground`                          | `SolidColorBrush` | SolidColorBrush { Color = Transparent } |                                 |
+| `NavigationBarEllipsisButtonForeground`                                | `SolidColorBrush` | OnSurfaceBrush                          |                                 |
+| `NavigationBarEllipsisButtonBackground`                                | `SolidColorBrush` | SolidColorBrush { Color = Transparent } |                                 |
+| `MaterialNavigationBarElevation`                                       | `Double`          | 4                                       |                                 |
+| `MaterialXamlNavigationBarHeight`                                      | `Double`          | 64                                      | `Space1600`                     |
+| `MaterialNavigationBarHeight`                                          | `Double`          | 64                                      | `Space1600`                     |
+| `MaterialNavigationBarContentMargin`                                   | `Thickness`       | 16,0,16,0                              | `Space400HorizontalThickness`   |
+| `MaterialAppBarEllipsisButtonInnerBorderMargin`                        | `Thickness`       | 2,6,6,6                                |                                 |
+| `NavigationBarMaterialEllipsisButtonFontFamily`                        | `FontFamily`      | MaterialRegularFontFamily               |                                 |
+| `NavigationBarMaterialEllipsisButtonFontWeight`                        | `FontWeight`      | SemiBold                                |                                 |
+| `NavigationBarMaterialEllipsisButtonFontSize`                          | `Double`          | ControlContentThemeFontSize             |                                 |
+| `NavigationBarMaterialEllipsisButtonWidth`                             | `Double`          | AppBarExpandButtonThemeWidth            |                                 |
+| `NavBarAppBarButtonContentHeight`                                      | `Double`          | 16                                      | `IconSizeSmall`                 |
+| `NavBarMainCommandAppBarButtonContentHeight`                           | `Double`          | 24                                      | `IconSizeMedium`                |
+| `NavBarAppBarThemeCompactHeight`                                       | `Double`          | 64                                      | `Space1600`                     |
+| `NavBarAppBarButtonPadding`                                            | `Thickness`       | 12,16                                   |                                 |
+| `NavBarAppBarButtonHasFlyoutChevronVisibility`                         | `Visibility`      | Collapsed                               |                                 |
 
 ## Navigation
 

--- a/doc/controls/TabBarAndTabBarItem.md
+++ b/doc/controls/TabBarAndTabBarItem.md
@@ -568,7 +568,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 | Key                                                                  | Type            | Value (Regular)                              | Design Token                    |
 |----------------------------------------------------------------------|-----------------|----------------------------------------------|---------------------------------|
 | `NavigationTabBarWidthOrHeight`                                    | `Double`          | 80                                           |                                 |
-| `NavigationTabBarTintOpacity`                                      | `Double`          | 0.8                                          |                                 |
+| `NavigationTabBarTintOpacity`                                      | `Double`          | 0.08                                         |                                 |
 | `NavigationTabBarItemIconHeight`                                   | `Double`          | 18                                           |                                 |
 | `NavigationTabBarItemActiveIndicatorWidth`                         | `Double`          | 64                                           | `Space1600`                     |
 | `NavigationTabBarItemActiveIndicatorHeight`                        | `Double`          | 32                                           | `ControlHeightSmall`            |

--- a/doc/controls/TabBarAndTabBarItem.md
+++ b/doc/controls/TabBarAndTabBarItem.md
@@ -562,31 +562,34 @@ xmlns:utu="using:Uno.Toolkit.UI"
 
 ## Lightweight Styling
 
-| Key                                                                  | Type            | Value                                        |
-|----------------------------------------------------------------------|-----------------|----------------------------------------------|
-| `NavigationTabBarWidthOrHeight`                                    | `Double`          | 80                                           |
-| `NavigationTabBarTintOpacity`                                      | `Double`          | 0.8                                          |
-| `NavigationTabBarItemIconHeight`                                   | `Double`          | 18                                           |
-| `NavigationTabBarItemActiveIndicatorWidth`                         | `Double`          | 64                                           |
-| `NavigationTabBarItemActiveIndicatorHeight`                        | `Double`          | 32                                           |
-| `NavigationTabBarItemPadding`                                      | `Thickness`       | 0,12,0,16                                    |
-| `NavigationTabBarItemActiveIndicatorCornerRadius`                  | `CornerRadius`    | 16                                           |
-| `TopTabBarHeight`                                                  | `Double`          | 48                                           |
-| `TopTabBarItemIconHeight`                                          | `Double`          | 20                                           |
-| `TopTabBarItemContentMargin`                                       | `Thickness`       | 0                                            |
-| `FabTabBarItemOffset`                                              | `Double`          | -32                                          |
-| `FabTabBarItemContentWidthOrHeight`                                | `Double`          | 16                                           |
-| `FabTabBarItemIconTextPadding`                                     | `Double`          | 12                                           |
-| `FabTabBarItemCornerRadius`                                        | `CornerRadius`    | 16                                           |
-| `FabTabBarItemPadding`                                             | `Thickness`       | 20                                           |
-| `NavigationTabBarItemSmallBadgeHeight`                             | `Double`          | 6                                            |
-| `NavigationTabBarItemSmallBadgeWidth`                              | `Double`          | 6                                            |
-| `NavigationTabBarItemSmallBadgeMargin`                             | `Thickness`       | 0,4,20,0                                     |
-| `NavigationTabBarItemLargeBadgeHeight`                             | `Double`          | 16                                           |
-| `NavigationTabBarItemLargeBadgeMinWidth`                           | `Double`          | 16                                           |
-| `NavigationTabBarItemLargeBadgeMargin`                             | `Thickness`       | 32,2,0,0                                     |
-| `NavigationTabBarItemLargeBadgePadding`                            | `Thickness`       | 4,0                                          |
-| `NavigationTabBarItemLargeBadgeCornerRadius`                       | `CornerRadius`    | 8                                            |
+> [!TIP]
+> Values marked with a design token name adjust automatically when you change `DefaultDensity` or `DefaultCornerRadius`. See [Design Tokens](../design-tokens.md) for details.
+
+| Key                                                                  | Type            | Value (Regular)                              | Design Token                    |
+|----------------------------------------------------------------------|-----------------|----------------------------------------------|---------------------------------|
+| `NavigationTabBarWidthOrHeight`                                    | `Double`          | 80                                           |                                 |
+| `NavigationTabBarTintOpacity`                                      | `Double`          | 0.8                                          |                                 |
+| `NavigationTabBarItemIconHeight`                                   | `Double`          | 18                                           |                                 |
+| `NavigationTabBarItemActiveIndicatorWidth`                         | `Double`          | 64                                           | `Space1600`                     |
+| `NavigationTabBarItemActiveIndicatorHeight`                        | `Double`          | 32                                           | `ControlHeightSmall`            |
+| `NavigationTabBarItemPadding`                                      | `Thickness`       | 0,12,0,16                                    |                                 |
+| `NavigationTabBarItemActiveIndicatorCornerRadius`                  | `CornerRadius`    | 16                                           | `Radius400CornerRadius`         |
+| `TopTabBarHeight`                                                  | `Double`          | 48                                           | `ControlHeightLarge`            |
+| `TopTabBarItemIconHeight`                                          | `Double`          | 20                                           | `Space500`                      |
+| `TopTabBarItemContentMargin`                                       | `Thickness`       | 8,0,0,0                                      | `Space200LeftThickness`         |
+| `FabTabBarItemOffset`                                              | `Double`          | -32                                          |                                 |
+| `FabTabBarItemContentWidthOrHeight`                                | `Double`          | 16                                           | `IconSizeSmall`                 |
+| `FabTabBarItemIconTextPadding`                                     | `Double`          | 12                                           | `Space300`                      |
+| `FabTabBarItemCornerRadius`                                        | `CornerRadius`    | 16                                           | `Radius400CornerRadius`         |
+| `FabTabBarItemPadding`                                             | `Thickness`       | 20                                           | `Space500Thickness`             |
+| `NavigationTabBarItemSmallBadgeHeight`                             | `Double`          | 6                                            | `Space150`                      |
+| `NavigationTabBarItemSmallBadgeWidth`                              | `Double`          | 6                                            | `Space150`                      |
+| `NavigationTabBarItemSmallBadgeMargin`                             | `Thickness`       | 0,4,20,0                                    |                                 |
+| `NavigationTabBarItemLargeBadgeHeight`                             | `Double`          | 16                                           | `Space400`                      |
+| `NavigationTabBarItemLargeBadgeMinWidth`                           | `Double`          | 16                                           | `Space400`                      |
+| `NavigationTabBarItemLargeBadgeMargin`                             | `Thickness`       | 32,2,0,0                                    |                                 |
+| `NavigationTabBarItemLargeBadgePadding`                            | `Thickness`       | 4,0                                          | `Space100HorizontalThickness`   |
+| `NavigationTabBarItemLargeBadgeCornerRadius`                       | `CornerRadius`    | 8                                            | `Radius200CornerRadius`         |
 | `VerticalTabBarBackground`                                         | `SolidColorBrush` | SurfaceBrush                                 |
 | `BottomTabBarBackground`                                           | `SolidColorBrush` | SurfaceBrush                                 |
 | `TopTabBarBackground`                                              | `SolidColorBrush` | BackgroundBrush                              |

--- a/doc/design-tokens.md
+++ b/doc/design-tokens.md
@@ -1,0 +1,177 @@
+---
+uid: Toolkit.DesignTokens
+---
+# Design Tokens
+
+The Uno Toolkit uses the **design token system** defined in [Uno.Themes](xref:uno.themes.designtokens) to control spacing, shape (corner radius), and density across all controls. Instead of hardcoding pixel values, toolkit controls reference semantic token keys that automatically adjust when the density or corner-radius base changes.
+
+> [!TIP]
+> For the full list of token keys and how they are generated, see the [Uno.Themes Design Tokens](xref:uno.themes.designtokens) documentation.
+
+## Token Categories Used by Toolkit Controls
+
+### Spacing (`Space*`)
+
+Spacing tokens control padding, margins, and layout gaps. They are computed as multiples of a base unit set by `DefaultDensity`.
+
+| Token | Regular (4 px) | Compact (3 px) | Comfy (5 px) |
+|-------|:--------------:|:--------------:|:------------:|
+| `Space100` | 4 | 3 | 5 |
+| `Space150` | 6 | 4.5 | 7.5 |
+| `Space200` | 8 | 6 | 10 |
+| `Space300` | 12 | 9 | 15 |
+| `Space400` | 16 | 12 | 20 |
+| `Space500` | 20 | 15 | 25 |
+| `Space600` | 24 | 18 | 30 |
+| `Space1600` | 64 | 48 | 80 |
+
+Each `Space*` key also has directional `Thickness` variants: `Space200Thickness`, `Space200HorizontalThickness`, `Space200LeftThickness`, `Space200TopThickness`, `Space200BottomThickness`, etc.
+
+### Shape (`Radius*`)
+
+Corner radius tokens are multiples of a base value set by `DefaultCornerRadius` (default: 4).
+
+| Token | Default (4 px) |
+|-------|:--------------:|
+| `Radius100` | 4 |
+| `Radius200` | 8 |
+| `Radius300` | 12 |
+| `Radius400` | 16 |
+
+Each also has a `CornerRadius` variant: `Radius200CornerRadius`, etc.
+
+### Fixed Tokens (Density-Invariant)
+
+These values remain constant regardless of density:
+
+| Token | Value (px) | Usage |
+|-------|:----------:|-------|
+| `ControlHeightSmall` | 32 | Chip height |
+| `ControlHeightMedium` | 40 | Avatar dimensions |
+| `ControlHeightMediumLarge` | 44 | iOS NavigationBar presenter |
+| `ControlHeightLarge` | 48 | Top TabBar height |
+| `IconSizeSmall` | 16 | AppBar button icons, FAB icon |
+| `IconSizeMedium` | 24 | Main command icons |
+
+## Toolkit Controls Using Design Tokens
+
+The following table maps toolkit controls to the tokens they reference. Values shown are for **Regular** density (base = 4 px) and default corner radius (base = 4 px).
+
+### Card
+
+| Resource Key | Token | Regular Value |
+|---|---|:---:|
+| `CardPadding` | `Space400Thickness` | 16 |
+| `CardCornerRadius` | `Radius300CornerRadius` | 12 |
+| `CardElevationMargin` | `Space150Thickness` | 6 |
+
+### Chip
+
+| Resource Key | Token | Regular Value |
+|---|---|:---:|
+| `ChipHeight` | `ControlHeightSmall` | 32 |
+| `ChipSize` | `Space300` | 12 |
+| `ChipCornerRadius` | `Radius200CornerRadius` | 8 |
+| `ChipContentMargin` | `Space200HorizontalThickness` | 8,0 |
+| `ChipPadding` | `Space200HorizontalThickness` | 8,0 |
+| `ChipElevationMargin` | `Space100Thickness` | 4 |
+| `ChipContentMinHeight` | `Space500` | 20 |
+
+### Divider
+
+| Resource Key | Token | Regular Value |
+|---|---|:---:|
+| `DividerSubHeaderMargin` | `Space100TopThickness` | 0,4,0,0 |
+
+### NavigationBar
+
+| Resource Key | Token | Regular Value |
+|---|---|:---:|
+| `MaterialXamlNavigationBarHeight` | `Space1600` | 64 |
+| `MaterialNavigationBarHeight` | `Space1600` | 64 |
+| `MaterialNavigationBarContentMargin` | `Space400HorizontalThickness` | 16,0,16,0 |
+| `NavigationBarPadding` | `Space100LeftThickness` | 4,0,0,0 |
+| `NavBarAppBarButtonContentHeight` | `IconSizeSmall` | 16 |
+| `NavBarMainCommandAppBarButtonContentHeight` | `IconSizeMedium` | 24 |
+| `NavBarAppBarThemeCompactHeight` | `Space1600` | 64 |
+
+### TabBar
+
+| Resource Key | Token | Regular Value |
+|---|---|:---:|
+| `TopTabBarHeight` | `ControlHeightLarge` | 48 |
+| `NavigationTabBarItemActiveIndicatorCornerRadius` | `Radius400CornerRadius` | 16 |
+| `TopTabBarItemIconHeight` | `Space500` | 20 |
+| `TopTabBarItemContentMargin` | `Space200LeftThickness` | 8,0,0,0 |
+| `FabTabBarItemContentWidthOrHeight` | `IconSizeSmall` | 16 |
+| `FabTabBarItemIconTextPadding` | `Space300` | 12 |
+| `FabTabBarItemCornerRadius` | `Radius400CornerRadius` | 16 |
+| `FabTabBarItemPadding` | `Space500Thickness` | 20 |
+| `NavigationTabBarItemSmallBadgeHeight` | `Space150` | 6 |
+| `NavigationTabBarItemSmallBadgeWidth` | `Space150` | 6 |
+| `NavigationTabBarItemLargeBadgeHeight` | `Space400` | 16 |
+| `NavigationTabBarItemLargeBadgeMinWidth` | `Space400` | 16 |
+| `NavigationTabBarItemLargeBadgePadding` | `Space100HorizontalThickness` | 4,0 |
+| `NavigationTabBarItemLargeBadgeCornerRadius` | `Radius200CornerRadius` | 8 |
+
+## Customizing Density
+
+Set the `DefaultDensity` property on your theme to adjust all spacing-based tokens at once:
+
+```xml
+<!-- Compact — base spacing = 3 px -->
+<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
+                      DefaultDensity="Compact" />
+
+<!-- Regular (default) — base spacing = 4 px -->
+<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material" />
+
+<!-- Comfy — base spacing = 5 px -->
+<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
+                      DefaultDensity="Comfy" />
+```
+
+The same property is available on `SimpleToolkitTheme`:
+
+```xml
+<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
+                    DefaultDensity="Compact" />
+```
+
+## Customizing Corner Radius
+
+Set `DefaultCornerRadius` to change the base unit for all shape tokens:
+
+```xml
+<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
+                      DefaultCornerRadius="6" />
+```
+
+With `DefaultCornerRadius="6"`, `Radius200CornerRadius` becomes `12` instead of `8`.
+
+## Overriding Individual Tokens
+
+You can override any token at any scope using standard XAML resource overrides:
+
+```xml
+<!-- Override globally in App.xaml -->
+<x:Double x:Key="Space400">20</x:Double>
+<Thickness x:Key="Space400Thickness">20</Thickness>
+
+<!-- Override at page scope -->
+<Page.Resources>
+    <CornerRadius x:Key="Radius200CornerRadius">10</CornerRadius>
+</Page.Resources>
+
+<!-- Override per control via lightweight styling -->
+<utu:Card>
+    <utu:Card.Resources>
+        <Thickness x:Key="CardPadding">24</Thickness>
+    </utu:Card.Resources>
+</utu:Card>
+```
+
+## Further Reading
+
+- [Uno.Themes Design Tokens](xref:uno.themes.designtokens) — full token key reference and generation logic
+- [Lightweight Styling](xref:Toolkit.LightweightStyling) — per-control resource key overrides

--- a/doc/lightweight-styling.md
+++ b/doc/lightweight-styling.md
@@ -55,6 +55,9 @@ All Lightweight Styling resource keys can also be used in C# Markup through a co
 
 ## Resource Keys
 
+> [!NOTE]
+> Many dimension-based resource keys (padding, margins, corner radii, heights) are now backed by [design tokens](design-tokens.md) that adjust automatically with `DefaultDensity` and `DefaultCornerRadius`. See the **Design Token** column in each control's table below.
+
 For more information about the lightweight styling resource keys used in each control, check out the following links:
 
 - [Card](controls/CardAndCardContentControl.md#lightweight-styling)

--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -16,6 +16,9 @@
   # ***************** Lightweight Styling ********
   - name: Lightweight Styling
     href: lightweight-styling.md
+  # ***************** Design Tokens **************
+  - name: Design Tokens
+    href: design-tokens.md
 
 # ******************* Learn **********************
 #- name: Learn

--- a/doc/uno-toolkit-migration.md
+++ b/doc/uno-toolkit-migration.md
@@ -25,11 +25,13 @@ Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-base
 
     This only affects code that merged these dictionaries directly by URI. Apps using `<MaterialToolkitTheme/>` or `<SimpleToolkitTheme/>` are unaffected.
 
-3. `MaterialToolkitTheme` and new `SimpleToolkitTheme` inherit from their underlying theme
+3. `BaseToolkitTheme` removed — toolkit themes inherit from their underlying theme directly
 
-    Previously `MaterialToolkitTheme` derived from `ResourceDictionary` and instantiated `MaterialTheme` internally as a merged dictionary. It now derives from `MaterialTheme` directly, and the new `SimpleToolkitTheme` derives from `SimpleTheme`. The override dependency properties (`FontOverrideSource`, `ColorOverrideSource`, `FontOverrideDictionary`, `ColorOverrideDictionary`) are now inherited from `BaseTheme` in Uno Themes.
+    The abstract `BaseToolkitTheme` class has been removed. `MaterialToolkitTheme` now derives from `MaterialTheme` directly, and `SimpleToolkitTheme` derives from `SimpleTheme`. The override dependency properties (`FontOverrideSource`, `ColorOverrideSource`, `FontOverrideDictionary`, `ColorOverrideDictionary`) are now inherited from `BaseTheme` in Uno Themes.
 
-    Source-compatible for normal XAML and C# usage — no changes required if you set these properties via XAML attributes or the standard property accessors. Reflection-based code that asserts the inheritance chain (e.g. `typeof(MaterialToolkitTheme).BaseType == typeof(ResourceDictionary)`) will need to walk the chain instead.
+    **If you derived from `BaseToolkitTheme`**: change your base class to `MaterialTheme` or `SimpleTheme` (from `Uno.Themes`) as appropriate, then override `GenerateSpecificResources()` to merge your toolkit resources.
+
+    Source-compatible for normal XAML and C# usage — no changes required if you set these properties via XAML attributes or the standard property accessors. Reflection-based code that asserts the inheritance chain (e.g. `typeof(MaterialToolkitTheme).BaseType == typeof(BaseToolkitTheme)`) will need to walk the chain instead.
 
     > [!IMPORTANT]
     > Because `MaterialToolkitTheme` is now also a `MaterialTheme`, do not initialize both `<MaterialTheme/>` and `<MaterialToolkitTheme/>` in the same `App.xaml` — that would cause duplicate theme initialization. The same applies to `<SimpleTheme/>` and `<SimpleToolkitTheme/>`. The toolkit theme already initializes the underlying theme.
@@ -62,7 +64,7 @@ Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-base
 
     | Property              | Type      | Default   | Description                                                                                                                                         |
     |-----------------------|-----------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-    | `DefaultDensity`      | `Density` | `Regular` | Drives the base spacing unit used by `Space*` tokens. Accepted values: `Compact` (3 px), `Regular` (4 px), `Comfy` (5 px). Control heights and icon sizes are unchanged across densities. |
+    | `DefaultDensity`      | `Density` | `Regular` | Drives the base spacing unit used by `Space*` tokens. Accepted values: `Compact` (3 px), `Regular` (4 px), `Comfy` (5 px). Fixed tokens (`ControlHeight*`, `IconSize*`) remain constant; `Space*`-based dimensions (padding, margins, some heights like NavigationBar) scale with density. |
     | `DefaultCornerRadius` | `double`  | `4`       | Base corner radius unit (in pixels). All `Radius*` tokens are computed as multiples of this. `RadiusFull` always remains `9999`.                    |
 
     ```xml

--- a/src/Uno.Toolkit.RuntimeTests/Tests/Given_DesignTokens.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/Given_DesignTokens.cs
@@ -19,32 +19,25 @@ namespace Uno.Toolkit.RuntimeTests.Tests;
 [TestClass]
 public class Given_DesignTokens
 {
-	// ─────────────────────────────────────────────────────────────────────
-	// Helpers
-	// ─────────────────────────────────────────────────────────────────────
+	#region Default Density
 
-	private static (Grid container, MaterialToolkitTheme theme) CreateThemedContainer()
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_DefaultDensity_Then_SpacingBaseIsFour()
 	{
-		var theme = new MaterialToolkitTheme();
-		var container = new Grid();
-		container.Resources.MergedDictionaries.Add(theme);
-		return (container, theme);
+		var (container, theme) = CreateThemedContainer();
+
+		// Default density should be Regular (int value 4), giving spacing base=4.
+		// Validate via Space100 which equals base×1.
+		Assert.AreEqual((int)theme.DefaultDensity, 4,
+			"Default density should be Regular (4)");
+		Assert.AreEqual(4.0, GetResource<double>(container, "Space100"), 0.001,
+			"Space100 should be 4 (base=4 × 1), confirming spacing base=4");
 	}
 
-	private static T GetResource<T>(Grid container, string key)
-	{
-		if (container.Resources.TryGetValue(key, out var value) && value is T typed)
-		{
-			return typed;
-		}
+	#endregion
 
-		Assert.Fail($"Resource '{key}' not found or not of type {typeof(T).Name}");
-		return default!;
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// 1. CARD — padding and corner radius reference design tokens
-	// ═══════════════════════════════════════════════════════════════════════
+	#region Card
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -79,9 +72,9 @@ public class Given_DesignTokens
 			"CardElevationMargin should be Space150Thickness (6) at Regular density");
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 2. CHIP — height, corner radius, padding, margins reference tokens
-	// ═══════════════════════════════════════════════════════════════════════
+	#endregion
+
+	#region Chip
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -147,9 +140,9 @@ public class Given_DesignTokens
 			"ChipContentMinHeight should be Space500 (20) at Regular density");
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 3. NAVIGATION BAR — heights and icon sizes reference tokens
-	// ═══════════════════════════════════════════════════════════════════════
+	#endregion
+
+	#region NavigationBar
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -208,9 +201,9 @@ public class Given_DesignTokens
 			"NavBarAppBarThemeCompactHeight should be Space1600 (64)");
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 4. TAB BAR — heights reference design tokens
-	// ═══════════════════════════════════════════════════════════════════════
+	#endregion
+
+	#region TabBar
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -286,9 +279,9 @@ public class Given_DesignTokens
 		Assert.AreEqual(new Thickness(20), GetResource<Thickness>(container, "FabTabBarItemPadding"));
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 4b. DIVIDER — sub-header margin references design tokens
-	// ═══════════════════════════════════════════════════════════════════════
+	#endregion
+
+	#region Divider
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -301,9 +294,9 @@ public class Given_DesignTokens
 			"DividerSubHeaderMargin should be Space100TopThickness (0,4,0,0)");
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 5. FIXED TOKENS — control heights and icon sizes are density-invariant
-	// ═══════════════════════════════════════════════════════════════════════
+	#endregion
+
+	#region Density Invariance
 
 	[TestMethod]
 	[RunsOnUIThread]
@@ -331,14 +324,17 @@ public class Given_DesignTokens
 			"NavBarMainCommandAppBarButtonContentHeight (IconSizeMedium) should be 24 at all densities");
 	}
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// 6. INTEGRATION — rendered controls use design token values
-	// ═══════════════════════════════════════════════════════════════════════
+	#endregion
+
+	#region Integration — Rendered Controls
 
 	[TestMethod]
 	[RunsOnUIThread]
 	public async Task When_CardRendered_Then_PaddingAndCornerRadiusFromTokens()
 	{
+		if (!Application.Current.Resources.ContainsKey("MaterialFilledCardStyle"))
+			Assert.Inconclusive("MaterialFilledCardStyle not available — run in Material sample app");
+
 		var card = XamlHelper.LoadXaml<Card>("""
 			<utu:Card Style="{StaticResource MaterialFilledCardStyle}" />
 		""");
@@ -358,6 +354,9 @@ public class Given_DesignTokens
 	[RunsOnUIThread]
 	public async Task When_ChipRendered_Then_CornerRadiusAndPaddingFromTokens()
 	{
+		if (!Application.Current.Resources.ContainsKey("MaterialChipStyle"))
+			Assert.Inconclusive("MaterialChipStyle not available — run in Material sample app");
+
 		var chip = XamlHelper.LoadXaml<Chip>("""
 			<utu:Chip Style="{StaticResource MaterialChipStyle}" Content="Test" />
 		""");
@@ -377,6 +376,9 @@ public class Given_DesignTokens
 	[RunsOnUIThread]
 	public async Task When_TopTabBarRendered_Then_MinHeightFromToken()
 	{
+		if (!Application.Current.Resources.ContainsKey("MaterialTopTabBarStyle"))
+			Assert.Inconclusive("MaterialTopTabBarStyle not available — run in Material sample app");
+
 		var tabBar = XamlHelper.LoadXaml<TabBar>("""
 			<utu:TabBar Style="{StaticResource MaterialTopTabBarStyle}">
 				<utu:TabBarItem Content="Tab1" />
@@ -389,5 +391,30 @@ public class Given_DesignTokens
 		Assert.AreEqual(48.0, tabBar.MinHeight, 0.001,
 			"Rendered TabBar.MinHeight should be ControlHeightLarge (48)");
 	}
+
+	#endregion
+
+	#region Helpers
+
+	private static (Grid container, MaterialToolkitTheme theme) CreateThemedContainer()
+	{
+		var theme = new MaterialToolkitTheme();
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+		return (container, theme);
+	}
+
+	private static T GetResource<T>(Grid container, string key)
+	{
+		if (container.Resources.TryGetValue(key, out var value) && value is T typed)
+		{
+			return typed;
+		}
+
+		Assert.Fail($"Resource '{key}' not found or not of type {typeof(T).Name}");
+		return default!;
+	}
+
+	#endregion
 }
 

--- a/src/Uno.Toolkit.RuntimeTests/Tests/Given_DesignTokens.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/Given_DesignTokens.cs
@@ -1,0 +1,395 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Material;
+using Uno.Themes;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.Toolkit.UI.Material;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+/// <summary>
+/// Verifies that toolkit control resources reference the correct design tokens
+/// via <see cref="MaterialToolkitTheme"/>.
+/// Note: Toolkit XAML resources using StaticResource aliases resolve at parse time
+/// against app-level resources, so these tests verify Regular density (base=4, corner=4)
+/// which matches the app theme configuration.
+/// </summary>
+[TestClass]
+public class Given_DesignTokens
+{
+	// ─────────────────────────────────────────────────────────────────────
+	// Helpers
+	// ─────────────────────────────────────────────────────────────────────
+
+	private static (Grid container, MaterialToolkitTheme theme) CreateThemedContainer()
+	{
+		var theme = new MaterialToolkitTheme();
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+		return (container, theme);
+	}
+
+	private static T GetResource<T>(Grid container, string key)
+	{
+		if (container.Resources.TryGetValue(key, out var value) && value is T typed)
+		{
+			return typed;
+		}
+
+		Assert.Fail($"Resource '{key}' not found or not of type {typeof(T).Name}");
+		return default!;
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 1. CARD — padding and corner radius reference design tokens
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_CardPadding_Then_MatchesSpace400Thickness()
+	{
+		var (container, _) = CreateThemedContainer();
+		var padding = GetResource<Thickness>(container, "CardPadding");
+		// Space400Thickness at Regular density (base=4): 4×4=16
+		Assert.AreEqual(new Thickness(16), padding,
+			"CardPadding should be Space400Thickness (16) at Regular density");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_CardCornerRadius_Then_MatchesRadius300CornerRadius()
+	{
+		var (container, _) = CreateThemedContainer();
+		var cr = GetResource<CornerRadius>(container, "CardCornerRadius");
+		// Radius300CornerRadius at base=4: 4×3=12
+		Assert.AreEqual(new CornerRadius(12), cr,
+			"CardCornerRadius should be Radius300CornerRadius (12) at base=4");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_CardElevationMargin_Then_MatchesSpace150Thickness()
+	{
+		var (container, _) = CreateThemedContainer();
+		var margin = GetResource<Thickness>(container, "CardElevationMargin");
+		// Space150Thickness at Regular density (base=4): 4×1.5=6
+		Assert.AreEqual(new Thickness(6), margin,
+			"CardElevationMargin should be Space150Thickness (6) at Regular density");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 2. CHIP — height, corner radius, padding, margins reference tokens
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ChipHeight_Then_MatchesControlHeightSmall()
+	{
+		var (container, _) = CreateThemedContainer();
+		var height = GetResource<double>(container, "ChipHeight");
+		Assert.AreEqual(32.0, height, 0.001, "ChipHeight should be ControlHeightSmall (32)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ChipCornerRadius_Then_MatchesRadius200CornerRadius()
+	{
+		var (container, _) = CreateThemedContainer();
+		var cr = GetResource<CornerRadius>(container, "ChipCornerRadius");
+		// Radius200CornerRadius at base=4: 4×2=8
+		Assert.AreEqual(new CornerRadius(8), cr,
+			"ChipCornerRadius should be Radius200CornerRadius (8) at base=4");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ChipPadding_Then_MatchesSpace200HorizontalThickness()
+	{
+		var (container, _) = CreateThemedContainer();
+		var padding = GetResource<Thickness>(container, "ChipPadding");
+		// Space200HorizontalThickness at Regular (base=4): Thickness(8,0,8,0)
+		Assert.AreEqual(new Thickness(8, 0, 8, 0), padding,
+			"ChipPadding should be Space200HorizontalThickness (8,0,8,0) at Regular density");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ChipElevationMargin_Then_MatchesSpace100Thickness()
+	{
+		var (container, _) = CreateThemedContainer();
+		var margin = GetResource<Thickness>(container, "ChipElevationMargin");
+		// Space100Thickness at Regular (base=4): Thickness(4)
+		Assert.AreEqual(new Thickness(4), margin,
+			"ChipElevationMargin should be Space100Thickness (4) at Regular density");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ChipSize_Then_MatchesSpace300()
+	{
+		var (container, _) = CreateThemedContainer();
+		var size = GetResource<double>(container, "ChipSize");
+		// Space300 at Regular (base=4): 4×3=12
+		Assert.AreEqual(12.0, size, 0.001,
+			"ChipSize should be Space300 (12) at Regular density");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_ChipContentMinHeight_Then_MatchesSpace500()
+	{
+		var (container, _) = CreateThemedContainer();
+		var minHeight = GetResource<double>(container, "ChipContentMinHeight");
+		// Space500 at Regular (base=4): 4×5=20
+		Assert.AreEqual(20.0, minHeight, 0.001,
+			"ChipContentMinHeight should be Space500 (20) at Regular density");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 3. NAVIGATION BAR — heights and icon sizes reference tokens
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NavigationBarHeight_Then_MatchesSpace1600()
+	{
+		var (container, _) = CreateThemedContainer();
+		// Space1600 at Regular (base=4): 4×16=64
+		var height = GetResource<double>(container, "MaterialNavigationBarHeight");
+		Assert.AreEqual(64.0, height, 0.001,
+			"MaterialNavigationBarHeight should be Space1600 (64) at Regular density");
+
+		var xamlHeight = GetResource<double>(container, "MaterialXamlNavigationBarHeight");
+		Assert.AreEqual(64.0, xamlHeight, 0.001,
+			"MaterialXamlNavigationBarHeight should be Space1600 (64) at Regular density");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NavigationBarContentMargin_Then_MatchesSpace400HorizontalThickness()
+	{
+		var (container, _) = CreateThemedContainer();
+		var margin = GetResource<Thickness>(container, "MaterialNavigationBarContentMargin");
+		// Space400HorizontalThickness at Regular (base=4): Thickness(16,0,16,0)
+		Assert.AreEqual(new Thickness(16, 0, 16, 0), margin,
+			"MaterialNavigationBarContentMargin should be Space400HorizontalThickness (16,0,16,0)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NavBarIconSizes_Then_MatchFixedTokens()
+	{
+		var (container, _) = CreateThemedContainer();
+		Assert.AreEqual(16.0, GetResource<double>(container, "NavBarAppBarButtonContentHeight"), 0.001,
+			"NavBarAppBarButtonContentHeight should be IconSizeSmall (16)");
+		Assert.AreEqual(24.0, GetResource<double>(container, "NavBarMainCommandAppBarButtonContentHeight"), 0.001,
+			"NavBarMainCommandAppBarButtonContentHeight should be IconSizeMedium (24)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NavigationBarPadding_Then_MatchesSpace100LeftThickness()
+	{
+		var (container, _) = CreateThemedContainer();
+		var padding = GetResource<Thickness>(container, "NavigationBarPadding");
+		// Space100LeftThickness at Regular (base=4): Thickness(4,0,0,0)
+		Assert.AreEqual(new Thickness(4, 0, 0, 0), padding,
+			"NavigationBarPadding should be Space100LeftThickness (4,0,0,0) at Regular density");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NavBarCompactHeight_Then_MatchesSpace1600()
+	{
+		var (container, _) = CreateThemedContainer();
+		Assert.AreEqual(64.0, GetResource<double>(container, "NavBarAppBarThemeCompactHeight"), 0.001,
+			"NavBarAppBarThemeCompactHeight should be Space1600 (64)");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 4. TAB BAR — heights reference design tokens
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_TopTabBarHeight_Then_MatchesControlHeightLarge()
+	{
+		var (container, _) = CreateThemedContainer();
+		var height = GetResource<double>(container, "TopTabBarHeight");
+		Assert.AreEqual(48.0, height, 0.001, "TopTabBarHeight should be ControlHeightLarge (48)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NavigationTabBarActiveIndicatorWidth_Then_MatchesSpace1600()
+	{
+		var (container, _) = CreateThemedContainer();
+		var width = GetResource<double>(container, "NavigationTabBarItemActiveIndicatorWidth");
+		// Space1600 at Regular (base=4): 4×16=64
+		Assert.AreEqual(64.0, width, 0.001,
+			"NavigationTabBarItemActiveIndicatorWidth should be Space1600 (64) at Regular density");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_NavigationTabBarActiveIndicatorHeight_Then_MatchesControlHeightSmall()
+	{
+		var (container, _) = CreateThemedContainer();
+		var height = GetResource<double>(container, "NavigationTabBarItemActiveIndicatorHeight");
+		Assert.AreEqual(32.0, height, 0.001,
+			"NavigationTabBarItemActiveIndicatorHeight should be ControlHeightSmall (32)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_TabBarCornerRadii_Then_MatchTokens()
+	{
+		var (container, _) = CreateThemedContainer();
+		// Radius400CornerRadius at base=4: 4×4=16
+		Assert.AreEqual(new CornerRadius(16),
+			GetResource<CornerRadius>(container, "NavigationTabBarItemActiveIndicatorCornerRadius"),
+			"NavigationTabBarItemActiveIndicatorCornerRadius should be Radius400CornerRadius (16)");
+		Assert.AreEqual(new CornerRadius(16),
+			GetResource<CornerRadius>(container, "FabTabBarItemCornerRadius"),
+			"FabTabBarItemCornerRadius should be Radius400CornerRadius (16)");
+		// Radius200CornerRadius at base=4: 4×2=8
+		Assert.AreEqual(new CornerRadius(8),
+			GetResource<CornerRadius>(container, "NavigationTabBarItemLargeBadgeCornerRadius"),
+			"NavigationTabBarItemLargeBadgeCornerRadius should be Radius200CornerRadius (8)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_TabBarBadgeDimensions_Then_MatchTokens()
+	{
+		var (container, _) = CreateThemedContainer();
+		// Space150 at Regular (base=4): 4×1.5=6
+		Assert.AreEqual(6.0, GetResource<double>(container, "NavigationTabBarItemSmallBadgeHeight"), 0.001);
+		Assert.AreEqual(6.0, GetResource<double>(container, "NavigationTabBarItemSmallBadgeWidth"), 0.001);
+		// Space400 at Regular (base=4): 4×4=16
+		Assert.AreEqual(16.0, GetResource<double>(container, "NavigationTabBarItemLargeBadgeHeight"), 0.001);
+		Assert.AreEqual(16.0, GetResource<double>(container, "NavigationTabBarItemLargeBadgeMinWidth"), 0.001);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_TabBarFabResources_Then_MatchTokens()
+	{
+		var (container, _) = CreateThemedContainer();
+		// FabTabBarItemContentWidthOrHeight = IconSizeSmall = 16
+		Assert.AreEqual(16.0, GetResource<double>(container, "FabTabBarItemContentWidthOrHeight"), 0.001);
+		// FabTabBarItemIconTextPadding = Space300 at Regular (base=4): 12
+		Assert.AreEqual(12.0, GetResource<double>(container, "FabTabBarItemIconTextPadding"), 0.001);
+		// FabTabBarItemPadding = Space500Thickness at Regular (base=4): Thickness(20)
+		Assert.AreEqual(new Thickness(20), GetResource<Thickness>(container, "FabTabBarItemPadding"));
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 4b. DIVIDER — sub-header margin references design tokens
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_DividerSubHeaderMargin_Then_MatchesSpace100TopThickness()
+	{
+		var (container, _) = CreateThemedContainer();
+		var margin = GetResource<Thickness>(container, "DividerSubHeaderMargin");
+		// Space100TopThickness at Regular (base=4): Thickness(0,4,0,0)
+		Assert.AreEqual(new Thickness(0, 4, 0, 0), margin,
+			"DividerSubHeaderMargin should be Space100TopThickness (0,4,0,0)");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 5. FIXED TOKENS — control heights and icon sizes are density-invariant
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(Density.Compact)]
+	[DataRow(Density.Regular)]
+	[DataRow(Density.Comfy)]
+	public void When_DensityChanges_Then_FixedToolkitTokensAreConstant(Density density)
+	{
+		var theme = new MaterialToolkitTheme { DefaultDensity = density };
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+
+		// ChipHeight is ControlHeightSmall = 32 at all densities
+		Assert.AreEqual(32.0, GetResource<double>(container, "ChipHeight"), 0.001,
+			"ChipHeight (ControlHeightSmall) should be 32 at all densities");
+
+		// TopTabBarHeight is ControlHeightLarge = 48 at all densities
+		Assert.AreEqual(48.0, GetResource<double>(container, "TopTabBarHeight"), 0.001,
+			"TopTabBarHeight (ControlHeightLarge) should be 48 at all densities");
+
+		// Icon sizes
+		Assert.AreEqual(16.0, GetResource<double>(container, "NavBarAppBarButtonContentHeight"), 0.001,
+			"NavBarAppBarButtonContentHeight (IconSizeSmall) should be 16 at all densities");
+		Assert.AreEqual(24.0, GetResource<double>(container, "NavBarMainCommandAppBarButtonContentHeight"), 0.001,
+			"NavBarMainCommandAppBarButtonContentHeight (IconSizeMedium) should be 24 at all densities");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 6. INTEGRATION — rendered controls use design token values
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_CardRendered_Then_PaddingAndCornerRadiusFromTokens()
+	{
+		var card = XamlHelper.LoadXaml<Card>("""
+			<utu:Card Style="{StaticResource MaterialFilledCardStyle}" />
+		""");
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(card);
+
+		// CardPadding = Space400Thickness at Regular (base=4): 16
+		Assert.AreEqual(new Thickness(16), card.Padding,
+			"Rendered Card.Padding should be Space400Thickness (16)");
+
+		// CardCornerRadius = Radius300CornerRadius at base=4: 12
+		Assert.AreEqual(new CornerRadius(12), card.CornerRadius,
+			"Rendered Card.CornerRadius should be Radius300CornerRadius (12)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_ChipRendered_Then_CornerRadiusAndPaddingFromTokens()
+	{
+		var chip = XamlHelper.LoadXaml<Chip>("""
+			<utu:Chip Style="{StaticResource MaterialChipStyle}" Content="Test" />
+		""");
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(chip);
+
+		// ChipCornerRadius = Radius200CornerRadius at base=4: 8
+		Assert.AreEqual(new CornerRadius(8), chip.CornerRadius,
+			"Rendered Chip.CornerRadius should be Radius200CornerRadius (8)");
+
+		// ChipPadding = Space200HorizontalThickness at Regular (base=4): (8,0,8,0)
+		Assert.AreEqual(new Thickness(8, 0, 8, 0), chip.Padding,
+			"Rendered Chip.Padding should be Space200HorizontalThickness (8,0,8,0)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_TopTabBarRendered_Then_MinHeightFromToken()
+	{
+		var tabBar = XamlHelper.LoadXaml<TabBar>("""
+			<utu:TabBar Style="{StaticResource MaterialTopTabBarStyle}">
+				<utu:TabBarItem Content="Tab1" />
+			</utu:TabBar>
+		""");
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(tabBar);
+
+		// TopTabBarHeight = ControlHeightLarge = 48
+		Assert.AreEqual(48.0, tabBar.MinHeight, 0.001,
+			"Rendered TabBar.MinHeight should be ControlHeightLarge (48)");
+	}
+}
+

--- a/src/Uno.Toolkit.RuntimeTests/Tests/Given_DesignTokens.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/Given_DesignTokens.cs
@@ -2,8 +2,6 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.Material;
-using Uno.Themes;
 using Uno.Toolkit.RuntimeTests.Helpers;
 using Uno.Toolkit.UI;
 using Uno.Toolkit.UI.Material;
@@ -309,12 +307,12 @@ public class Given_DesignTokens
 
 	[TestMethod]
 	[RunsOnUIThread]
-	[DataRow(Density.Compact)]
-	[DataRow(Density.Regular)]
-	[DataRow(Density.Comfy)]
-	public void When_DensityChanges_Then_FixedToolkitTokensAreConstant(Density density)
+	[DataRow(3)] // Compact
+	[DataRow(4)] // Regular
+	[DataRow(5)] // Comfy
+	public void When_DensityChanges_Then_FixedToolkitTokensAreConstant(int densityValue)
 	{
-		var theme = new MaterialToolkitTheme { DefaultDensity = density };
+		var theme = new MaterialToolkitTheme { DefaultDensity = (Uno.Themes.Density)densityValue };
 		var container = new Grid();
 		container.Resources.MergedDictionaries.Add(theme);
 

--- a/src/Uno.Toolkit.RuntimeTests/Tests/Given_SimpleDesignTokens.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/Given_SimpleDesignTokens.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Reflection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+/// <summary>
+/// Verifies that Simple toolkit control resources reference the correct design tokens.
+/// Uses reflection to instantiate SimpleToolkitTheme to avoid compile-time dependency
+/// on Uno.Simple.WinUI (which conflicts with Uno.Themes.WinUI Density type).
+/// These tests only run when the Simple library is available (i.e., in the Simple sample app).
+/// </summary>
+[TestClass]
+public class Given_SimpleDesignTokens
+{
+	// ─────────────────────────────────────────────────────────────────────
+	// Helpers
+	// ─────────────────────────────────────────────────────────────────────
+
+	private static readonly Type? s_simpleThemeType =
+		Type.GetType("Uno.Toolkit.UI.Simple.SimpleToolkitTheme, Uno.Toolkit.WinUI.Simple");
+
+	private static Grid CreateThemedContainer()
+	{
+		if (s_simpleThemeType == null)
+		{
+			Assert.Inconclusive("SimpleToolkitTheme not available — run in Simple sample app");
+		}
+		var theme = (ResourceDictionary)Activator.CreateInstance(s_simpleThemeType!)!;
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+		return container;
+	}
+
+	private static Grid CreateThemedContainerWithDensity(int densityValue)
+	{
+		if (s_simpleThemeType == null)
+		{
+			Assert.Inconclusive("SimpleToolkitTheme not available — run in Simple sample app");
+		}
+		var theme = (ResourceDictionary)Activator.CreateInstance(s_simpleThemeType!)!;
+
+		// Set DefaultDensity via DependencyProperty (Density: Compact=3, Regular=4, Comfy=5)
+		var dpProp = s_simpleThemeType!.GetProperty(
+			"DefaultDensityProperty",
+			BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+		Assert.IsNotNull(dpProp, "DefaultDensityProperty not found");
+		var dp = (DependencyProperty)dpProp!.GetValue(null)!;
+
+		var densityProp = s_simpleThemeType.GetProperty(
+			"DefaultDensity",
+			BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+		Assert.IsNotNull(densityProp, "DefaultDensity property not found");
+		var densityEnumType = densityProp!.PropertyType;
+		var densityVal = Enum.ToObject(densityEnumType, densityValue);
+
+		((DependencyObject)theme).SetValue(dp, densityVal);
+
+		var container = new Grid();
+		container.Resources.MergedDictionaries.Add(theme);
+		return container;
+	}
+
+	private static T GetResource<T>(Grid container, string key)
+	{
+		if (container.Resources.TryGetValue(key, out var value) && value is T typed)
+		{
+			return typed;
+		}
+
+		Assert.Fail($"Resource '{key}' not found or not of type {typeof(T).Name}");
+		return default!;
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 1. CARD — padding and corner radius reference design tokens
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SimpleCardPadding_Then_MatchesSpace600Thickness()
+	{
+		var container = CreateThemedContainer();
+		var padding = GetResource<Thickness>(container, "CardPadding");
+		// Space600Thickness at Regular density (base=4): 4×6=24
+		Assert.AreEqual(new Thickness(24), padding,
+			"CardPadding should be Space600Thickness (24) at Regular density");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SimpleCardCornerRadius_Then_MatchesRadius200CornerRadius()
+	{
+		var container = CreateThemedContainer();
+		var cr = GetResource<CornerRadius>(container, "CardCornerRadius");
+		// Radius200CornerRadius at base=4: 4×2=8
+		Assert.AreEqual(new CornerRadius(8), cr,
+			"CardCornerRadius should be Radius200CornerRadius (8) at base=4");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 2. CHIP — height, corner radius, padding reference tokens
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SimpleChipHeight_Then_MatchesControlHeightSmall()
+	{
+		var container = CreateThemedContainer();
+		var height = GetResource<double>(container, "ChipHeight");
+		Assert.AreEqual(32.0, height, 0.001, "ChipHeight should be ControlHeightSmall (32)");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SimpleChipCornerRadius_Then_MatchesRadius200CornerRadius()
+	{
+		var container = CreateThemedContainer();
+		var cr = GetResource<CornerRadius>(container, "ChipCornerRadius");
+		// Radius200CornerRadius at base=4: 4×2=8
+		Assert.AreEqual(new CornerRadius(8), cr,
+			"ChipCornerRadius should be Radius200CornerRadius (8) at base=4");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SimpleChipPadding_Then_MatchesSpace200HorizontalThickness()
+	{
+		var container = CreateThemedContainer();
+		var padding = GetResource<Thickness>(container, "ChipPadding");
+		// Space200HorizontalThickness at Regular (base=4): Thickness(8,0,8,0)
+		Assert.AreEqual(new Thickness(8, 0, 8, 0), padding,
+			"ChipPadding should be Space200HorizontalThickness (8,0,8,0) at Regular density");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 3. NAVIGATION BAR — padding references token
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SimpleNavigationBarPadding_Then_MatchesSpace100LeftThickness()
+	{
+		var container = CreateThemedContainer();
+		var padding = GetResource<Thickness>(container, "NavigationBarPadding");
+		// Space100LeftThickness at Regular (base=4): Thickness(4,0,0,0)
+		Assert.AreEqual(new Thickness(4, 0, 0, 0), padding,
+			"NavigationBarPadding should be Space100LeftThickness (4,0,0,0) at Regular density");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 4. TAB BAR — height references design token
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SimpleTopTabBarHeight_Then_MatchesControlHeightLarge()
+	{
+		var container = CreateThemedContainer();
+		var height = GetResource<double>(container, "TopTabBarHeight");
+		Assert.AreEqual(48.0, height, 0.001, "TopTabBarHeight should be ControlHeightLarge (48)");
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// 5. FIXED TOKENS — density-invariant across Simple theme
+	// ═══════════════════════════════════════════════════════════════════════
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(3)] // Compact
+	[DataRow(4)] // Regular
+	[DataRow(5)] // Comfy
+	public void When_SimpleDensityChanges_Then_FixedTokensAreConstant(int densityValue)
+	{
+		var container = CreateThemedContainerWithDensity(densityValue);
+
+		// ChipHeight is ControlHeightSmall = 32 at all densities
+		Assert.AreEqual(32.0, GetResource<double>(container, "ChipHeight"), 0.001,
+			"ChipHeight (ControlHeightSmall) should be 32 at all densities");
+
+		// TopTabBarHeight is ControlHeightLarge = 48 at all densities
+		Assert.AreEqual(48.0, GetResource<double>(container, "TopTabBarHeight"), 0.001,
+			"TopTabBarHeight (ControlHeightLarge) should be 48 at all densities");
+	}
+}

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Card.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Card.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:toolkit="using:Uno.UI.Toolkit"
@@ -96,21 +96,21 @@
 	<x:Double x:Key="CardMaxWidth">344</x:Double>
 
 	<!--  Thickness  -->
-	<Thickness x:Key="CardPadding">16</Thickness>
+	<StaticResource x:Key="CardPadding" ResourceKey="Space400Thickness" />
 	<Thickness x:Key="CardBorderThickness">1</Thickness>
 
 	<!--  Corner Radius  -->
-	<CornerRadius x:Key="CardCornerRadius">12</CornerRadius>
+	<StaticResource x:Key="CardCornerRadius" ResourceKey="Radius300CornerRadius" />
 
 	<!--  Card Elevation Variables  -->
 	<x:Double x:Key="CardElevation">6</x:Double>
-	<Thickness x:Key="CardElevationMargin">6</Thickness>
+	<StaticResource x:Key="CardElevationMargin" ResourceKey="Space150Thickness" />
 	<!--#endregion-->
 
 	<!--  Card Templates  -->
 	<DataTemplate x:Key="M3DefaultHeaderContentTemplate">
 		<TextBlock
-			Margin="16,16,16,0"
+			Margin="{ThemeResource Space400Thickness}"
 			MaxLines="1"
 			Style="{ThemeResource TitleMedium}"
 			Text="{Binding}" />
@@ -118,7 +118,7 @@
 
 	<DataTemplate x:Key="M3DefaultSubHeaderContentTemplate">
 		<TextBlock
-			Margin="16,0,16,16"
+			Margin="{ThemeResource Space400Thickness}"
 			Foreground="{ThemeResource ContentTemplateForeground}"
 			MaxLines="2"
 			Style="{ThemeResource LabelSmall}"
@@ -127,7 +127,7 @@
 
 	<DataTemplate x:Key="M3DefaultSupportingContentTemplate">
 		<TextBlock
-			Margin="16,0,16,16"
+			Margin="{ThemeResource Space400Thickness}"
 			Foreground="{ThemeResource ContentTemplateForeground}"
 			Style="{ThemeResource BodyMedium}"
 			Text="{Binding}" />
@@ -135,7 +135,7 @@
 
 	<DataTemplate x:Key="M3DefaultAvatarSupportingContentTemplate">
 		<TextBlock
-			Margin="16,12,16,16"
+			Margin="{ThemeResource Space400Thickness}"
 			Foreground="{ThemeResource ContentTemplateForeground}"
 			Style="{ThemeResource BodyMedium}"
 			Text="{Binding}" />
@@ -144,7 +144,7 @@
 	<DataTemplate x:Key="M3DefaultSmallMediaSupportingContentTemplate">
 		<Border BorderBrush="{ThemeResource ContentTemplateBorderBrush}" BorderThickness="0,1,0,0">
 			<TextBlock
-				Margin="16,12,16,16"
+				Margin="{ThemeResource Space400Thickness}"
 				Foreground="{ThemeResource ContentTemplateForeground}"
 				Style="{ThemeResource BodyMedium}"
 				Text="{Binding}" />
@@ -168,7 +168,7 @@
 
 	<DataTemplate x:Key="M3DefaultAvatarContentTemplate">
 		<Image
-			MaxHeight="40"
+			MaxHeight="{ThemeResource ControlHeightMedium}"
 			Source="{Binding}"
 			Stretch="Uniform" />
 	</DataTemplate>
@@ -649,7 +649,7 @@
 						<!--  Avatart part  -->
 						<ContentPresenter
 							x:Name="AvatarContentPresenter"
-							Margin="16,0,0,0"
+							Margin="{ThemeResource Space400LeftThickness}"
 							HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 							VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 							AutomationProperties.AccessibilityView="Raw"
@@ -870,7 +870,7 @@
 							<!--  Avatart part  -->
 							<ContentPresenter
 								x:Name="AvatarContentPresenter"
-								Margin="16,0,0,0"
+								Margin="{ThemeResource Space400LeftThickness}"
 								HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 								VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 								AutomationProperties.AccessibilityView="Raw"

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Chip.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Chip.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:not_win="http://uno.ui/not_win"
@@ -11,21 +11,21 @@
 
 	<ResourceDictionary.ThemeDictionaries>
 		<ResourceDictionary x:Key="Default">
-			<x:Double x:Key="ChipContentMinHeight">20</x:Double>
+			<StaticResource x:Key="ChipContentMinHeight" ResourceKey="Space500" />
 			<x:Double x:Key="ChipDeleteIconContainerLength">18</x:Double>
 			<x:Double x:Key="ChipDeleteIconLength">11</x:Double>
 			<x:Double x:Key="ChipElevation">4</x:Double>
 			<x:Double x:Key="ChipElevationDisabled">0</x:Double>
-			<x:Double x:Key="ChipHeight">32</x:Double>
+			<StaticResource x:Key="ChipHeight" ResourceKey="ControlHeightSmall" />
 			<x:Double x:Key="ChipIconSize">18</x:Double>
-			<x:Double x:Key="ChipSize">12</x:Double>
+			<StaticResource x:Key="ChipSize" ResourceKey="Space300" />
 
-			<CornerRadius x:Key="ChipCornerRadius">8</CornerRadius>
+			<StaticResource x:Key="ChipCornerRadius" ResourceKey="Radius200CornerRadius" />
 			<Thickness x:Key="ChipBorderThickness">1</Thickness>
-			<Thickness x:Key="ChipContentMargin">8,0</Thickness>
+			<StaticResource x:Key="ChipContentMargin" ResourceKey="Space200HorizontalThickness" />
 			<Thickness x:Key="ChipElevationBorderThickness">0</Thickness>
-			<Thickness x:Key="ChipElevationMargin">4</Thickness>
-			<Thickness x:Key="ChipPadding">8,0</Thickness>
+			<StaticResource x:Key="ChipElevationMargin" ResourceKey="Space100Thickness" />
+			<StaticResource x:Key="ChipPadding" ResourceKey="Space200HorizontalThickness" />
 
 			<!-- Brushes -->
 			<StaticResource x:Key="ChipBackground"
@@ -146,21 +146,21 @@
 		</ResourceDictionary>
 
 		<ResourceDictionary x:Key="Light">
-			<x:Double x:Key="ChipContentMinHeight">20</x:Double>
+			<StaticResource x:Key="ChipContentMinHeight" ResourceKey="Space500" />
 			<x:Double x:Key="ChipDeleteIconContainerLength">18</x:Double>
 			<x:Double x:Key="ChipDeleteIconLength">11</x:Double>
 			<x:Double x:Key="ChipElevation">4</x:Double>
 			<x:Double x:Key="ChipElevationDisabled">0</x:Double>
-			<x:Double x:Key="ChipHeight">32</x:Double>
+			<StaticResource x:Key="ChipHeight" ResourceKey="ControlHeightSmall" />
 			<x:Double x:Key="ChipIconSize">18</x:Double>
-			<x:Double x:Key="ChipSize">12</x:Double>
+			<StaticResource x:Key="ChipSize" ResourceKey="Space300" />
 
-			<CornerRadius x:Key="ChipCornerRadius">8</CornerRadius>
+			<StaticResource x:Key="ChipCornerRadius" ResourceKey="Radius200CornerRadius" />
 			<Thickness x:Key="ChipBorderThickness">1</Thickness>
-			<Thickness x:Key="ChipContentMargin">8,0</Thickness>
+			<StaticResource x:Key="ChipContentMargin" ResourceKey="Space200HorizontalThickness" />
 			<Thickness x:Key="ChipElevationBorderThickness">0</Thickness>
-			<Thickness x:Key="ChipElevationMargin">4</Thickness>
-			<Thickness x:Key="ChipPadding">8,0</Thickness>
+			<StaticResource x:Key="ChipElevationMargin" ResourceKey="Space100Thickness" />
+			<StaticResource x:Key="ChipPadding" ResourceKey="Space200HorizontalThickness" />
 
 			<!-- Brushes -->
 			<StaticResource x:Key="ChipBackground"

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/ChipGroup.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/ChipGroup.xaml
@@ -12,7 +12,7 @@
 
 	<ItemsPanelTemplate x:Key="MaterialHorizontalChipGroupItemsPanel">
 		<StackPanel Orientation="Horizontal"
-					Spacing="8" />
+					Spacing="{ThemeResource Space200}" />
 	</ItemsPanelTemplate>
 
 	<Style x:Key="MaterialBaseChipGroupStyle"

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Divider.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/Divider.xaml
@@ -13,7 +13,7 @@
 			<StaticResource x:Key="DividerSubHeaderFontSize" ResourceKey="BodySmallFontSize" />
 			<StaticResource x:Key="DividerSubHeaderCharacterSpacing" ResourceKey="BodySmallCharacterSpacing" />
 
-			<Thickness x:Key="DividerSubHeaderMargin">0,4,0,0</Thickness>
+			<StaticResource x:Key="DividerSubHeaderMargin" ResourceKey="Space100TopThickness" />
 			<x:Double x:Key="DividerHeight">1</x:Double>
 		</ResourceDictionary>
 		<ResourceDictionary x:Key="Light">
@@ -25,7 +25,7 @@
 			<StaticResource x:Key="DividerSubHeaderFontSize" ResourceKey="BodySmallFontSize" />
 			<StaticResource x:Key="DividerSubHeaderCharacterSpacing" ResourceKey="BodySmallCharacterSpacing" />
 
-			<Thickness x:Key="DividerSubHeaderMargin">0,4,0,0</Thickness>
+			<StaticResource x:Key="DividerSubHeaderMargin" ResourceKey="Space100TopThickness" />
 			<x:Double x:Key="DividerHeight">1</x:Double>
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/NavigationBar.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:android="http://uno.ui/android"
 					xmlns:contract12NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,12)"
@@ -33,7 +33,7 @@
 			<StaticResource x:Key="NavigationBarMainCommandForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarBackground" ResourceKey="SurfaceBrush" />
-			<Thickness x:Key="NavigationBarPadding">4,0,0,0</Thickness>
+			<StaticResource x:Key="NavigationBarPadding" ResourceKey="Space100LeftThickness" />
 			<StaticResource x:Key="NavigationBarFontFamily" ResourceKey="TitleLargeFontFamily" />
 			<StaticResource x:Key="NavigationBarFontWeight" ResourceKey="TitleLargeFontWeight" />
 			<StaticResource x:Key="NavigationBarFontSize" ResourceKey="TitleLargeFontSize" />
@@ -68,9 +68,9 @@
 							 Color="Transparent" />
 
 			<x:Double x:Key="MaterialNavigationBarElevation">4</x:Double>
-			<x:Double x:Key="MaterialXamlNavigationBarHeight">64</x:Double>
-			<x:Double x:Key="MaterialNavigationBarHeight">64</x:Double>
-			<Thickness x:Key="MaterialNavigationBarContentMargin">16,0</Thickness>
+			<StaticResource x:Key="MaterialXamlNavigationBarHeight" ResourceKey="Space1600" />
+			<StaticResource x:Key="MaterialNavigationBarHeight" ResourceKey="Space1600" />
+			<StaticResource x:Key="MaterialNavigationBarContentMargin" ResourceKey="Space400HorizontalThickness" />
 			<Thickness x:Key="MaterialAppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
 
 			<StaticResource x:Key="NavigationBarMaterialEllipsisButtonFontFamily" ResourceKey="MaterialRegularFontFamily" />
@@ -78,9 +78,9 @@
 			<StaticResource x:Key="NavigationBarMaterialEllipsisButtonFontSize" ResourceKey="ControlContentThemeFontSize" />
 			<StaticResource x:Key="NavigationBarMaterialEllipsisButtonWidth" ResourceKey="AppBarExpandButtonThemeWidth" />
 
-			<x:Double x:Key="NavBarAppBarButtonContentHeight">16</x:Double>
-			<x:Double x:Key="NavBarMainCommandAppBarButtonContentHeight">24</x:Double>
-			<x:Double x:Key="NavBarAppBarThemeCompactHeight">64</x:Double>
+			<StaticResource x:Key="NavBarAppBarButtonContentHeight" ResourceKey="IconSizeSmall" />
+			<StaticResource x:Key="NavBarMainCommandAppBarButtonContentHeight" ResourceKey="IconSizeMedium" />
+			<StaticResource x:Key="NavBarAppBarThemeCompactHeight" ResourceKey="Space1600" />
 			<Thickness x:Key="NavBarAppBarButtonPadding">12,16,12,16</Thickness>
 			<Visibility x:Key="NavBarAppBarButtonHasFlyoutChevronVisibility">Collapsed</Visibility>
 			<x:String x:Key="NavigationBarBackIconData">M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z</x:String>
@@ -93,7 +93,7 @@
 			<StaticResource x:Key="NavigationBarMainCommandForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarBackground" ResourceKey="SurfaceBrush" />
-			<Thickness x:Key="NavigationBarPadding">4,0,0,0</Thickness>
+			<StaticResource x:Key="NavigationBarPadding" ResourceKey="Space100LeftThickness" />
 			<StaticResource x:Key="NavigationBarFontFamily" ResourceKey="TitleLargeFontFamily" />
 			<StaticResource x:Key="NavigationBarFontWeight" ResourceKey="TitleLargeFontWeight" />
 			<StaticResource x:Key="NavigationBarFontSize" ResourceKey="TitleLargeFontSize" />
@@ -126,9 +126,9 @@
 
 
 			<x:Double x:Key="MaterialNavigationBarElevation">4</x:Double>
-			<x:Double x:Key="MaterialXamlNavigationBarHeight">64</x:Double>
-			<x:Double x:Key="MaterialNavigationBarHeight">64</x:Double>
-			<Thickness x:Key="MaterialNavigationBarContentMargin">16,0</Thickness>
+			<StaticResource x:Key="MaterialXamlNavigationBarHeight" ResourceKey="Space1600" />
+			<StaticResource x:Key="MaterialNavigationBarHeight" ResourceKey="Space1600" />
+			<StaticResource x:Key="MaterialNavigationBarContentMargin" ResourceKey="Space400HorizontalThickness" />
 
 			<Thickness x:Key="MaterialAppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
 			<StaticResource x:Key="NavigationBarMaterialEllipsisButtonFontFamily" ResourceKey="MaterialRegularFontFamily" />
@@ -136,9 +136,9 @@
 			<StaticResource x:Key="NavigationBarMaterialEllipsisButtonFontSize" ResourceKey="ControlContentThemeFontSize" />
 			<StaticResource x:Key="NavigationBarMaterialEllipsisButtonWidth" ResourceKey="AppBarExpandButtonThemeWidth" />
 
-			<x:Double x:Key="NavBarAppBarButtonContentHeight">16</x:Double>
-			<x:Double x:Key="NavBarMainCommandAppBarButtonContentHeight">24</x:Double>
-			<x:Double x:Key="NavBarAppBarThemeCompactHeight">64</x:Double>
+			<StaticResource x:Key="NavBarAppBarButtonContentHeight" ResourceKey="IconSizeSmall" />
+			<StaticResource x:Key="NavBarMainCommandAppBarButtonContentHeight" ResourceKey="IconSizeMedium" />
+			<StaticResource x:Key="NavBarAppBarThemeCompactHeight" ResourceKey="Space1600" />
 			<Thickness x:Key="NavBarAppBarButtonPadding">12,16,12,16</Thickness>
 			<Visibility x:Key="NavBarAppBarButtonHasFlyoutChevronVisibility">Collapsed</Visibility>
 			<x:String x:Key="NavigationBarBackIconData">M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z</x:String>

--- a/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Material/Styles/Controls/v2/TabBar.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -17,36 +17,36 @@
 			<!--  Base Navigation-style TabBar Resources  -->
 			<x:Double x:Key="NavigationTabBarWidthOrHeight">80</x:Double>
 			<x:Double x:Key="NavigationTabBarItemIconHeight">18</x:Double>
-			<x:Double x:Key="NavigationTabBarItemActiveIndicatorWidth">64</x:Double>
-			<x:Double x:Key="NavigationTabBarItemActiveIndicatorHeight">32</x:Double>
+			<StaticResource x:Key="NavigationTabBarItemActiveIndicatorWidth" ResourceKey="Space1600" />
+			<StaticResource x:Key="NavigationTabBarItemActiveIndicatorHeight" ResourceKey="ControlHeightSmall" />
 			<Thickness x:Key="NavigationTabBarItemPadding">0,12,0,16</Thickness>
-			<CornerRadius x:Key="NavigationTabBarItemActiveIndicatorCornerRadius">16</CornerRadius>
+			<StaticResource x:Key="NavigationTabBarItemActiveIndicatorCornerRadius" ResourceKey="Radius400CornerRadius" />
 			<x:Double x:Key="NavigationTabBarTintOpacity">0.08</x:Double>
 
 			<!--  Top TabBar Resources  -->
-			<x:Double x:Key="TopTabBarHeight">48</x:Double>
-			<x:Double x:Key="TopTabBarItemIconHeight">20</x:Double>
-			<Thickness x:Key="TopTabBarItemContentMargin">8,0,0,0</Thickness>
+			<StaticResource x:Key="TopTabBarHeight" ResourceKey="ControlHeightLarge" />
+			<StaticResource x:Key="TopTabBarItemIconHeight" ResourceKey="Space500" />
+			<StaticResource x:Key="TopTabBarItemContentMargin" ResourceKey="Space200LeftThickness" />
 			<Thickness x:Key="TopTabBarItemContentOnlyMargin">0</Thickness>
 			
 			<!--  FAB Resources  -->
 			<x:Double x:Key="FabTabBarItemOffset">-32</x:Double>
-			<x:Double x:Key="FabTabBarItemContentWidthOrHeight">16</x:Double>
-			<x:Double x:Key="FabTabBarItemIconTextPadding">12</x:Double>
-			<CornerRadius x:Key="FabTabBarItemCornerRadius">16</CornerRadius>
-			<Thickness x:Key="FabTabBarItemPadding">20</Thickness>
+			<StaticResource x:Key="FabTabBarItemContentWidthOrHeight" ResourceKey="IconSizeSmall" />
+			<StaticResource x:Key="FabTabBarItemIconTextPadding" ResourceKey="Space300" />
+			<StaticResource x:Key="FabTabBarItemCornerRadius" ResourceKey="Radius400CornerRadius" />
+			<StaticResource x:Key="FabTabBarItemPadding" ResourceKey="Space500Thickness" />
 
 			<!--  Small Badge  -->
-			<x:Double x:Key="NavigationTabBarItemSmallBadgeHeight">6</x:Double>
-			<x:Double x:Key="NavigationTabBarItemSmallBadgeWidth">6</x:Double>
+			<StaticResource x:Key="NavigationTabBarItemSmallBadgeHeight" ResourceKey="Space150" />
+			<StaticResource x:Key="NavigationTabBarItemSmallBadgeWidth" ResourceKey="Space150" />
 			<Thickness x:Key="NavigationTabBarItemSmallBadgeMargin">0,4,20,0</Thickness>
 
 			<!--  Large Badge  -->
-			<x:Double x:Key="NavigationTabBarItemLargeBadgeHeight">16</x:Double>
-			<x:Double x:Key="NavigationTabBarItemLargeBadgeMinWidth">16</x:Double>
+			<StaticResource x:Key="NavigationTabBarItemLargeBadgeHeight" ResourceKey="Space400" />
+			<StaticResource x:Key="NavigationTabBarItemLargeBadgeMinWidth" ResourceKey="Space400" />
 			<Thickness x:Key="NavigationTabBarItemLargeBadgeMargin">32,2,0,0</Thickness>
-			<Thickness x:Key="NavigationTabBarItemLargeBadgePadding">4,0</Thickness>
-			<CornerRadius x:Key="NavigationTabBarItemLargeBadgeCornerRadius">8</CornerRadius>
+			<StaticResource x:Key="NavigationTabBarItemLargeBadgePadding" ResourceKey="Space100HorizontalThickness" />
+			<StaticResource x:Key="NavigationTabBarItemLargeBadgeCornerRadius" ResourceKey="Radius200CornerRadius" />
 
 			<!--  Brushes  -->
 			<StaticResource x:Key="VerticalTabBarBackground" ResourceKey="SurfaceBrush" />
@@ -213,36 +213,36 @@
 			<!--  Base Navigation-style TabBar Resources  -->
 			<x:Double x:Key="NavigationTabBarWidthOrHeight">80</x:Double>
 			<x:Double x:Key="NavigationTabBarItemIconHeight">18</x:Double>
-			<x:Double x:Key="NavigationTabBarItemActiveIndicatorWidth">64</x:Double>
-			<x:Double x:Key="NavigationTabBarItemActiveIndicatorHeight">32</x:Double>
+			<StaticResource x:Key="NavigationTabBarItemActiveIndicatorWidth" ResourceKey="Space1600" />
+			<StaticResource x:Key="NavigationTabBarItemActiveIndicatorHeight" ResourceKey="ControlHeightSmall" />
 			<Thickness x:Key="NavigationTabBarItemPadding">0,12,0,16</Thickness>
-			<CornerRadius x:Key="NavigationTabBarItemActiveIndicatorCornerRadius">16</CornerRadius>
+			<StaticResource x:Key="NavigationTabBarItemActiveIndicatorCornerRadius" ResourceKey="Radius400CornerRadius" />
 			<x:Double x:Key="NavigationTabBarTintOpacity">0.08</x:Double>
 
 			<!--  Top TabBar Resources  -->
-			<x:Double x:Key="TopTabBarHeight">48</x:Double>
-			<x:Double x:Key="TopTabBarItemIconHeight">20</x:Double>
-			<Thickness x:Key="TopTabBarItemContentMargin">8,0,0,0</Thickness>
+			<StaticResource x:Key="TopTabBarHeight" ResourceKey="ControlHeightLarge" />
+			<StaticResource x:Key="TopTabBarItemIconHeight" ResourceKey="Space500" />
+			<StaticResource x:Key="TopTabBarItemContentMargin" ResourceKey="Space200LeftThickness" />
 			<Thickness x:Key="TopTabBarItemContentOnlyMargin">0</Thickness>
 			
 			<!--  FAB Resources  -->
 			<x:Double x:Key="FabTabBarItemOffset">-32</x:Double>
-			<x:Double x:Key="FabTabBarItemContentWidthOrHeight">16</x:Double>
-			<x:Double x:Key="FabTabBarItemIconTextPadding">12</x:Double>
-			<CornerRadius x:Key="FabTabBarItemCornerRadius">16</CornerRadius>
-			<Thickness x:Key="FabTabBarItemPadding">20</Thickness>
+			<StaticResource x:Key="FabTabBarItemContentWidthOrHeight" ResourceKey="IconSizeSmall" />
+			<StaticResource x:Key="FabTabBarItemIconTextPadding" ResourceKey="Space300" />
+			<StaticResource x:Key="FabTabBarItemCornerRadius" ResourceKey="Radius400CornerRadius" />
+			<StaticResource x:Key="FabTabBarItemPadding" ResourceKey="Space500Thickness" />
 
 			<!--  Small Badge  -->
-			<x:Double x:Key="NavigationTabBarItemSmallBadgeHeight">6</x:Double>
-			<x:Double x:Key="NavigationTabBarItemSmallBadgeWidth">6</x:Double>
+			<StaticResource x:Key="NavigationTabBarItemSmallBadgeHeight" ResourceKey="Space150" />
+			<StaticResource x:Key="NavigationTabBarItemSmallBadgeWidth" ResourceKey="Space150" />
 			<Thickness x:Key="NavigationTabBarItemSmallBadgeMargin">0,4,20,0</Thickness>
 
 			<!--  Large Badge  -->
-			<x:Double x:Key="NavigationTabBarItemLargeBadgeHeight">16</x:Double>
-			<x:Double x:Key="NavigationTabBarItemLargeBadgeMinWidth">16</x:Double>
+			<StaticResource x:Key="NavigationTabBarItemLargeBadgeHeight" ResourceKey="Space400" />
+			<StaticResource x:Key="NavigationTabBarItemLargeBadgeMinWidth" ResourceKey="Space400" />
 			<Thickness x:Key="NavigationTabBarItemLargeBadgeMargin">32,2,0,0</Thickness>
-			<Thickness x:Key="NavigationTabBarItemLargeBadgePadding">4,0</Thickness>
-			<CornerRadius x:Key="NavigationTabBarItemLargeBadgeCornerRadius">8</CornerRadius>
+			<StaticResource x:Key="NavigationTabBarItemLargeBadgePadding" ResourceKey="Space100HorizontalThickness" />
+			<StaticResource x:Key="NavigationTabBarItemLargeBadgeCornerRadius" ResourceKey="Radius200CornerRadius" />
 
 			<!--  Brushes  -->
 			<StaticResource x:Key="VerticalTabBarBackground" ResourceKey="SurfaceBrush" />
@@ -670,7 +670,7 @@
                                         Fill="{ThemeResource NavigationTabBarItemPointerFillBrush}"
                                         Visibility="Collapsed" />
 
-                                    <Grid x:Name="ContentGrid" RowSpacing="4">
+                                    <Grid x:Name="ContentGrid" RowSpacing="{ThemeResource Space100}">
                                         <Grid.RowDefinitions>
                                             <RowDefinition x:Name="IconRow" Height="*" />
                                             <RowDefinition x:Name="ContentRow" Height="Auto" />
@@ -1040,7 +1040,7 @@
                                         Fill="{ThemeResource ColoredTopTabBarItemPointerFillBrush}"
                                         Visibility="Collapsed" />
 
-                                    <Grid x:Name="ContentGrid" ColumnSpacing="8">
+                                    <Grid x:Name="ContentGrid" ColumnSpacing="{ThemeResource Space200}">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition x:Name="IconRow" Width="*" />
                                             <ColumnDefinition x:Name="ContentRow" Width="Auto" />

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/Card.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/Card.xaml
@@ -50,14 +50,14 @@
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
 
-	<CornerRadius x:Key="SimpleCardCornerRadius">8</CornerRadius>
-	<Thickness x:Key="SimpleCardPadding">24</Thickness>
+	<StaticResource x:Key="SimpleCardCornerRadius" ResourceKey="Radius200CornerRadius" />
+	<StaticResource x:Key="SimpleCardPadding" ResourceKey="Space600Thickness" />
 	<Thickness x:Key="SimpleCardBorderThickness">1</Thickness>
 	<x:Double x:Key="SimpleCardMinWidth">240</x:Double>
 	<x:Double x:Key="SimpleCardMaxWidth">440</x:Double>
 
-	<CornerRadius x:Key="CardCornerRadius">8</CornerRadius>
-	<Thickness x:Key="CardPadding">24</Thickness>
+	<StaticResource x:Key="CardCornerRadius" ResourceKey="Radius200CornerRadius" />
+	<StaticResource x:Key="CardPadding" ResourceKey="Space600Thickness" />
 	<Thickness x:Key="CardBorderThickness">1</Thickness>
 	<x:Double x:Key="CardMinHeight">72</x:Double>
 	<x:Double x:Key="CardMaxWidth">440</x:Double>
@@ -66,7 +66,7 @@
 
 	<DataTemplate x:Key="SimpleDefaultHeaderContentTemplate">
 		<TextBlock
-			Margin="0,0,0,8"
+			Margin="{ThemeResource Space200BottomThickness}"
 			FontSize="24"
 			FontWeight="SemiBold"
 			Foreground="{ThemeResource CardForeground}"
@@ -91,15 +91,15 @@
 	</DataTemplate>
 
 	<DataTemplate x:Key="SimpleDefaultMediaContentTemplate">
-		<Border MinHeight="160" CornerRadius="8">
+		<Border MinHeight="160" CornerRadius="{ThemeResource Radius200CornerRadius}">
 			<Image Source="{Binding}" Stretch="UniformToFill" />
 		</Border>
 	</DataTemplate>
 
 	<DataTemplate x:Key="SimpleDefaultAvatarContentTemplate">
 		<Image
-			MaxWidth="40"
-			MaxHeight="40"
+			MaxWidth="{ThemeResource ControlHeightMedium}"
+			MaxHeight="{ThemeResource ControlHeightMedium}"
 			Source="{Binding}"
 			Stretch="Uniform" />
 	</DataTemplate>
@@ -121,7 +121,7 @@
 	</DataTemplate>
 
 	<DataTemplate x:Key="SimpleDefaultSmallMediaContentTemplate">
-		<Border MaxHeight="94" CornerRadius="8">
+		<Border MaxHeight="94" CornerRadius="{ThemeResource Radius200CornerRadius}">
 			<Image
 				VerticalAlignment="Top"
 				Source="{Binding}"
@@ -174,7 +174,7 @@
 						<!--  Media content  -->
 						<ContentPresenter
 							x:Name="MediaContentPresenter"
-							Margin="0,0,0,24"
+							Margin="{ThemeResource Space600BottomThickness}"
 							HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 							AutomationProperties.AccessibilityView="Raw"
 							Content="{TemplateBinding MediaContent}"
@@ -186,7 +186,7 @@
 						<ContentPresenter
 							x:Name="AvatarContentPresenter"
 							Grid.Row="1"
-							Margin="0,0,0,8"
+							Margin="{ThemeResource Space200BottomThickness}"
 							AutomationProperties.AccessibilityView="Raw"
 							Content="{TemplateBinding AvatarContent}"
 							ContentTemplate="{TemplateBinding AvatarContentTemplate}"
@@ -217,7 +217,7 @@
 						<ContentPresenter
 							x:Name="SupportingContentPresenter"
 							Grid.Row="4"
-							Margin="0,24,0,0"
+							Margin="{ThemeResource Space600TopThickness}"
 							HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 							AutomationProperties.AccessibilityView="Raw"
 							Content="{TemplateBinding SupportingContent}"
@@ -318,7 +318,7 @@
 
 	<DataTemplate x:Key="SimpleBrandHeaderContentTemplate">
 		<TextBlock
-			Margin="0,0,0,8"
+			Margin="{ThemeResource Space200BottomThickness}"
 			FontSize="24"
 			FontWeight="SemiBold"
 			Foreground="{ThemeResource BrandCardForeground}"

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/Chip.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/Chip.xaml
@@ -11,14 +11,14 @@
 
 		<!--  ─── Light Theme ───  -->
 		<ResourceDictionary x:Key="Light">
-			<x:Double x:Key="ChipHeight">32</x:Double>
-			<x:Double x:Key="ChipIconSize">16</x:Double>
+			<StaticResource x:Key="ChipHeight" ResourceKey="ControlHeightSmall" />
+			<StaticResource x:Key="ChipIconSize" ResourceKey="IconSizeSmall" />
 			<x:Double x:Key="ChipDeleteIconContainerLength">18</x:Double>
 			<x:Double x:Key="ChipDeleteIconLength">11</x:Double>
-			<CornerRadius x:Key="ChipCornerRadius">8</CornerRadius>
+			<StaticResource x:Key="ChipCornerRadius" ResourceKey="Radius200CornerRadius" />
 			<Thickness x:Key="ChipBorderThickness">0</Thickness>
-			<Thickness x:Key="ChipContentMargin">12,0</Thickness>
-			<Thickness x:Key="ChipPadding">8,0</Thickness>
+			<StaticResource x:Key="ChipContentMargin" ResourceKey="Space300HorizontalThickness" />
+			<StaticResource x:Key="ChipPadding" ResourceKey="Space200HorizontalThickness" />
 
 			<!--  Semantic keys (design-system-agnostic, shared with Material)  -->
 			<StaticResource x:Key="ChipBackground" ResourceKey="SurfaceVariantBrush" />
@@ -44,14 +44,14 @@
 		</ResourceDictionary>
 
 		<ResourceDictionary x:Key="Default">
-			<x:Double x:Key="ChipHeight">32</x:Double>
-			<x:Double x:Key="ChipIconSize">16</x:Double>
+			<StaticResource x:Key="ChipHeight" ResourceKey="ControlHeightSmall" />
+			<StaticResource x:Key="ChipIconSize" ResourceKey="IconSizeSmall" />
 			<x:Double x:Key="ChipDeleteIconContainerLength">18</x:Double>
 			<x:Double x:Key="ChipDeleteIconLength">11</x:Double>
-			<CornerRadius x:Key="ChipCornerRadius">8</CornerRadius>
+			<StaticResource x:Key="ChipCornerRadius" ResourceKey="Radius200CornerRadius" />
 			<Thickness x:Key="ChipBorderThickness">0</Thickness>
-			<Thickness x:Key="ChipContentMargin">12,0</Thickness>
-			<Thickness x:Key="ChipPadding">8,0</Thickness>
+			<StaticResource x:Key="ChipContentMargin" ResourceKey="Space300HorizontalThickness" />
+			<StaticResource x:Key="ChipPadding" ResourceKey="Space200HorizontalThickness" />
 
 			<!--  Semantic keys (design-system-agnostic, shared with Material)  -->
 			<StaticResource x:Key="ChipBackground" ResourceKey="SurfaceVariantBrush" />

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/ChipGroup.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/ChipGroup.xaml
@@ -4,7 +4,7 @@
 	xmlns:utu="using:Uno.Toolkit.UI">
 
 	<ItemsPanelTemplate x:Key="SimpleHorizontalChipGroupItemsPanel">
-		<StackPanel Orientation="Horizontal" Spacing="8" />
+		<StackPanel Orientation="Horizontal" Spacing="{ThemeResource Space200}" />
 	</ItemsPanelTemplate>
 
 	<Style x:Key="SimpleBaseChipGroupStyle" TargetType="utu:ChipGroup">

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/Divider.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/Divider.xaml
@@ -15,7 +15,7 @@
 			<x:Double x:Key="DividerSubHeaderFontSize">14</x:Double>
 			<x:Int32 x:Key="DividerSubHeaderCharacterSpacing">0</x:Int32>
 
-			<Thickness x:Key="DividerSubHeaderMargin">0,4,0,0</Thickness>
+			<StaticResource x:Key="DividerSubHeaderMargin" ResourceKey="Space100TopThickness" />
 			<x:Double x:Key="DividerHeight">1</x:Double>
 		</ResourceDictionary>
 
@@ -29,7 +29,7 @@
 			<x:Double x:Key="DividerSubHeaderFontSize">14</x:Double>
 			<x:Int32 x:Key="DividerSubHeaderCharacterSpacing">0</x:Int32>
 
-			<Thickness x:Key="DividerSubHeaderMargin">0,4,0,0</Thickness>
+			<StaticResource x:Key="DividerSubHeaderMargin" ResourceKey="Space100TopThickness" />
 			<x:Double x:Key="DividerHeight">1</x:Double>
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/NavigationBar.xaml
@@ -33,7 +33,7 @@
 			<StaticResource x:Key="NavigationBarMainCommandForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarBackground" ResourceKey="SurfaceBrush" />
-			<Thickness x:Key="NavigationBarPadding">4,0,0,0</Thickness>
+			<StaticResource x:Key="NavigationBarPadding" ResourceKey="Space100LeftThickness" />
 			<StaticResource x:Key="NavigationBarFontFamily" ResourceKey="SimpleFontFamily" />
 			<FontWeight x:Key="NavigationBarFontWeight">Normal</FontWeight>
 			<x:Double x:Key="NavigationBarFontSize">24</x:Double>
@@ -65,9 +65,9 @@
 			<StaticResource x:Key="PrimaryModalNavigationBarBackground" ResourceKey="NavigationBarBackground" />
 
 			<x:Double x:Key="NavigationBarElevation">0</x:Double>
-			<x:Double x:Key="XamlNavigationBarHeight">64</x:Double>
-			<x:Double x:Key="NavigationBarHeight">64</x:Double>
-			<Thickness x:Key="NavigationBarContentMargin">16,0</Thickness>
+			<StaticResource x:Key="XamlNavigationBarHeight" ResourceKey="Space1600" />
+			<StaticResource x:Key="NavigationBarHeight" ResourceKey="Space1600" />
+			<StaticResource x:Key="NavigationBarContentMargin" ResourceKey="Space400HorizontalThickness" />
 			<Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
 
 			<StaticResource x:Key="NavigationBarEllipsisButtonFontFamily" ResourceKey="SimpleFontFamily" />
@@ -75,9 +75,9 @@
 			<StaticResource x:Key="NavigationBarEllipsisButtonFontSize" ResourceKey="ControlContentThemeFontSize" />
 			<StaticResource x:Key="NavigationBarEllipsisButtonWidth" ResourceKey="AppBarExpandButtonThemeWidth" />
 
-			<x:Double x:Key="NavBarAppBarButtonContentHeight">16</x:Double>
-			<x:Double x:Key="NavBarMainCommandAppBarButtonContentHeight">24</x:Double>
-			<x:Double x:Key="NavBarAppBarThemeCompactHeight">64</x:Double>
+			<StaticResource x:Key="NavBarAppBarButtonContentHeight" ResourceKey="IconSizeSmall" />
+			<StaticResource x:Key="NavBarMainCommandAppBarButtonContentHeight" ResourceKey="IconSizeMedium" />
+			<StaticResource x:Key="NavBarAppBarThemeCompactHeight" ResourceKey="Space1600" />
 			<Thickness x:Key="NavBarAppBarButtonPadding">12,16,12,16</Thickness>
 			<Visibility x:Key="NavBarAppBarButtonHasFlyoutChevronVisibility">Collapsed</Visibility>
 			<x:String x:Key="NavigationBarBackIconData">M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z</x:String>
@@ -92,7 +92,7 @@
 			<StaticResource x:Key="NavigationBarMainCommandForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarBackground" ResourceKey="SurfaceBrush" />
-			<Thickness x:Key="NavigationBarPadding">4,0,0,0</Thickness>
+			<StaticResource x:Key="NavigationBarPadding" ResourceKey="Space100LeftThickness" />
 			<StaticResource x:Key="NavigationBarFontFamily" ResourceKey="SimpleFontFamily" />
 			<FontWeight x:Key="NavigationBarFontWeight">Normal</FontWeight>
 			<x:Double x:Key="NavigationBarFontSize">24</x:Double>
@@ -124,9 +124,9 @@
 			<StaticResource x:Key="PrimaryModalNavigationBarBackground" ResourceKey="NavigationBarBackground" />
 
 			<x:Double x:Key="NavigationBarElevation">0</x:Double>
-			<x:Double x:Key="XamlNavigationBarHeight">64</x:Double>
-			<x:Double x:Key="NavigationBarHeight">64</x:Double>
-			<Thickness x:Key="NavigationBarContentMargin">16,0</Thickness>
+			<StaticResource x:Key="XamlNavigationBarHeight" ResourceKey="Space1600" />
+			<StaticResource x:Key="NavigationBarHeight" ResourceKey="Space1600" />
+			<StaticResource x:Key="NavigationBarContentMargin" ResourceKey="Space400HorizontalThickness" />
 			<Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
 
 			<StaticResource x:Key="NavigationBarEllipsisButtonFontFamily" ResourceKey="SimpleFontFamily" />
@@ -134,9 +134,9 @@
 			<StaticResource x:Key="NavigationBarEllipsisButtonFontSize" ResourceKey="ControlContentThemeFontSize" />
 			<StaticResource x:Key="NavigationBarEllipsisButtonWidth" ResourceKey="AppBarExpandButtonThemeWidth" />
 
-			<x:Double x:Key="NavBarAppBarButtonContentHeight">16</x:Double>
-			<x:Double x:Key="NavBarMainCommandAppBarButtonContentHeight">24</x:Double>
-			<x:Double x:Key="NavBarAppBarThemeCompactHeight">64</x:Double>
+			<StaticResource x:Key="NavBarAppBarButtonContentHeight" ResourceKey="IconSizeSmall" />
+			<StaticResource x:Key="NavBarMainCommandAppBarButtonContentHeight" ResourceKey="IconSizeMedium" />
+			<StaticResource x:Key="NavBarAppBarThemeCompactHeight" ResourceKey="Space1600" />
 			<Thickness x:Key="NavBarAppBarButtonPadding">12,16,12,16</Thickness>
 			<Visibility x:Key="NavBarAppBarButtonHasFlyoutChevronVisibility">Collapsed</Visibility>
 			<x:String x:Key="NavigationBarBackIconData">M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z</x:String>
@@ -177,7 +177,7 @@
 							HorizontalAlignment="Center"
 							VerticalAlignment="Center"
 							Orientation="Vertical"
-							Spacing="8">
+							Spacing="{ThemeResource Space200}">
 							<!--  Icon content wrapped in Viewbox (shown when Icon is set)  -->
 							<Viewbox
 								x:Name="ContentViewbox"
@@ -1264,7 +1264,7 @@
 			<!--  Setting Content to null to avoid the implicit binding to Content on the NativeNavigationBarPresenter  -->
 			<utu:NativeNavigationBarPresenter
 				x:Name="NavigationBarPresenter"
-				Height="44"
+				Height="{ThemeResource ControlHeightMediumLarge}"
 				Content="{x:Null}" />
 		</Border>
 	</ios:ControlTemplate>

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/TabBar.xaml
@@ -12,7 +12,7 @@
 		<!--  ─── Light Theme ───  -->
 		<ResourceDictionary x:Key="Light">
 
-			<x:Double x:Key="TopTabBarHeight">48</x:Double>
+			<StaticResource x:Key="TopTabBarHeight" ResourceKey="ControlHeightLarge" />
 			<StaticResource x:Key="TopTabBarBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="TopTabBarBottomBorderBrush" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="BottomTabBarBackground" ResourceKey="SurfaceBrush" />
@@ -31,7 +31,7 @@
 		<!--  ─── Dark Theme (Default) ───  -->
 		<ResourceDictionary x:Key="Default">
 
-			<x:Double x:Key="TopTabBarHeight">48</x:Double>
+			<StaticResource x:Key="TopTabBarHeight" ResourceKey="ControlHeightLarge" />
 			<StaticResource x:Key="TopTabBarBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="TopTabBarBottomBorderBrush" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="BottomTabBarBackground" ResourceKey="SurfaceBrush" />
@@ -218,7 +218,7 @@
 							Padding="{TemplateBinding Padding}"
 							HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 							VerticalAlignment="Center"
-							RowSpacing="4">
+							RowSpacing="{ThemeResource Space100}">
 							<Grid.RowDefinitions>
 								<RowDefinition x:Name="IconRow" Height="Auto" />
 								<RowDefinition x:Name="ContentRow" Height="Auto" />


### PR DESCRIPTION
Replace hardcoded pixel values (padding, margins, corner radii, heights) with design token references (`Space*`, `Radius*`, `ControlHeight*`, `IconSize*`) across all Material v2 and Simple toolkit control styles. Add a design tokens documentation page and regression tests.


Closes https://github.com/unoplatform/uno.toolkit.ui/issues/1592