### PR TITLE
ci: Bump canary updater tool to 1.3.1

### DIFF
--- a/build/workflow/templates/canary-updater.yml
+++ b/build/workflow/templates/canary-updater.yml
@@ -8,7 +8,7 @@ steps:
       branchToMerge: main
       summaryFile: '$(Build.ArtifactStagingDirectory)/Canary.md'
       resultFile: '$(Build.ArtifactStagingDirectory)/result.json'
-      nugetUpdaterVersion: '1.2.10'
+      nugetUpdaterVersion: '1.3.1'
       packageAuthor: 'Uno Platform,unoplatform'
       additionalPublicSources: 'https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json'
 


### PR DESCRIPTION
Bump `nugetUpdaterVersion` `1.2.10 → 1.3.1` (latest stable) as the single source on the default branch; `canaries/dev` inherits it via the `main` merge. `1.3.1` adds the property-package fallback mappings (unoplatform/nuget.updater#40) so `UnoThemes`/`UnoMaterial` resolve their WinUI variants.

Note: this is fleet alignment.