### PR TITLE
fix: migrate toolkit themes to BaseTheme.AddThemeSpecificResources hook

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<SkiaSharpVersion>3.119.2</SkiaSharpVersion>
-		<UnoThemesVersion>7.0.0-dev.29</UnoThemesVersion>
+		<UnoThemesVersion>7.0.0-dev.35</UnoThemesVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <UnoThemesVersion>7.0.0-dev.29</UnoThemesVersion>
+    <UnoThemesVersion>7.0.0-dev.35</UnoThemesVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.14" />

--- a/src/library/Uno.Toolkit.Material/MaterialToolkitTheme.cs
+++ b/src/library/Uno.Toolkit.Material/MaterialToolkitTheme.cs
@@ -29,12 +29,16 @@ namespace Uno.Toolkit.UI.Material
 		{
 		}
 
-		protected override ResourceDictionary GenerateSpecificResources()
+		protected override void AddThemeSpecificResources()
 		{
-			var dict = base.GenerateSpecificResources();
-			dict.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitPackageName}/Generated/mergedpages.xaml") });
-			dict.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitMaterialPackageName}/Generated/mergedpages.v2.xaml") });
-			return dict;
+			base.AddThemeSpecificResources();
+
+			// Layer the toolkit's own control styles on top of the generated theme.
+			// A fresh ResourceDictionary is created per call so hot-reload edits to the
+			// underlying XAML propagate, and AddThemeDictionary tracks them so they are
+			// removed and re-added on every rebuild instead of accumulating.
+			AddThemeDictionary(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitPackageName}/Generated/mergedpages.xaml") });
+			AddThemeDictionary(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitMaterialPackageName}/Generated/mergedpages.v2.xaml") });
 		}
 	}
 }

--- a/src/library/Uno.Toolkit.Simple/SimpleToolkitTheme.cs
+++ b/src/library/Uno.Toolkit.Simple/SimpleToolkitTheme.cs
@@ -24,12 +24,16 @@ namespace Uno.Toolkit.UI.Simple
 		{
 		}
 
-		protected override ResourceDictionary GenerateSpecificResources()
+		protected override void AddThemeSpecificResources()
 		{
-			var dict = base.GenerateSpecificResources();
-			dict.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitPackageName}/Generated/mergedpages.xaml") });
-			dict.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitSimplePackageName}/Generated/mergedpages.xaml") });
-			return dict;
+			base.AddThemeSpecificResources();
+
+			// Layer the toolkit's own control styles on top of the generated theme.
+			// A fresh ResourceDictionary is created per call so hot-reload edits to the
+			// underlying XAML propagate, and AddThemeDictionary tracks them so they are
+			// removed and re-added on every rebuild instead of accumulating.
+			AddThemeDictionary(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitPackageName}/Generated/mergedpages.xaml") });
+			AddThemeDictionary(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitSimplePackageName}/Generated/mergedpages.xaml") });
 		}
 	}
 }


### PR DESCRIPTION
This pull request updates the Uno Themes package version and refactors how theme-specific resources are added in both the Material and Simple toolkit themes. The main focus is on improving how resource dictionaries are managed and ensuring better support for hot-reload scenarios.

Dependency updates:

* Updated `UnoThemesVersion` to `7.0.0-dev.35` in both `samples/Directory.Packages.props` and `src/Directory.Packages.props` to use the latest development version. [[1]](diffhunk://#diff-8f89fce241ca6b7cc6aadbd5301d1568306ec7cc6b53117a6ed2b48816991e11L5-R5) [[2]](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11L4-R4)

Theme resource management improvements:

* Refactored `MaterialToolkitTheme` (`MaterialToolkitTheme.cs`) to override `AddThemeSpecificResources` instead of `GenerateSpecificResources`. Now uses `AddThemeDictionary` to add merged resource dictionaries, which helps avoid dictionary accumulation and supports hot-reload by ensuring fresh dictionaries are used on each update.
* Applied the same refactor to `SimpleToolkitTheme` (`SimpleToolkitTheme.cs`), switching to `AddThemeSpecificResources` and using `AddThemeDictionary` for better resource management and hot-reload support.