### PR TITLE
fix: prevent infinite dispatcher loop in SafeArea race detection on Android lock/unlock

### DIFF
--- a/specs/safearea-bounds-guard/recap.md
+++ b/specs/safearea-bounds-guard/recap.md
@@ -1,0 +1,185 @@
+# SafeArea Bounds-Transition Guard — R&D Recap
+
+## Summary
+
+Three PRs form a progressive fix chain for a race condition in `SafeArea.UpdateInsets()` where `ApplicationView.VisibleBounds` updates before `Window.Bounds` during system-bar transitions, causing downstream UI corruption and dispatcher starvation.
+
+| PR | Issue | Platform | Problem | Fix |
+|----|-------|----------|---------|-----|
+| [#1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) | [dispatchscience-private#74](https://github.com/unoplatform/dispatchscience-private/issues/74) | Android | Inflated bottom inset during StatusBar translucency transition | Added bounds-transition deferral guard + `Math.Max(0,…)` clamping |
+| [#1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572) | [kahua-private#458](https://github.com/unoplatform/kahua-private/issues/458) | iOS (iPad) | Infinite dispatcher loop after FormSheet modal dismiss | Restricted guard to `OperatingSystem.IsAndroid()` |
+| [#1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593) | [kahua-private#460](https://github.com/unoplatform/kahua-private/issues/460) | Android | Dispatcher starvation on lock/unlock (Low-priority queue starved) | Converted infinite re-deferral to one-shot accept-and-proceed |
+
+---
+
+## Problem Chain
+
+### Original Problem ([dispatchscience-private#74](https://github.com/unoplatform/dispatchscience-private/issues/74))
+
+**Scenario:** Android app with `SafeArea.Insets="VisibleBounds"` on a layout containing a `TabBar` in an Auto-height Grid row. User sets `StatusBar.Background` to a translucent color.
+
+**Root cause:** During the StatusBar translucency transition, `ApplicationView.VisibleBounds` updates to reflect the new translucent-bar coordinates *before* `Window.Bounds` updates. `GetWindowInsets()` computes `Bounds.Bottom - VisibleBounds.Bottom` against the stale (smaller) `Bounds`, producing an inflated bottom inset (~75.8px vs expected ~24px). This inflated value is applied as padding to the TabBar's Auto-sized row, permanently stretching it.
+
+**Fix ([PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)):**
+
+1. Added `Math.Max(0, …)` clamping to all four sides in `GetWindowInsets()` — prevents negative insets during transition.
+2. Added a bounds-transition guard in `UpdateInsets()` with three branches:
+   - **Branch 2:** `lastKnownBounds != default && visibleBoundsChanged && !boundsChanged` → Set `s_boundsTransitionPending = true`, defer via `Schedule()`, return.
+   - **Branch 1:** `s_boundsTransitionPending && !boundsChanged` → Re-defer via `Schedule()`, return.
+   - **Branch 3:** Else → Clear pending, update caches, proceed.
+3. Added parent `InvalidateMeasure()` in `OnInsetsApplied` for Android.
+4. The guard was **not platform-restricted** — it ran on all platforms.
+
+### First Regression ([kahua-private#458](https://github.com/unoplatform/kahua-private/issues/458))
+
+**Scenario:** iPad app with `SafeArea.Insets="VisibleBounds"`. User opens a `UIImagePickerController` presented as `FormSheet`/`OverFullScreen`. After dismissing the modal, taps, buttons, and back-navigation stop responding. Scroll (UIKit gesture recognizers) continues to work.
+
+**Root cause:** On iPad, dismissing a FormSheet modal causes `VisibleBounds` to update while `Window.Bounds` stays stable — the host view was never detached, so Bounds has no reason to change. [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)'s guard enters Branch 2 (defer), then Branch 1 fires on the deferred callback and **re-defers indefinitely** because `boundsChanged` is perpetually `false`. This infinite `Normal`-priority dispatch loop live-locks the managed `DispatcherQueue`, starving all input handling.
+
+**Fix ([PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572)):**
+
+Changed the guard condition from `if (!HasSoftInput())` to `if (!HasSoftInput() && OperatingSystem.IsAndroid())`:
+
+- The entire bounds-transition block is now **skipped on non-Android platforms**.
+- Used `OperatingSystem.IsAndroid()` instead of `#if __ANDROID__` so the guard remains active on Skia Android builds (which use the `net9.0` TFM without the `__ANDROID__` define).
+- Added test hooks (`TestHook_LastKnownBounds`, `TestHook_LastKnownVisibleBounds`, `TestHook_BoundsTransitionPending`, `TestHook_InvokeUpdateInsets`) under `#if DEBUG`.
+- Added test `BoundsTransitionGuard_NotActive_OnNonAndroid`.
+- Added sample page `CameraSafeAreaTestPage` for iPad manual repro.
+
+### Second Regression ([kahua-private#460](https://github.com/unoplatform/kahua-private/issues/460))
+
+**Scenario:** Android app with `SafeArea.Insets="VisibleBounds"`. User locks and unlocks the device. After unlock, low-priority `DispatcherQueue` items (e.g., timer-based updates, deferred navigation) stop executing.
+
+**Root cause:** On some Android devices/OEM skins, locking/unlocking causes `VisibleBounds` to shift while `Window.Bounds` genuinely never changes. [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)'s Branch 1 still re-defers indefinitely because `boundsChanged` is perpetually `false`. While [PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572) restricted the guard to Android, it did not fix the infinite re-deferral loop *on Android itself*. The continuous `Normal`-priority `Schedule()` calls permanently occupy the dispatcher. Additionally, `LayoutUpdated` keeps firing from the re-layouts, piling up more `Normal`-priority dispatches. `Low`-priority `DispatcherQueue` items are permanently starved — `TryEnqueue` returns `true` (misleading callers into thinking the work was accepted) but the enqueued actions never execute because the `Normal`-priority queue is never empty.
+
+**Fix ([PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593)):**
+
+Changed Branch 1 behavior from "re-defer" to "accept current values":
+
+```csharp
+// BEFORE (PR #1554, still present after PR #1572):
+if (s_boundsTransitionPending && !boundsChanged)
+{
+    Owner?.GetDispatcherCompat().Schedule(() => UpdateInsets(forceUpdate: true));
+    return; // ← infinite loop if Bounds never catches up
+}
+
+// AFTER (PR #1593):
+if (s_boundsTransitionPending && !boundsChanged)
+{
+    // Accept current values — no infinite re-deferral.
+    s_boundsTransitionPending = false;
+    s_lastKnownBounds = currentBounds;
+    s_lastKnownVisibleBounds = currentVB;
+    // Falls through to UpdateSafeAreaOverride()
+}
+```
+
+This preserves [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)'s one-deferral opportunity for `Window.Bounds` to catch up (via Branch 2 → defer once) while guaranteeing termination: if Bounds doesn't catch up after one dispatch cycle, the guard accepts current values and proceeds.
+
+#### Device Dependency
+
+The bug is device-dependent because it requires two conditions to hold simultaneously:
+
+1. `VisibleBounds` changes during lock/unlock (most Android devices).
+2. `Window.Bounds` does **not** change during the same transition (varies by OEM skin, navigation mode, display cutout, and API level).
+
+When both conditions hold, `s_boundsTransitionPending` is set but never cleared, creating the infinite loop. On some devices the timing gap is so short that by the next dispatch tick both values have caught up — those devices never hit the bug because Branch 3 fires and clears the flag normally.
+
+---
+
+## Regression Safety Analysis
+
+### [PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593) vs [PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572) (iPad live-lock)
+
+**No regression.** [PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572) gates the entire bounds-transition block with `OperatingSystem.IsAndroid()`. [PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593)'s changes are *entirely inside* that gate. On iOS/iPad/WASM/Windows/macOS, the gate skips the block — [PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593) has zero effect on non-Android platforms.
+
+### [PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593) vs [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) (inflated bottom inset)
+
+**No regression.** The StatusBar translucency transition scenario works as follows:
+
+1. VB changes → Branch 2 fires → defers once (unchanged by [PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593)).
+2. On the deferred callback, either:
+   - **Bounds caught up** → Branch 3 fires → normal update with correct bounds. ✅
+   - **Bounds didn't catch up** → Branch 1 fires → accepts current values ([PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593)'s change).
+
+In the translucency transition, `Window.Bounds` *does* catch up within one dispatch cycle, so the happy path (Branch 3) fires. Even in the theoretical case where it doesn't, the `Math.Max(0, …)` clamping from [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) prevents negative insets, and subsequent `LayoutUpdated` / `SizeChanged` events will trigger `UpdateInsets` again with the final correct values.
+
+---
+
+## Guard Logic (Final State)
+
+```
+UpdateInsets() called
+│
+├── HasSoftInput()? ──yes──► Skip guard entirely (keyboard is up)
+│
+├── OperatingSystem.IsAndroid()? ──no──► Skip guard entirely (PR #1572)
+│
+└── Android, no soft input:
+    │
+    ├── Branch 1: pending && !boundsChanged
+    │   → Accept current values, clear pending, proceed (PR #1593)
+    │
+    ├── Branch 2: lastKnownBounds != default && VB changed && !boundsChanged
+    │   → Set pending, defer once via Schedule(), return
+    │
+    └── Branch 3: else (bounds caught up or no transition)
+        → Clear pending, update caches, proceed
+```
+
+**Invariant:** At most one deferral per VB-change event. Infinite loops are structurally impossible because Branch 1 always terminates.
+
+---
+
+## Test Coverage
+
+### Non-Android Tests (`#if DEBUG && !__ANDROID__ && !WINDOWS_WINUI`)
+
+| Test | Covers |
+|------|--------|
+| `BoundsTransitionGuard_NotActive_OnNonAndroid` | Guard doesn't engage when VB changes ahead of Bounds (iPad live-lock regression guard) |
+| `BoundsTransitionGuard_IgnoredForAllStates_OnNonAndroid` | Stale pending flag stays unchanged (guard block entirely skipped) |
+
+### Android Tests (`#if DEBUG && __ANDROID__`)
+
+| Test | Covers |
+|------|--------|
+| `BoundsTransition_DefersOnce_WhenVisibleBoundsChangeAheadOfWindowBounds` | Branch 2: VB changed, Bounds didn't → pending set |
+| `BoundsTransition_AcceptsCurrent_AfterSingleDeferral` | Branch 1: pending + Bounds unchanged → accept, clear, update all caches |
+| `BoundsTransition_ClearsGuard_WhenBoundsCatchUp` | Branch 3: Bounds caught up → pending cleared |
+| `BoundsTransition_NoDeferral_WhenLastKnownBoundsIsDefault` | Edge case: first-ever call with default bounds → no deferral |
+| `BoundsTransition_FullCycle_DefersOnceThenAccepts` | Integration: Branch 2 → Branch 1 (Bounds never catch up — [PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593) fix) |
+| `BoundsTransition_FullCycle_DefersOnceThenBoundsCatchUp` | Integration: Branch 2 → Branch 3 (Bounds catch up — [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) happy path) |
+
+### Android UI Tests (`#if __ANDROID__`)
+
+| Test | Covers |
+|------|--------|
+| `Translucent_SystemBars` | Static translucent bars: correct inset padding applied |
+| `Translucent_SystemBars_Dynamic` | Dynamic opaque→translucent transition: insets update correctly |
+| `BottomInset_NotInflated_WhenTransitioningToTranslucentBars` | [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) regression guard: TabBar height doesn't inflate during transition |
+
+### Manual Repro Page
+
+`CameraSafeAreaTestPage` (added by [PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572)): iPad-only page with a `UIImagePickerController` FormSheet to manually verify tap counter remains responsive after modal dismiss.
+
+---
+
+## Key Design Decisions
+
+1. **`OperatingSystem.IsAndroid()` vs `#if __ANDROID__`**: Runtime check is required because Skia Android builds use the `net9.0` TFM without the `__ANDROID__` compiler define. The guard must be active on Skia Android.
+
+2. **One-shot deferral vs zero deferral**: Zero deferral (removing the guard entirely on Android) would re-expose the [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) bug. One-shot deferral gives `Window.Bounds` exactly one dispatch cycle to catch up — sufficient for the StatusBar translucency transition — while preventing infinite loops.
+
+3. **Accept-and-proceed vs accept-and-return**: Branch 1 falls through to `UpdateSafeAreaOverride()` instead of returning. This ensures insets are computed with the best-available values even when Bounds didn't catch up.
+
+4. **Static fields for bounds tracking**: `s_lastKnownBounds`, `s_lastKnownVisibleBounds`, and `s_boundsTransitionPending` are static because `Window.Bounds` and `VisibleBounds` are app-global — there's one window, one set of system bars. All `SafeAreaDetails` instances observe the same transition.
+
+---
+
+## File References
+
+- Implementation: `src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs` (lines ~470–530)
+- Tests: `src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs`
+- iPad repro page: `samples/Uno.Toolkit.Samples/Content/TestPages/CameraSafeAreaTestPage.WinUI.xaml`

--- a/specs/safearea-bounds-guard/recap.md
+++ b/specs/safearea-bounds-guard/recap.md
@@ -6,19 +6,19 @@ Three PRs form a progressive fix chain for a race condition in `SafeArea.UpdateI
 
 | PR | Issue | Platform | Problem | Fix |
 |----|-------|----------|---------|-----|
-| [#1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) | [dispatchscience-private#74](https://github.com/unoplatform/dispatchscience-private/issues/74) | Android | Inflated bottom inset during StatusBar translucency transition | Added bounds-transition deferral guard + `Math.Max(0,…)` clamping |
-| [#1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572) | [kahua-private#458](https://github.com/unoplatform/kahua-private/issues/458) | iOS (iPad) | Infinite dispatcher loop after FormSheet modal dismiss | Restricted guard to `OperatingSystem.IsAndroid()` |
-| [#1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593) | [kahua-private#460](https://github.com/unoplatform/kahua-private/issues/460) | Android | Dispatcher starvation on lock/unlock (Low-priority queue starved) | Converted infinite re-deferral to one-shot accept-and-proceed |
+| [#1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) | [`dispatchscience-private#74`](https://github.com/unoplatform/dispatchscience-private/issues/74) | Android | Inflated bottom inset during `StatusBar` translucency transition | Added bounds-transition deferral guard + `Math.Max(0,…)` clamping |
+| [#1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572) | [`kahua-private#458`](https://github.com/unoplatform/kahua-private/issues/458) | iOS (iPad) | Infinite dispatcher loop after `FormSheet` modal dismiss | Restricted guard to `OperatingSystem.IsAndroid()` |
+| [#1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593) | [`kahua-private#460`](https://github.com/unoplatform/kahua-private/issues/460) | Android | Dispatcher starvation on lock/unlock (Low-priority queue starved) | Converted infinite re-deferral to one-shot accept-and-proceed |
 
 ---
 
 ## Problem Chain
 
-### Original Problem ([dispatchscience-private#74](https://github.com/unoplatform/dispatchscience-private/issues/74))
+### Original Problem ([`dispatchscience-private#74`](https://github.com/unoplatform/dispatchscience-private/issues/74))
 
 **Scenario:** Android app with `SafeArea.Insets="VisibleBounds"` on a layout containing a `TabBar` in an Auto-height Grid row. User sets `StatusBar.Background` to a translucent color.
 
-**Root cause:** During the StatusBar translucency transition, `ApplicationView.VisibleBounds` updates to reflect the new translucent-bar coordinates *before* `Window.Bounds` updates. `GetWindowInsets()` computes `Bounds.Bottom - VisibleBounds.Bottom` against the stale (smaller) `Bounds`, producing an inflated bottom inset (~75.8px vs expected ~24px). This inflated value is applied as padding to the TabBar's Auto-sized row, permanently stretching it.
+**Root cause:** During the `StatusBar` translucency transition, `ApplicationView.VisibleBounds` updates to reflect the new translucent-bar coordinates *before* `Window.Bounds` updates. `GetWindowInsets()` computes `Bounds.Bottom - VisibleBounds.Bottom` against the stale (smaller) `Bounds`, producing an inflated bottom inset (~75.8px vs expected ~24px). This inflated value is applied as padding to the TabBar's Auto-sized row, permanently stretching it.
 
 **Fix ([PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)):**
 
@@ -30,11 +30,11 @@ Three PRs form a progressive fix chain for a race condition in `SafeArea.UpdateI
 3. Added parent `InvalidateMeasure()` in `OnInsetsApplied` for Android.
 4. The guard was **not platform-restricted** — it ran on all platforms.
 
-### First Regression ([kahua-private#458](https://github.com/unoplatform/kahua-private/issues/458))
+### First Regression ([`kahua-private#458`](https://github.com/unoplatform/kahua-private/issues/458))
 
-**Scenario:** iPad app with `SafeArea.Insets="VisibleBounds"`. User opens a `UIImagePickerController` presented as `FormSheet`/`OverFullScreen`. After dismissing the modal, taps, buttons, and back-navigation stop responding. Scroll (UIKit gesture recognizers) continues to work.
+**Scenario:** iPad app with `SafeArea.Insets="VisibleBounds"`. User opens a `UIImagePickerController` presented as `FormSheet`/`OverFullScreen`. After dismissing the modal, taps, buttons, and back-navigation stop responding. Scroll (`UIKit` gesture recognizers) continues to work.
 
-**Root cause:** On iPad, dismissing a FormSheet modal causes `VisibleBounds` to update while `Window.Bounds` stays stable — the host view was never detached, so Bounds has no reason to change. [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)'s guard enters Branch 2 (defer), then Branch 1 fires on the deferred callback and **re-defers indefinitely** because `boundsChanged` is perpetually `false`. This infinite `Normal`-priority dispatch loop live-locks the managed `DispatcherQueue`, starving all input handling.
+**Root cause:** On iPad, dismissing a `FormSheet` modal causes `VisibleBounds` to update while `Window.Bounds` stays stable — the host view was never detached, so Bounds has no reason to change. [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)'s guard enters Branch 2 (defer), then Branch 1 fires on the deferred callback and **re-defers indefinitely** because `boundsChanged` is perpetually `false`. This infinite `Normal`-priority dispatch loop live-locks the managed `DispatcherQueue`, starving all input handling.
 
 **Fix ([PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572)):**
 
@@ -46,7 +46,7 @@ Changed the guard condition from `if (!HasSoftInput())` to `if (!HasSoftInput() 
 - Added test `BoundsTransitionGuard_NotActive_OnNonAndroid`.
 - Added sample page `CameraSafeAreaTestPage` for iPad manual repro.
 
-### Second Regression ([kahua-private#460](https://github.com/unoplatform/kahua-private/issues/460))
+### Second Regression ([`kahua-private#460`](https://github.com/unoplatform/kahua-private/issues/460))
 
 **Scenario:** Android app with `SafeArea.Insets="VisibleBounds"`. User locks and unlocks the device. After unlock, low-priority `DispatcherQueue` items (e.g., timer-based updates, deferred navigation) stop executing.
 
@@ -96,7 +96,7 @@ When both conditions hold, `s_boundsTransitionPending` is set but never cleared,
 
 ### [PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593) vs [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) (inflated bottom inset)
 
-**No regression.** The StatusBar translucency transition scenario works as follows:
+**No regression.** The `StatusBar` translucency transition scenario works as follows:
 
 1. VB changes → Branch 2 fires → defers once (unchanged by [PR #1593](https://github.com/unoplatform/uno.toolkit.ui/pull/1593)).
 2. On the deferred callback, either:
@@ -162,7 +162,7 @@ UpdateInsets() called
 
 ### Manual Repro Page
 
-`CameraSafeAreaTestPage` (added by [PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572)): iPad-only page with a `UIImagePickerController` FormSheet to manually verify tap counter remains responsive after modal dismiss.
+`CameraSafeAreaTestPage` (added by [PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572)): iPad-only page with a `UIImagePickerController` `FormSheet` to manually verify tap counter remains responsive after modal dismiss.
 
 ---
 

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs
@@ -92,6 +92,10 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		[RequiresFullWindow]
 		public async Task BoundsTransitionGuard_NotActive_OnNonAndroid()
 		{
+			// Guard spec: SafeArea.cs → "Bounds-transition guard" block, gated by
+			//   `!HasSoftInput() && OperatingSystem.IsAndroid()`.
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
 			// Regression test for the iPad CameraCaptureUI live-lock (fix/iPadOS.transitions).
 			//
 			// PR #1554 added a Bounds/VisibleBounds-mismatch guard in UpdateInsets() that
@@ -133,6 +137,369 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 				Assert.IsFalse(
 					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
 					"Bounds-transition guard must stay gated off on non-Android — otherwise iPad live-locks the managed dispatcher after a FormSheet modal dismisses (see fix/iPadOS.transitions).");
+			}
+			finally
+			{
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = savedBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = savedVisibleBounds;
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = savedPending;
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task BoundsTransitionGuard_IgnoredForAllStates_OnNonAndroid()
+		{
+			// Guard spec: SafeArea.cs → "Bounds-transition guard" block, gated by
+			//   `!HasSoftInput() && OperatingSystem.IsAndroid()`.
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
+			// Complementary to BoundsTransitionGuard_NotActive_OnNonAndroid:
+			// Even if s_boundsTransitionPending is already true (e.g. stale state from a
+			// previous Android-gated execution), the guard block is entirely skipped on
+			// non-Android. The pending flag must remain unchanged — it is never read or
+			// cleared outside the Android guard.
+			var grid = new Grid { Background = new SolidColorBrush(Colors.Red), Width = 200, Height = 200 };
+			SafeArea.SetInsets(grid, SafeArea.InsetMask.VisibleBounds);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(grid);
+			await UnitTestUIContentHelperEx.WaitForIdle();
+
+			var details = SafeArea.SafeAreaDetails.FindInstance(grid)
+				?? throw new InvalidOperationException("SafeAreaDetails not found");
+
+			var savedBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownBounds;
+			var savedVisibleBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds;
+			var savedPending = SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending;
+
+			try
+			{
+				var currentBounds = XamlWindow.Current?.Bounds ?? default;
+
+				// Seed a "pending" state that would be handled on Android but must be ignored here.
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = currentBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = true;
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
+
+				// On non-Android, the guard block is skipped entirely, so the pending flag
+				// stays in whatever state it was seeded with.
+				Assert.IsTrue(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"On non-Android the guard block is entirely skipped — pending flag must stay unchanged.");
+			}
+			finally
+			{
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = savedBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = savedVisibleBounds;
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = savedPending;
+			}
+		}
+#endif
+
+#if DEBUG && __ANDROID__
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task BoundsTransition_DefersOnce_WhenVisibleBoundsChangeAheadOfWindowBounds()
+		{
+			// Guard spec: SafeArea.cs → Branch 2 — defer once.
+			// Introduced in: https://github.com/unoplatform/uno.toolkit.ui/pull/1554
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
+			// Branch 2: VisibleBounds changed but Window.Bounds hasn't yet — the guard
+			// must set s_boundsTransitionPending = true and schedule one deferred callback.
+			var grid = new Grid { Background = new SolidColorBrush(Colors.Red), Width = 200, Height = 200 };
+			SafeArea.SetInsets(grid, SafeArea.InsetMask.VisibleBounds);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(grid);
+			await UnitTestUIContentHelperEx.WaitForIdle();
+
+			var details = SafeArea.SafeAreaDetails.FindInstance(grid)
+				?? throw new InvalidOperationException("SafeAreaDetails not found");
+
+			var savedBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownBounds;
+			var savedVisibleBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds;
+			var savedPending = SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending;
+
+			try
+			{
+				var currentBounds = XamlWindow.Current?.Bounds ?? default;
+
+				// Seed: Bounds match current (no change), VisibleBounds differ (changed).
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = currentBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = false;
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
+
+				// Branch 2 fires synchronously: pending flag must be true.
+				Assert.IsTrue(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"Guard must set pending=true when VisibleBounds changed ahead of Window.Bounds.");
+			}
+			finally
+			{
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = savedBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = savedVisibleBounds;
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = savedPending;
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task BoundsTransition_AcceptsCurrent_AfterSingleDeferral()
+		{
+			// Guard spec: SafeArea.cs → Branch 1 — accept-and-proceed (one-shot).
+			// Fixed in: https://github.com/unoplatform/uno.toolkit.ui/pull/1593
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
+			// Branch 1 — THE KEY FIX: After one deferral, if Bounds still hasn't caught up,
+			// the guard must accept current values and clear pending instead of re-deferring
+			// indefinitely (which would starve DispatcherQueue Low-priority items).
+			var grid = new Grid { Background = new SolidColorBrush(Colors.Red), Width = 200, Height = 200 };
+			SafeArea.SetInsets(grid, SafeArea.InsetMask.VisibleBounds);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(grid);
+			await UnitTestUIContentHelperEx.WaitForIdle();
+
+			var details = SafeArea.SafeAreaDetails.FindInstance(grid)
+				?? throw new InvalidOperationException("SafeAreaDetails not found");
+
+			var savedBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownBounds;
+			var savedVisibleBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds;
+			var savedPending = SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending;
+
+			try
+			{
+				var currentBounds = XamlWindow.Current?.Bounds ?? default;
+
+				// Seed: pending=true (already deferred once), Bounds match current (no change).
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = currentBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = true;
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
+
+				// Branch 1 must accept and clear pending — no infinite re-deferral.
+				Assert.IsFalse(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"After one deferral, guard must accept current values and clear pending to prevent dispatcher starvation.");
+
+				// Cached values must be updated to the current state.
+				Assert.AreEqual(currentBounds, SafeArea.SafeAreaDetails.TestHook_LastKnownBounds,
+					"LastKnownBounds must be updated to current Window.Bounds after acceptance.");
+
+				var currentVB = ApplicationView.GetForCurrentView().VisibleBounds;
+				Assert.AreEqual(currentVB, SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds,
+					"LastKnownVisibleBounds must be updated to current VisibleBounds after acceptance.");
+			}
+			finally
+			{
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = savedBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = savedVisibleBounds;
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = savedPending;
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task BoundsTransition_ClearsGuard_WhenBoundsCatchUp()
+		{
+			// Guard spec: SafeArea.cs → Branch 3 — normal path.
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
+			// Branch 3: When Bounds change (i.e. they caught up to VisibleBounds), the guard
+			// must clear pending and update cached values — normal flow resumes.
+			var grid = new Grid { Background = new SolidColorBrush(Colors.Red), Width = 200, Height = 200 };
+			SafeArea.SetInsets(grid, SafeArea.InsetMask.VisibleBounds);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(grid);
+			await UnitTestUIContentHelperEx.WaitForIdle();
+
+			var details = SafeArea.SafeAreaDetails.FindInstance(grid)
+				?? throw new InvalidOperationException("SafeAreaDetails not found");
+
+			var savedBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownBounds;
+			var savedVisibleBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds;
+			var savedPending = SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending;
+
+			try
+			{
+				var currentBounds = XamlWindow.Current?.Bounds ?? default;
+
+				// Seed: pending=true, but lastKnownBounds differ from current → boundsChanged=true.
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = true;
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
+
+				// Branch 3: bounds caught up — pending must be cleared and caches updated.
+				Assert.IsFalse(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"Guard must clear pending when Window.Bounds have caught up.");
+				Assert.AreEqual(currentBounds, SafeArea.SafeAreaDetails.TestHook_LastKnownBounds,
+					"LastKnownBounds must be updated when bounds catch up.");
+			}
+			finally
+			{
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = savedBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = savedVisibleBounds;
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = savedPending;
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task BoundsTransition_NoDeferral_WhenLastKnownBoundsIsDefault()
+		{
+			// Guard spec: SafeArea.cs → Branch 2 edge case (s_lastKnownBounds == default).
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
+			// Edge case for Branch 2 guard: s_lastKnownBounds == default means this is the
+			// first ever UpdateInsets call. Even if VisibleBounds changed, no deferral should
+			// occur because there is no "prior state" to compare against.
+			var grid = new Grid { Background = new SolidColorBrush(Colors.Red), Width = 200, Height = 200 };
+			SafeArea.SetInsets(grid, SafeArea.InsetMask.VisibleBounds);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(grid);
+			await UnitTestUIContentHelperEx.WaitForIdle();
+
+			var details = SafeArea.SafeAreaDetails.FindInstance(grid)
+				?? throw new InvalidOperationException("SafeAreaDetails not found");
+
+			var savedBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownBounds;
+			var savedVisibleBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds;
+			var savedPending = SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending;
+
+			try
+			{
+				// Seed: lastKnownBounds = default (first run), VB differs from current.
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = default;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = false;
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
+
+				// Branch 2 condition requires s_lastKnownBounds != default — since it IS default,
+				// we must fall through to Branch 3 (normal update), so no deferral.
+				Assert.IsFalse(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"No deferral should occur on the first-ever UpdateInsets call (lastKnownBounds is default).");
+			}
+			finally
+			{
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = savedBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = savedVisibleBounds;
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = savedPending;
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task BoundsTransition_FullCycle_DefersOnceThenAccepts()
+		{
+			// Guard spec: SafeArea.cs → Branch 2 → Branch 1 full cycle.
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
+			// Integration test: walks through the complete cycle that the fix enables.
+			// Step 1 (Branch 2): VB changed, Bounds didn't → defer once.
+			// Step 2 (Branch 1): Pending, Bounds still unchanged → accept and clear.
+			// This proves the infinite loop is impossible.
+			var grid = new Grid { Background = new SolidColorBrush(Colors.Red), Width = 200, Height = 200 };
+			SafeArea.SetInsets(grid, SafeArea.InsetMask.VisibleBounds);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(grid);
+			await UnitTestUIContentHelperEx.WaitForIdle();
+
+			var details = SafeArea.SafeAreaDetails.FindInstance(grid)
+				?? throw new InvalidOperationException("SafeAreaDetails not found");
+
+			var savedBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownBounds;
+			var savedVisibleBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds;
+			var savedPending = SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending;
+
+			try
+			{
+				var currentBounds = XamlWindow.Current?.Bounds ?? default;
+
+				// Step 1: Simulate VB changing while Bounds stays the same.
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = currentBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = false;
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
+				Assert.IsTrue(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"Step 1: Guard must defer once when VB changed ahead of Bounds.");
+
+				// Step 2: Simulate the deferred callback firing — Bounds still haven't changed.
+				// (In real code, the deferred Schedule() calls UpdateInsets again.)
+				details.TestHook_InvokeUpdateInsets(forceUpdate: true);
+				Assert.IsFalse(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"Step 2: Guard must accept and clear pending after one deferral — no infinite loop.");
+			}
+			finally
+			{
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = savedBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = savedVisibleBounds;
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = savedPending;
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task BoundsTransition_FullCycle_DefersOnceThenBoundsCatchUp()
+		{
+			// Guard spec: SafeArea.cs → Branch 2 → Branch 3 happy-path cycle.
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
+			// Happy-path full cycle (the PR #1554 intended flow):
+			// Step 1 (Branch 2): VB changed, Bounds didn't → defer once.
+			// Step 2 (Branch 3): Bounds caught up → clear pending, update caches, proceed.
+			// This is the translucent StatusBar transition scenario where Window.Bounds
+			// updates one dispatch cycle after VisibleBounds.
+			var grid = new Grid { Background = new SolidColorBrush(Colors.Red), Width = 200, Height = 200 };
+			SafeArea.SetInsets(grid, SafeArea.InsetMask.VisibleBounds);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(grid);
+			await UnitTestUIContentHelperEx.WaitForIdle();
+
+			var details = SafeArea.SafeAreaDetails.FindInstance(grid)
+				?? throw new InvalidOperationException("SafeAreaDetails not found");
+
+			var savedBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownBounds;
+			var savedVisibleBounds = SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds;
+			var savedPending = SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending;
+
+			try
+			{
+				var currentBounds = XamlWindow.Current?.Bounds ?? default;
+
+				// Step 1: Simulate VB changing while Bounds stays the same.
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = currentBounds;
+				SafeArea.SafeAreaDetails.TestHook_LastKnownVisibleBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+				SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending = false;
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: false);
+				Assert.IsTrue(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"Step 1: Guard must defer once when VB changed ahead of Bounds.");
+
+				// Step 2: Simulate Bounds catching up between deferred callbacks.
+				// In reality, Window.Bounds changes → currentBounds differs from cached.
+				// We simulate this by changing the cached value so the comparison yields
+				// boundsChanged=true when XamlWindow.Current?.Bounds is read.
+				SafeArea.SafeAreaDetails.TestHook_LastKnownBounds = new Windows.Foundation.Rect(0, 0, 1, 1);
+
+				details.TestHook_InvokeUpdateInsets(forceUpdate: true);
+				Assert.IsFalse(
+					SafeArea.SafeAreaDetails.TestHook_BoundsTransitionPending,
+					"Step 2: Guard must clear pending when Bounds have caught up.");
+				Assert.AreEqual(currentBounds, SafeArea.SafeAreaDetails.TestHook_LastKnownBounds,
+					"Step 2: LastKnownBounds must be updated to the new Bounds value.");
 			}
 			finally
 			{
@@ -226,6 +593,10 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		[TestMethod]
 		public async Task BottomInset_NotInflated_WhenTransitioningToTranslucentBars()
 		{
+			// Guard spec: SafeArea.cs → Branch 2 defers to prevent this inflation.
+			// Original fix: https://github.com/unoplatform/uno.toolkit.ui/pull/1554
+			// Full R&D recap: specs/safearea-bounds-guard/recap.md
+			//
 			// Regression test: When transitioning to translucent system bars (e.g., setting StatusBar.Background),
 			// VisibleBounds updates before Window.Bounds, causing the SafeArea to temporarily calculate inflated
 			// bottom insets. This transient inflation can permanently stretch controls in Auto-sized grid rows.

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -467,28 +467,42 @@ namespace Uno.Toolkit.UI
 					return;
 				}
 
-				// Detect race condition: VisibleBounds updated before Window.Bounds.
+				// ──────────────────────────────────────────────────────────────────
+				// Bounds-transition guard — Android-only deferral for VisibleBounds /
+				// Window.Bounds race condition.
 				//
-				// On Android, StatusBar translucency transitions can cause
-				// ApplicationView.VisibleBounds to update before Window.Bounds, which leads
-				// GetWindowInsets() to compute an inflated bottom inset against the stale
-				// Bounds and permanently stretch Auto-sized rows. Deferring the inset
-				// computation until Window.Bounds catches up resolves that.
-				// (See PR #1554 / dispatchscience-private#74.)
+				// Full R&D recap: specs/safearea-bounds-guard/recap.md
 				//
-				// The guard is restricted to Android at runtime because the same shape of
-				// state — VisibleBounds changes while Window.Bounds stays stable — arises
-				// naturally on iPad after a UIImagePickerController-style FormSheet /
-				// OverFullScreen modal dismisses. There, Window.Bounds will never catch up
-				// (iOS keeps the host view attached and the modal did not change Bounds),
-				// so the deferred UpdateInsets call reschedules itself indefinitely on the
-				// DispatcherQueue and live-locks managed input handling — scroll continues
-				// to work because UIKit gesture recognizers route at the native layer, but
-				// taps/buttons/back-nav stop responding.
+				// Three issues drove this guard through successive fixes:
+				//
+				//   1. https://github.com/unoplatform/dispatchscience-private/issues/74 → PR https://github.com/unoplatform/uno.toolkit.ui/pull/1554
+				//      Android: StatusBar translucency transitions cause VisibleBounds to
+				//      update before Window.Bounds, making GetWindowInsets() compute an
+				//      inflated bottom inset against the stale Bounds and permanently
+				//      stretching Auto-sized rows. Fix: defer the inset computation until
+				//      Window.Bounds catches up (Branch 2 below), then re-check (Branch 1).
+				//
+				//   2. https://github.com/unoplatform/kahua-private/issues/458 → PR https://github.com/unoplatform/uno.toolkit.ui/pull/1572
+				//      iPad: the same VisibleBounds-changes-without-Bounds-changing shape
+				//      occurs naturally after a UIImagePickerController FormSheet /
+				//      OverFullScreen modal dismisses (iOS keeps the host view attached, so
+				//      Window.Bounds never catches up). The original Branch 1 re-deferred
+				//      infinitely at Normal priority, live-locking managed input handling
+				//      (scroll still worked via native UIKit gesture recognizers, but taps /
+				//      buttons / back-nav stopped responding). Fix: restrict the entire
+				//      guard to Android via `OperatingSystem.IsAndroid()`.
+				//
+				//   3. https://github.com/unoplatform/kahua-private/issues/460 → PR https://github.com/unoplatform/uno.toolkit.ui/pull/1593
+				//      Android: on some devices/OEM skins, Window.Bounds genuinely never
+				//      changes during lock/unlock — only VisibleBounds shifts. The original
+				//      Branch 1 kept re-deferring at Normal priority, starving Low-priority
+				//      DispatcherQueue work. Fix: convert Branch 1 from re-defer to
+				//      accept-and-proceed (one-shot pattern).
 				//
 				// `OperatingSystem.IsAndroid()` (vs `#if __ANDROID__`) is required so the
 				// guard remains active for Skia Android builds (`net9.0` TFM without the
 				// `__ANDROID__` define).
+				// ──────────────────────────────────────────────────────────────────
 				if (!HasSoftInput() && OperatingSystem.IsAndroid())
 				{
 					var currentBounds = XamlWindow.Current?.Bounds ?? Rect.Empty;
@@ -499,26 +513,37 @@ namespace Uno.Toolkit.UI
 
 					if (s_boundsTransitionPending && !boundsChanged)
 					{
-						// A previous instance already detected a transition in progress and
-						// Window.Bounds still hasn't caught up — defer this instance too.
-						Owner?.GetDispatcherCompat().Schedule(() => UpdateInsets(forceUpdate: true));
-						return;
+						// Branch 1 — accept-and-proceed (one-shot).
+						// We already deferred once (Branch 2) and Window.Bounds still hasn't
+						// caught up. Accept current values instead of re-deferring to avoid
+						// an infinite Normal-priority dispatch loop that permanently starves
+						// Low-priority DispatcherQueue items.
+						// Fixed in: https://github.com/unoplatform/uno.toolkit.ui/pull/1593
+						s_boundsTransitionPending = false;
+						s_lastKnownBounds = currentBounds;
+						s_lastKnownVisibleBounds = currentVB;
 					}
-
-					if (s_lastKnownBounds != default
+					else if (s_lastKnownBounds != default
 						&& visibleBoundsChanged
 						&& !boundsChanged)
 					{
-						// VisibleBounds changed but Window.Bounds hasn't caught up yet — defer.
+						// Branch 2 — defer once.
+						// VisibleBounds changed but Window.Bounds hasn't caught up yet.
+						// Defer the inset computation to give Bounds time to settle.
+						// Introduced in: https://github.com/unoplatform/uno.toolkit.ui/pull/1554
 						s_boundsTransitionPending = true;
 						Owner?.GetDispatcherCompat().Schedule(() => UpdateInsets(forceUpdate: true));
 						return;
 					}
-
-					// Bounds have caught up (or no transition was pending) — update cached values.
-					s_boundsTransitionPending = false;
-					s_lastKnownBounds = currentBounds;
-					s_lastKnownVisibleBounds = currentVB;
+					else
+					{
+						// Branch 3 — normal path.
+						// Bounds have caught up (or no transition was pending). Update
+						// cached values and proceed with inset computation.
+						s_boundsTransitionPending = false;
+						s_lastKnownBounds = currentBounds;
+						s_lastKnownVisibleBounds = currentVB;
+					}
 				}
 
 				UpdateSafeAreaOverride();


### PR DESCRIPTION
Fixes https://github.com/unoplatform/kahua-private/issues/460
Related to https://github.com/unoplatform/kahua-private/issues/458
Related to https://github.com/unoplatform/dispatchscience-private/issues/74

## Summary

Fixes a regression introduced by [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) where locking and unlocking an Android device causes `DispatcherQueue.TryEnqueue` (Low priority) to return `true` but the enqueued action never executes. This effectively freezes all Low-priority dispatcher work after a screen lock/unlock cycle.

## Root Cause

[PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) added a race-condition guard in `SafeArea.UpdateInsets()` to handle the case where `ApplicationView.VisibleBounds` updates before `Window.Bounds` during Android StatusBar translucency transitions. The guard defers inset computation until `Window.Bounds` catches up.

However, the implementation has an infinite re-deferral bug:

1. On screen lock/unlock, `VisibleBounds` changes but `Window.Bounds` **does not change** on certain Android devices/OEM skins (depends on navigation mode, display cutout, API level).
2. The code sets `s_boundsTransitionPending = true` and defers at `Normal` priority via `DispatcherCompat.Schedule()`.
3. When the deferred call fires, `s_boundsTransitionPending` is still `true` and bounds still haven't changed → the code **re-defers again**, creating an infinite loop.
4. `LayoutUpdated` keeps firing → more `Normal`-priority dispatches pile up.
5. **Low-priority `DispatcherQueue` items are permanently starved** — they never execute because the Normal-priority queue is never empty.

## The Fix

Convert the infinite re-deferral into a **one-shot deferral with fallthrough**:

| Scenario | Before (buggy) | After (fixed) |
|---|---|---|
| Deferred call fires, bounds still unchanged | Re-defers again → **infinite loop** | Clears flag, accepts current values → **falls through** |
| Initial transition detected | Sets flag, defers once ✓ | Sets flag, defers once ✓ (unchanged) |
| Bounds caught up or no transition | Clears flag, proceeds ✓ | Clears flag, proceeds ✓ (unchanged) |

The key change is that when the deferred call fires and `Window.Bounds` still hasn't caught up, we **accept the current values** and proceed rather than re-scheduling endlessly. On devices where `Window.Bounds` genuinely never changes during lock/unlock (only `VisibleBounds` shifts), this is the correct behavior — the one-frame deferral already gave `Window.Bounds` a chance to update, and continuing to wait is futile.

## Device Dependency

The bug is device-dependent because it requires:
- `VisibleBounds` to change during lock/unlock (most Android devices)
- `Window.Bounds` to **not** change during the same transition (varies by OEM skin, navigation mode, display cutout, and API level)

The timing gap is so short that by the next dispatch tick, both have caught up on some devices.

When both conditions hold, the `s_boundsTransitionPending` flag is set but never cleared, creating the infinite loop.

## Test Coverage

- Runtime tests in `SafeAreaTests.cs` covering all three branches of the bounds-transition guard:
  - **Branch 1** — `_isDeferredUpdate == true` (deferred callback fires, bounds unchanged → accept and proceed)
  - **Branch 2** — Fresh transition detected (bounds mismatch → defer once)
  - **Branch 3** — No transition (bounds match → proceed immediately)
- R&D recap documenting the full 3-PR fix chain ([PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554) → [PR #1572](https://github.com/unoplatform/uno.toolkit.ui/pull/1572) → this PR): `specs/safearea-bounds-guard/recap.md`

## Verification

- **Confirmed regression window**: The issue reproduces with UnoToolkit `8.5.0-dev.31`+ (which includes [PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)) but **does not reproduce** with `8.5.0-dev.30` (pre-[PR #1554](https://github.com/unoplatform/uno.toolkit.ui/pull/1554)).
- **Repro app**: See https://github.com/unoplatform/kahua-private/issues/460#issuecomment-4404142005 for details.