### PR TITLE
feat: implement static control styles for Material and Simple toolkit

### DIFF
--- a/src/library/Uno.Toolkit.Material/MaterialToolkitTheme.cs
+++ b/src/library/Uno.Toolkit.Material/MaterialToolkitTheme.cs
@@ -1,4 +1,3 @@
-using System;
 using Uno.Material;
 
 #if IS_WINUI
@@ -17,9 +16,6 @@ namespace Uno.Toolkit.UI.Material
 	/// </summary>
 	public class MaterialToolkitTheme : MaterialTheme
 	{
-		private const string ToolkitPackageName = "Uno.Toolkit.WinUI";
-		private const string ToolkitMaterialPackageName = "Uno.Toolkit.WinUI.Material";
-
 		public MaterialToolkitTheme() : this(colorOverride: null, fontOverride: null)
 		{
 		}
@@ -29,16 +25,12 @@ namespace Uno.Toolkit.UI.Material
 		{
 		}
 
-		protected override void AddThemeSpecificResources()
-		{
-			base.AddThemeSpecificResources();
-
-			// Layer the toolkit's own control styles on top of the generated theme.
-			// A fresh ResourceDictionary is created per call so hot-reload edits to the
-			// underlying XAML propagate, and AddThemeDictionary tracks them so they are
-			// removed and re-added on every rebuild instead of accumulating.
-			AddThemeDictionary(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitPackageName}/Generated/mergedpages.xaml") });
-			AddThemeDictionary(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitMaterialPackageName}/Generated/mergedpages.v2.xaml") });
-		}
+		/// <summary>
+		/// The combined, static control styles for the Material toolkit theme. This layers the
+		/// Material base styles, the toolkit base styles, and the toolkit Material styles into a
+		/// single source so they are applied once via <see cref="ResourceDictionary.Source"/>,
+		/// rather than re-added on every theme rebuild through the dynamic resource hook.
+		/// </summary>
+		protected override string DefaultStylesSource => "ms-appx:///Uno.Toolkit.WinUI.Material/Themes/MaterialToolkitStyles.xaml";
 	}
 }

--- a/src/library/Uno.Toolkit.Material/Themes/MaterialToolkitStyles.xaml
+++ b/src/library/Uno.Toolkit.Material/Themes/MaterialToolkitStyles.xaml
@@ -1,0 +1,17 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<!--
+	Combined static control styles for the Material toolkit theme, layered lowest -> highest.
+	Used as the MaterialToolkitTheme.DefaultStylesSource so these styles are applied once via
+	ResourceDictionary.Source instead of being churned through the dynamic AddThemeSpecificResources hook.
+	-->
+	<ResourceDictionary.MergedDictionaries>
+		<!-- Material (Material Design 3) base control styles -->
+		<ResourceDictionary Source="ms-appx:///Uno.Material.WinUI/Generated/mergedpages.v2.xaml" />
+		<!-- Toolkit base control styles -->
+		<ResourceDictionary Source="ms-appx:///Uno.Toolkit.WinUI/Generated/mergedpages.xaml" />
+		<!-- Toolkit Material control styles (override the layers above) -->
+		<ResourceDictionary Source="ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.v2.xaml" />
+	</ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>

--- a/src/library/Uno.Toolkit.Simple/SimpleToolkitTheme.cs
+++ b/src/library/Uno.Toolkit.Simple/SimpleToolkitTheme.cs
@@ -1,4 +1,3 @@
-using System;
 using Uno.Simple;
 using Microsoft.UI.Xaml;
 
@@ -12,9 +11,6 @@ namespace Uno.Toolkit.UI.Simple
 	/// </summary>
 	public class SimpleToolkitTheme : SimpleTheme
 	{
-		private const string ToolkitPackageName = "Uno.Toolkit.WinUI";
-		private const string ToolkitSimplePackageName = "Uno.Toolkit.WinUI.Simple";
-
 		public SimpleToolkitTheme() : this(colorOverride: null, fontOverride: null)
 		{
 		}
@@ -24,16 +20,12 @@ namespace Uno.Toolkit.UI.Simple
 		{
 		}
 
-		protected override void AddThemeSpecificResources()
-		{
-			base.AddThemeSpecificResources();
-
-			// Layer the toolkit's own control styles on top of the generated theme.
-			// A fresh ResourceDictionary is created per call so hot-reload edits to the
-			// underlying XAML propagate, and AddThemeDictionary tracks them so they are
-			// removed and re-added on every rebuild instead of accumulating.
-			AddThemeDictionary(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitPackageName}/Generated/mergedpages.xaml") });
-			AddThemeDictionary(new ResourceDictionary { Source = new Uri($"ms-appx:///{ToolkitSimplePackageName}/Generated/mergedpages.xaml") });
-		}
+		/// <summary>
+		/// The combined, static control styles for the Simple toolkit theme. This layers the
+		/// Simple base styles, the toolkit base styles, and the toolkit Simple styles into a
+		/// single source so they are applied once via <see cref="ResourceDictionary.Source"/>,
+		/// rather than re-added on every theme rebuild through the dynamic resource hook.
+		/// </summary>
+		protected override string DefaultStylesSource => "ms-appx:///Uno.Toolkit.WinUI.Simple/Themes/SimpleToolkitStyles.xaml";
 	}
 }

--- a/src/library/Uno.Toolkit.Simple/Themes/SimpleToolkitStyles.xaml
+++ b/src/library/Uno.Toolkit.Simple/Themes/SimpleToolkitStyles.xaml
@@ -1,0 +1,17 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<!--
+	Combined static control styles for the Simple toolkit theme, layered lowest -> highest.
+	Used as the SimpleToolkitTheme.DefaultStylesSource so these styles are applied once via
+	ResourceDictionary.Source instead of being churned through the dynamic AddThemeSpecificResources hook.
+	-->
+	<ResourceDictionary.MergedDictionaries>
+		<!-- Simple Design System base control styles -->
+		<ResourceDictionary Source="ms-appx:///Uno.Simple.WinUI/Generated/mergedpages.xaml" />
+		<!-- Toolkit base control styles -->
+		<ResourceDictionary Source="ms-appx:///Uno.Toolkit.WinUI/Generated/mergedpages.xaml" />
+		<!-- Toolkit Simple control styles (override the layers above) -->
+		<ResourceDictionary Source="ms-appx:///Uno.Toolkit.WinUI.Simple/Generated/mergedpages.xaml" />
+	</ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>


### PR DESCRIPTION
This pull request refactors how theme-specific control styles are applied in both the Material and Simple toolkit themes. Instead of dynamically layering multiple resource dictionaries at runtime, it introduces a single, static XAML resource dictionary for each theme that combines all necessary style layers. This change simplifies theme application, improves performance, and reduces issues with resource churn during theme rebuilds.

Theme resource management improvements:

* Replaced the dynamic `AddThemeSpecificResources` method in `MaterialToolkitTheme` and `SimpleToolkitTheme` with a static `DefaultStylesSource` property, each pointing to a new combined XAML resource dictionary. This ensures all required styles are loaded once, rather than being re-applied on every theme rebuild. (`MaterialToolkitTheme.cs`, `SimpleToolkitTheme.cs`) [[1]](diffhunk://#diff-7b1b2c8936a87dbf7af71e13d5d1c8a763bef7cac8b54b01b6d5a97b17bd1d2fL32-R34) [[2]](diffhunk://#diff-358c881d3901c486bdeddcd9d7d535ce07e9bc30289d0a90fdc1f6dced650bf0L27-R29)
* Removed the unused package name constants and related `using System;` directives from both theme classes, streamlining the code. (`MaterialToolkitTheme.cs`, `SimpleToolkitTheme.cs`) [[1]](diffhunk://#diff-7b1b2c8936a87dbf7af71e13d5d1c8a763bef7cac8b54b01b6d5a97b17bd1d2fL20-L22) [[2]](diffhunk://#diff-7b1b2c8936a87dbf7af71e13d5d1c8a763bef7cac8b54b01b6d5a97b17bd1d2fL1) [[3]](diffhunk://#diff-358c881d3901c486bdeddcd9d7d535ce07e9bc30289d0a90fdc1f6dced650bf0L15-L17) [[4]](diffhunk://#diff-358c881d3901c486bdeddcd9d7d535ce07e9bc30289d0a90fdc1f6dced650bf0L1)

New combined resource dictionaries:

* Added `MaterialToolkitStyles.xaml` and `SimpleToolkitStyles.xaml`, each merging the base, toolkit, and theme-specific style dictionaries in the correct order. These files are referenced by the new `DefaultStylesSource` properties and ensure proper style layering. (`MaterialToolkitStyles.xaml`, `SimpleToolkitStyles.xaml`) [[1]](diffhunk://#diff-3dc9b05bca4359bd26ac83c2ae9854eee5e78203cb28b9bae27696672645ea75R1-R17) [[2]](diffhunk://#diff-6a0cc7d6cdd2f2c5a28d7deebda4710d2bb3b34cb8a38176b0dc03f944c78bffR1-R17)