### PR TITLE
fix(SafeArea): subscribe to process-global InputPane/ApplicationView events weakly

### DIFF
--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -381,6 +381,14 @@ namespace Uno.Toolkit.UI
 				out TypedEventHandler<TSender, TArgs> handler)
 				where TSender : class
 			{
+				// The whole point of this wrapper is that the global event singleton holds only a
+				// WeakReference back. That guarantee is defeated if a caller passes a capturing lambda:
+				// its closure display-class would be rooted by the delegate (Target != null) and would
+				// in turn root whatever it captured. Callers must pass static/non-capturing delegates
+				// (Target == null); assert it in DEBUG so an accidental capture is caught during dev.
+				System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+				System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+
 				var weakTarget = new WeakReference<SafeAreaDetails>(target);
 				TypedEventHandler<TSender, TArgs> h = null!;
 				h = (s, e) =>

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -5,7 +5,6 @@
 
 using Microsoft.Extensions.Logging;
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Uno.Disposables;
@@ -387,8 +386,10 @@ namespace Uno.Toolkit.UI
 				// its closure display-class would be rooted by the delegate (Target != null) and would
 				// in turn root whatever it captured. Callers must pass static/non-capturing delegates
 				// (Target == null); assert it in DEBUG so an accidental capture is caught during dev.
-				Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
-				Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+				// Fully qualified: on net*-android an unqualified `Debug` binds to the inherited
+				// Android.Views.ViewGroup.Debug(int) method (CS0119), not System.Diagnostics.Debug.
+				System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+				System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
 
 				var weakTarget = new WeakReference<SafeAreaDetails>(target);
 				TypedEventHandler<TSender, TArgs> h = null!;

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Uno.Disposables;
@@ -386,8 +387,8 @@ namespace Uno.Toolkit.UI
 				// its closure display-class would be rooted by the delegate (Target != null) and would
 				// in turn root whatever it captured. Callers must pass static/non-capturing delegates
 				// (Target == null); assert it in DEBUG so an accidental capture is caught during dev.
-				System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
-				System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+				Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+				Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
 
 				var weakTarget = new WeakReference<SafeAreaDetails>(target);
 				TypedEventHandler<TSender, TArgs> h = null!;

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -377,8 +377,7 @@ namespace Uno.Toolkit.UI
 			private static TypedEventHandler<TSender, TArgs> CreateWeakHandler<TSender, TArgs>(
 				SafeAreaDetails target,
 				Action<SafeAreaDetails, TSender, TArgs> onEvent,
-				Action<TSender, TypedEventHandler<TSender, TArgs>> detach,
-				out TypedEventHandler<TSender, TArgs> handler)
+				Action<TSender, TypedEventHandler<TSender, TArgs>> detach)
 				where TSender : class
 			{
 				// The whole point of this wrapper is that the global event singleton holds only a
@@ -404,7 +403,6 @@ namespace Uno.Toolkit.UI
 						detach(s, h);
 					}
 				};
-				handler = h;
 				return h;
 			}
 
@@ -418,11 +416,11 @@ namespace Uno.Toolkit.UI
 				// the owner and its ALC for the process lifetime. Subscribe weakly so the global singleton
 				// only holds a WeakReference back; the wrapper self-detaches once this instance is collected.
 				var appView = ApplicationView.GetForCurrentView();
-				appView.VisibleBoundsChanged += CreateWeakHandler<ApplicationView, object>(
+				var appViewHandler = CreateWeakHandler<ApplicationView, object>(
 					this,
 					static (self, s, e) => self.OnInsetUpdateRequired(s, e),
-					static (s, h) => s.VisibleBoundsChanged -= h,
-					out var appViewHandler);
+					static (s, h) => s.VisibleBoundsChanged -= h);
+				appView.VisibleBoundsChanged += appViewHandler;
 				_subscriptions.Add(() => appView.VisibleBoundsChanged -= appViewHandler);
 
 				if (InputPane.GetForCurrentView() is { } inputPane)
@@ -434,8 +432,7 @@ namespace Uno.Toolkit.UI
 						{
 							s.Showing -= h;
 							s.Hiding -= h;
-						},
-						out _);
+						});
 					inputPane.Showing += inputPaneHandler;
 					inputPane.Hiding += inputPaneHandler;
 

--- a/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
+++ b/src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs
@@ -369,20 +369,70 @@ namespace Uno.Toolkit.UI
 				UpdateInsets();
 			}
 
+			// Creates a TypedEventHandler that invokes <paramref name="onEvent"/> against a WeakReference
+			// to <paramref name="target"/>, so a process-global event source cannot strongly root the
+			// target. Once the target has been collected the wrapper detaches itself via
+			// <paramref name="detach"/>. onEvent/detach MUST be static (non-capturing) so the returned
+			// delegate captures only the WeakReference — never the target instance.
+			private static TypedEventHandler<TSender, TArgs> CreateWeakHandler<TSender, TArgs>(
+				SafeAreaDetails target,
+				Action<SafeAreaDetails, TSender, TArgs> onEvent,
+				Action<TSender, TypedEventHandler<TSender, TArgs>> detach,
+				out TypedEventHandler<TSender, TArgs> handler)
+				where TSender : class
+			{
+				var weakTarget = new WeakReference<SafeAreaDetails>(target);
+				TypedEventHandler<TSender, TArgs> h = null!;
+				h = (s, e) =>
+				{
+					if (weakTarget.TryGetTarget(out var self))
+					{
+						onEvent(self, s, e);
+					}
+					else
+					{
+						detach(s, h);
+					}
+				};
+				handler = h;
+				return h;
+			}
+
 			private void RegisterEvents()
 			{
-				ApplicationView.GetForCurrentView().VisibleBoundsChanged += OnInsetUpdateRequired;
-				_subscriptions.Add(() => ApplicationView.GetForCurrentView().VisibleBoundsChanged -= OnInsetUpdateRequired);
+				// ApplicationView and InputPane are process-global singletons. Subscribing to their events
+				// with an instance-method delegate makes the singleton strongly root this SafeAreaDetails
+				// (and, through its subscription closures, the owner element). Unregister() undoes this on
+				// the owner's Unloaded — but that event does not fire when the owner's AssemblyLoadContext
+				// is torn down abruptly (e.g. a plugin/preview host unloading a collectible ALC), leaking
+				// the owner and its ALC for the process lifetime. Subscribe weakly so the global singleton
+				// only holds a WeakReference back; the wrapper self-detaches once this instance is collected.
+				var appView = ApplicationView.GetForCurrentView();
+				appView.VisibleBoundsChanged += CreateWeakHandler<ApplicationView, object>(
+					this,
+					static (self, s, e) => self.OnInsetUpdateRequired(s, e),
+					static (s, h) => s.VisibleBoundsChanged -= h,
+					out var appViewHandler);
+				_subscriptions.Add(() => appView.VisibleBoundsChanged -= appViewHandler);
 
 				if (InputPane.GetForCurrentView() is { } inputPane)
 				{
-					inputPane.Showing += OnInputPaneChanged;
-					inputPane.Hiding += OnInputPaneChanged;
+					var inputPaneHandler = CreateWeakHandler<InputPane, InputPaneVisibilityEventArgs>(
+						this,
+						static (self, s, e) => self.OnInputPaneChanged(s, e),
+						static (s, h) =>
+						{
+							s.Showing -= h;
+							s.Hiding -= h;
+						},
+						out _);
+					inputPane.Showing += inputPaneHandler;
+					inputPane.Hiding += inputPaneHandler;
 
 					_subscriptions.Add(() =>
 					{
-						inputPane.Showing -= OnInputPaneChanged;
-						inputPane.Hiding -= OnInputPaneChanged;
+						inputPane.Showing -= inputPaneHandler;
+						inputPane.Hiding -= inputPaneHandler;
 					});
 				}
 


### PR DESCRIPTION
**ALC pin-fix — standalone (uno.toolkit.ui).** Base: `main`. Independent of the uno framework stack; a downstream host-side sweep mitigates until this ships.

Fixes #1602

## Spec

`SafeAreaDetails` subscribed to the process-global `ApplicationView.VisibleBoundsChanged` and `InputPane.Showing`/`Hiding` events with instance-method delegates, so the process-lifetime singleton strongly rooted the `SafeAreaDetails` and — through its `_subscriptions` closures, which capture `owner` — the owner element and its whole subtree. `Unregister()` undoes this only on the owner's `Unloaded`, which does not fire when a tree is discarded abruptly (e.g. a host unloading a plugin/preview app hosted in a collectible `AssemblyLoadContext`), leaking the owner — and its ALC — for the process lifetime, one leak per unloaded owner.

This PR makes the global-event subscriptions weak so the singleton can never root a discarded `SafeAreaDetails`, while keeping behaviour identical while the owner is alive. Verified downstream in a designer-style host via ClrMD heap-dump root attribution: after this change (as part of a broader pin audit), zero objects from an unloaded preview-app ALC remain reachable and the ALC completes unloading.

## Implementation

`src/Uno.Toolkit.UI/Controls/SafeArea/SafeArea.cs` (+56/−6, single file):

- Added `SafeAreaDetails.CreateWeakHandler<TSender, TArgs>(target, onEvent, detach, out handler)`: builds a `TypedEventHandler<TSender, TArgs>` whose closure captures **only** a `WeakReference<SafeAreaDetails>`. While the target is alive it forwards to `onEvent`; once the target has been collected it self-detaches from the sender via `detach`. Both callbacks are required to be `static` (non-capturing) lambdas so the returned delegate never captures the target instance; the handler is also returned via `out` so the normal `Unloaded` path can still unsubscribe eagerly.
- `RegisterEvents()` — `ApplicationView`: subscribes `VisibleBoundsChanged` through `CreateWeakHandler` forwarding to `OnInsetUpdateRequired`; the eager-unsubscribe closure added to `_subscriptions` now captures the same `appView` instance instead of re-calling `GetForCurrentView()` at dispose time.
- `RegisterEvents()` — `InputPane`: one weak wrapper serves both `Showing` and `Hiding` (forwarding to `OnInputPaneChanged`); its `detach` removes it from both events; the eager `_subscriptions` unsubscribe is preserved.
- The ScrollViewer-ancestor `SizeChanged` subscription is intentionally left as a strong instance delegate: the scroll ancestor belongs to the same visual tree as the owner, so it cannot outlive it — there is no cross-lifetime root there.
- An explanatory comment in `RegisterEvents()` documents why weak subscription is mandatory for process-global sources.

## Test plan

- **Red/green regression test** (to be committed with this fix): `SafeAreaTests.When_Owner_Discarded_Without_Unloaded_Details_And_Owner_Are_Collected` in `src/Uno.Toolkit.RuntimeTests/Tests/SafeAreaTests.cs`. Arrange: load a `SafeArea`-annotated `Grid`, resolve its `SafeAreaDetails` via the existing internal `FindInstance` hook, detach the private `OnOwnerUnloaded` handler (reflection-bound delegate) to model teardown without `Unloaded`, clear content inside a `[NoInlining]` helper, keep only `WeakReference`s. Act: GC collect/finalize loop with dispatcher idles. Assert: both `WeakReference`s die. Fails on main (singletons root the graph); passes with this change.
- Existing `SafeAreaTests` runtime tests cover the alive-path behaviour (insets still applied on `VisibleBoundsChanged` / input-pane transitions) — unchanged, since the weak wrapper forwards to the same `OnInsetUpdateRequired`/`OnInputPaneChanged` methods.
- Downstream verification: ClrMD dump-based GC-root attribution in a host that load/unload-cycles preview apps in collectible ALCs confirmed the `ApplicationView`/`InputPane`-rooted pins are gone and the ALC unloads to zero retained objects.

## Risks / rollback

- **Stale wrapper window:** after the target is collected, the small wrapper delegate (closure holding one dead `WeakReference`) stays on the singleton until the next event firing self-detaches it, or until the eager `Unloaded`-path unsubscribe ran. It cannot root the owner tree; cost is a few dozen bytes per collected instance, bounded and self-cleaning.
- **No timing/reentrancy change:** events fire on the same thread and forward to the same handlers; while the owner is alive, behaviour is byte-for-byte equivalent.
- **Rollback:** revert the single commit — the change is fully contained in `SafeArea.cs`.
