### PR TITLE
fix: update color constants for theme initialization tests

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/ThemeInitTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ThemeInitTests.cs
@@ -31,8 +31,8 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 	[RunsOnUIThread]
 	internal class ThemeInitTests
 	{
-		private const string DarkColor = "#FFC5BDFF";
-		private const string LightColor = "#FF594DB4";
+`		private const string DarkColor = "#FFC7BFFF";
+		private const string LightColor = "#FF5946D2";
 
 		[TestMethod]
 		[DataRow(true, DisplayName = "Dark Mode")]


### PR DESCRIPTION
This pull request updates the theme color constants used in the `ThemeInitTests` class. The hexadecimal values for both `DarkColor` and `LightColor` have been changed to reflect new color definitions.

- Updated theme color constants:
  - Changed `DarkColor` to `#FFC7BFFF` and `LightColor` to `#FF5946D2` in `ThemeInitTests.cs` (`ThemeInitTests` class).