### PR TITLE
fix: weak-subscription / static-pin sweeps for collectible ALCs (batch 3)

### DIFF
--- a/specs/alc-weak-subscription-sweeps/recap.md
+++ b/specs/alc-weak-subscription-sweeps/recap.md
@@ -15,7 +15,7 @@ roots an object graph that belongs to the previewed app's ALC, so the ALc's
 `LoaderAllocator` is never released and the ALC leaks for the process lifetime.
 
 This spec tracks a batch of low-risk sweeps that make those subscriptions weak /
-self-detaching, or add explicit purge hooks, without changing behaviour for normal apps.
+self-detaching, or add explicit purge hooks, without changing behavior for normal apps.
 
 Backing issue: **#1607**.
 

--- a/specs/alc-weak-subscription-sweeps/recap.md
+++ b/specs/alc-weak-subscription-sweeps/recap.md
@@ -1,0 +1,89 @@
+# ALC Weak-Subscription / Pin Sweeps — Recap
+
+## Context
+
+A downstream host that loads previewed apps into their own collectible
+`AssemblyLoadContext`s needs those ALCs to be fully collectible after the previewed
+app is unloaded. Several Toolkit types subscribe to **process-global event sources**
+or hold **process-lifetime static references** with either no teardown, or a teardown
+path that only runs on an event that may never fire in a fixed-size preview canvas.
+
+In an ordinary app these references are harmless because the process, the Toolkit
+assembly, the window, and the app all share one lifetime. Across a collectible-ALC
+boundary they become **hard pins**: the global source (or a Toolkit static) strongly
+roots an object graph that belongs to the previewed app's ALC, so the ALc's
+`LoaderAllocator` is never released and the ALC leaks for the process lifetime.
+
+This spec tracks a batch of low-risk sweeps that make those subscriptions weak /
+self-detaching, or add explicit purge hooks, without changing behaviour for normal apps.
+
+Backing issue: **#1607**.
+
+The weak self-detaching handler pattern reuses the template established for the
+`SafeArea` process-global `InputPane` / `ApplicationView` subscriptions
+(`CreateWeakHandler`): a `WeakReference<T>` to the target plus **static, non-capturing**
+`onEvent` / `detach` delegates so the global source holds only a weak reference, and the
+wrapper detaches itself once the target is collected.
+
+## Findings
+
+| # | Type | Problem | Fix |
+|---|------|---------|-----|
+| 1 | `ResponsiveHelper.InitializeIfNeeded` | Strong `XamlRoot.Changed` lambda captures the process-lifetime static `_defaultSizeProvider`; no teardown, no reset. Host `XamlRoot` roots the Toolkit static chain for the process lifetime. | Weak self-detaching `XamlRoot.Changed` handler + internal `Reset()` purge hook. |
+| 2 | `DependencyObjectExtensions._dependencyPropertyReflectionCache` | `Type`-keyed static dictionary never releases `Type` keys → a `Type` from a collectible ALC keeps that ALC alive. | Release entries whose `Type` belongs to an unloaded/collected ALC. |
+| 3 | `NavigationBar` → `SystemNavigationManager.BackRequested` | Strong sub; detached on `Unloaded`, but `Unloaded` does not fire on abrupt ALC teardown. | Weak self-detaching handler; keep the fast `Unloaded` path. |
+| 4 | `ResponsiveExtension` | `HardSelfReferences` + static `WindowSizeChanged` sub + `TrackedInstances` accumulate per cycle; cleanup only runs from `OnWindowSizeChanged`, which never fires in a fixed preview canvas. | Unloaded-hooked removal + dead-host sweep on `Connect` + weak handler; prune dead weak-refs in `TrackedInstances`. |
+| 5 | `FrameworkElementExtensions.SubscribeToNestedElements` | Returned disposable clears its subscription list **without invoking** the recorded unsubscribe actions → `Loaded` handlers stay attached. | Invoke each recorded `Unsubscribe()` on dispose. |
+| 6 | `ExtendedSplashScreen` | Static `Instance` + retained splash bitmap never released. | Clear on `Unloaded`; drop `SplashScreenContent` after the loaded transition. |
+
+### Out of scope (follow-ups only)
+
+- `ShadowsCache` dispose-on-evict
+- `StatusBar` teardown
+- `ResponsiveView` slot cache
+
+## Finding 1 — ResponsiveHelper (landed)
+
+**Before**
+
+```csharp
+provider.Changed += (s, e) => _defaultSizeProvider.Size = s.Size;
+```
+
+The lambda captures the static `_defaultSizeProvider`. The host `XamlRoot` (window-owned,
+outlives previewed apps) holds this delegate forever, so the Toolkit static chain — and
+transitively the Toolkit ALC — is pinned for the process lifetime. There was no teardown
+path at all.
+
+**After**
+
+- A `CreateWeakHandler<XamlRoot, XamlRootChangedEventArgs>` wrapper holds a
+  `WeakReference<ResponsiveSizeProvider>` and static non-capturing `onEvent`/`detach`
+  delegates; the `XamlRoot` now holds only a weak reference back and the wrapper
+  self-detaches once the provider is collected.
+- The subscription is also recorded in a `SerialDisposable` (`_defaultSizeProviderDisposable`).
+- New internal `Reset()` tears down the default and override providers and their
+  subscriptions and clears `WindowSize`, so a host can fully reset the singleton between
+  app loads.
+
+**Tests** (`ResponsiveHelperLeakTests`, `#if DEBUG`, runtime):
+
+- `Reset_TearsDown_DefaultProvider` — deterministic: `InitializeIfNeeded` initializes,
+  `Reset` tears down (`TestHook_IsDefaultProviderInitialized == false`), and a subsequent
+  `InitializeIfNeeded` re-initializes cleanly.
+- `DefaultProvider_IsCollectible_WhileXamlRootAlive` — GC proof: while the host `XamlRoot`
+  is kept strongly alive and subscribed, the default provider becomes collectible after
+  `Reset()`. On the pre-fix strong-lambda code the `XamlRoot.Changed` closure would keep
+  the provider alive (red); with the weak handler it is collected (green).
+
+Test hooks added under `#if DEBUG`: `TestHook_IsDefaultProviderInitialized`,
+`TestHook_GetDefaultProvider()`.
+
+## Progress
+
+- [x] Finding 1 — ResponsiveHelper weak handler + Reset (fix + tests compile clean)
+- [ ] Finding 2 — DependencyObjectExtensions reflection-cache ALC purge
+- [ ] Finding 3 — NavigationBar BackRequested weak handler
+- [ ] Finding 4 — ResponsiveExtension accumulation sweeps
+- [ ] Finding 5 — SubscribeToNestedElements dispose invokes unsubscribe
+- [ ] Finding 6 — ExtendedSplashScreen Instance + bitmap release

--- a/specs/alc-weak-subscription-sweeps/recap.md
+++ b/specs/alc-weak-subscription-sweeps/recap.md
@@ -81,9 +81,22 @@ Test hooks added under `#if DEBUG`: `TestHook_IsDefaultProviderInitialized`,
 
 ## Progress
 
-- [x] Finding 1 — ResponsiveHelper weak handler + Reset (fix + tests compile clean)
-- [ ] Finding 2 — DependencyObjectExtensions reflection-cache ALC purge
-- [ ] Finding 3 — NavigationBar BackRequested weak handler
-- [ ] Finding 4 — ResponsiveExtension accumulation sweeps
-- [ ] Finding 5 — SubscribeToNestedElements dispose invokes unsubscribe
-- [ ] Finding 6 — ExtendedSplashScreen Instance + bitmap release
+- [x] Finding 1 — ResponsiveHelper weak handler + Reset
+- [x] Finding 2 — DependencyObjectExtensions reflection-cache keyed weakly by Type (ConditionalWeakTable)
+- [x] Finding 3 — NavigationBar BackRequested weak self-detaching handler (keeps Unloaded fast path)
+- [x] Finding 4 — ResponsiveExtension weak WindowSizeChanged sub + Unloaded teardown + dead-instance sweep
+- [x] Finding 5 — SubscribeToNestedElements dispose invokes recorded Unsubscribe actions
+- [x] Finding 6 — ExtendedSplashScreen releases static Instance + splash content (Android: recycles bitmap) on Unloaded
+
+All fixes + red/green tests compile clean on `net9.0` (Toolkit.UI + RuntimeTests, 0 warnings).
+
+## Tests (all runtime, `#if DEBUG`)
+
+| Finding | Test class | Tests |
+|---------|-----------|-------|
+| 1 | `ResponsiveHelperLeakTests` | `Reset_TearsDown_DefaultProvider`, `DefaultProvider_IsCollectible_WhileXamlRootAlive` |
+| 2 | `DependencyObjectExtensionsLeakTests` | `ReflectionCache_DoesNotRoot_CollectibleTypeKey` (RunAndCollect dynamic assembly) |
+| 3 | `NavigationBarLeakTests` | `BackRequested_Subscription_IsWeak_WhenUnloadedNeverFires` |
+| 4 | `ResponsiveExtensionsLeakTests` | `SweepDeadInstances_Prunes_CollectedTrackedInstances`, `Connected_Extension_IsCollectible_WithoutResizeOrExplicitUninstall` |
+| 5 | `FrameworkElementExtensionsLeakTests` | `SubscribeToNestedElements_Dispose_DetachesLoadedHandlers` |
+| 6 | `ExtendedSplashScreenLeakTests` | `Instance_IsReleased_OnUnloaded`, `SplashScreen_IsCollectible_AfterUnloaded` |

--- a/src/Uno.Toolkit.RuntimeTests/Tests/DependencyObjectExtensionsLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/DependencyObjectExtensionsLeakTests.cs
@@ -1,0 +1,74 @@
+#if DEBUG && !__WASM__ && !__ANDROID__ && !__IOS__
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+
+using DependencyObjectExtensions = Uno.Toolkit.UI.DependencyObjectExtensions;
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+/// <summary>
+/// Guards that the process-lifetime dependency-property reflection cache does not strongly root its
+/// owner <see cref="Type"/> keys. A Type from a collectible assembly (modelling a previewed app loaded
+/// into a collectible AssemblyLoadContext) must remain collectible, otherwise the cache pins the Type's
+/// LoaderAllocator — and the whole ALC — for the process lifetime.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+internal class DependencyObjectExtensionsLeakTests
+{
+	[TestMethod]
+	public async Task ReflectionCache_DoesNotRoot_CollectibleTypeKey()
+	{
+		var typeRef = PopulateCacheFromCollectibleAssembly();
+
+		await CollectAndWait();
+
+		Assert.IsFalse(
+			typeRef.IsAlive,
+			"A Type from a collectible (RunAndCollect) assembly should be collectible after use; " +
+			"if it survives, the reflection cache is strongly rooting the Type key. " +
+			"A ConditionalWeakTable-keyed cache releases the entry with its Type; a Dictionary<Type,...> pins it.");
+	}
+
+	// Emits a collectible dynamic assembly, uses one of its Types as a cache key, then returns a weak
+	// reference to that Type. The assembly/Type is only referenced from within this non-inlined frame so
+	// it can be collected once we drop out of it (subject only to the cache not rooting it).
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference PopulateCacheFromCollectibleAssembly()
+	{
+		var asmName = new AssemblyName("Uno.Toolkit.RuntimeTests.Collectible." + Guid.NewGuid().ToString("N"));
+		var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.RunAndCollect);
+		var moduleBuilder = asmBuilder.DefineDynamicModule("Main");
+		var typeBuilder = moduleBuilder.DefineType("CollectibleOwner", TypeAttributes.Public);
+		var owner = typeBuilder.CreateType()!;
+
+		// Populate the cache for this collectible Type. The DP does not exist on it; that is fine — the
+		// cache still records a (Type -> per-property dictionary) entry keyed by the collectible Type.
+		_ = owner.FindDependencyProperty("SomeMissingProperty");
+
+		Assert.IsTrue(
+			DependencyObjectExtensions.TestHook_ReflectionCacheContains(owner),
+			"The reflection cache should hold an entry for the Type immediately after lookup.");
+
+		return new WeakReference(owner);
+	}
+
+	private static async Task CollectAndWait()
+	{
+		for (var i = 0; i < 8; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			await UnitTestUIContentHelperEx.WaitForIdle();
+		}
+	}
+}
+#endif

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ExtendedSplashScreenLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ExtendedSplashScreenLeakTests.cs
@@ -1,0 +1,95 @@
+#if DEBUG
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+/// <summary>
+/// Guards that <see cref="ExtendedSplashScreen"/> releases its process-lifetime static <c>Instance</c>
+/// (and its splash content) when it unloads. Otherwise the last-created splash screen — and, when it
+/// belongs to a previewed app loaded into a collectible AssemblyLoadContext, that app's whole ALC —
+/// stays pinned for the process lifetime.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class ExtendedSplashScreenLeakTests
+{
+	[TestMethod]
+#if __ANDROID__ || __IOS__
+	[Ignore("Splash screen control hosting differs on native platforms.")]
+#endif
+	public async Task Instance_IsReleased_OnUnloaded()
+	{
+		var container = new ContentControl();
+
+		var splash = new ExtendedSplashScreen { Platforms = SplashScreenPlatform.None };
+		container.Content = splash;
+		await UnitTestUIContentHelperEx.SetContentAndWait(container);
+
+		Assert.IsTrue(
+			ExtendedSplashScreen.TestHook_HasInstance,
+			"The static Instance should reference the loaded splash screen.");
+
+		container.Content = null;
+		await UnitTestUIContentHelperEx.WaitFor(() => !ExtendedSplashScreen.TestHook_HasInstance);
+
+		Assert.IsFalse(
+			ExtendedSplashScreen.TestHook_HasInstance,
+			"The static Instance should be released once the splash screen unloads.");
+	}
+
+	[TestMethod]
+#if __ANDROID__ || __IOS__
+	[Ignore("Splash screen control hosting differs on native platforms.")]
+#endif
+	public async Task SplashScreen_IsCollectible_AfterUnloaded()
+	{
+		var splashRef = await LoadAndUnloadSplash();
+
+		await CollectAndWait();
+
+		Assert.IsFalse(
+			splashRef.IsAlive,
+			"An ExtendedSplashScreen should be collectible after unloading; if it survives, the static " +
+			"Instance (or retained splash content) is still rooting it.");
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static async Task<WeakReference> LoadAndUnloadSplash()
+	{
+		var container = new ContentControl();
+		var splash = new ExtendedSplashScreen { Platforms = SplashScreenPlatform.None };
+		var splashRef = new WeakReference(splash);
+
+		container.Content = splash;
+		await UnitTestUIContentHelperEx.SetContentAndWait(container);
+
+		container.Content = null;
+		await UnitTestUIContentHelperEx.WaitFor(() => !ExtendedSplashScreen.TestHook_HasInstance);
+
+		return splashRef;
+	}
+
+	private static async Task CollectAndWait()
+	{
+		for (var i = 0; i < 8; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			await UnitTestUIContentHelperEx.WaitForIdle();
+		}
+	}
+}
+#endif

--- a/src/Uno.Toolkit.RuntimeTests/Tests/FrameworkElementExtensionsLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/FrameworkElementExtensionsLeakTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+/// <summary>
+/// Guards that the disposable returned by
+/// <see cref="FrameworkElementExtensions.SubscribeToNestedElements"/> actually detaches its
+/// <c>Loaded</c> handlers on dispose. Leaving them attached pins the whole subscription closure
+/// (including the caller-supplied callback) to any host-owned element that outlives a previewed app
+/// loaded into a collectible AssemblyLoadContext.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+internal class FrameworkElementExtensionsLeakTests
+{
+	private sealed class Sentinel;
+
+	[TestMethod]
+	public async Task SubscribeToNestedElements_Dispose_DetachesLoadedHandlers()
+	{
+		// The root stays alive (it plays the role of the long-lived, host-owned element). After the
+		// disposable is disposed, a sentinel captured only by the subscription callback must become
+		// collectible — which is only possible if the Loaded handler was actually removed from the root.
+		var root = new Grid();
+		await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+		var sentinelRef = SubscribeThenDispose(root);
+
+		await CollectAndWait();
+
+		Assert.IsFalse(
+			sentinelRef.IsAlive,
+			"The subscription callback should be collectible after disposing the SubscribeToNestedElements handle; " +
+			"if it survives, the Loaded handler was not detached and is still rooted by the (alive) root element.");
+
+		GC.KeepAlive(root);
+	}
+
+	// Kept in a separate non-inlined frame so neither the disposable, the callback, nor the sentinel
+	// stays alive via a local on the test method's stack while we assert collection.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference SubscribeThenDispose(Grid root)
+	{
+		var sentinel = new Sentinel();
+		var sentinelRef = new WeakReference(sentinel);
+
+		// The callback captures the sentinel; the whole closure is reachable through the Loaded handler
+		// registered on 'root' until the returned disposable detaches it.
+		var subscription = root.SubscribeToNestedElements(
+			new Func<FrameworkElement, FrameworkElement?>[] { fe => fe },
+			_ => GC.KeepAlive(sentinel));
+
+		subscription.Dispose();
+
+		return sentinelRef;
+	}
+
+	private static async Task CollectAndWait()
+	{
+		for (var i = 0; i < 5; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			await UnitTestUIContentHelperEx.WaitForIdle();
+		}
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/FrameworkElementExtensionsLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/FrameworkElementExtensionsLeakTests.cs
@@ -35,7 +35,9 @@ internal class FrameworkElementExtensionsLeakTests
 		// The root stays alive (it plays the role of the long-lived, host-owned element). After the
 		// disposable is disposed, a sentinel captured only by the subscription callback must become
 		// collectible — which is only possible if the Loaded handler was actually removed from the root.
-		var root = new Grid();
+		// Give the root a non-zero size: SetContentAndWait's loaded-check treats an element with
+		// ActualWidth/ActualHeight == 0 as not-yet-loaded, so a bare Grid would time out.
+		var root = new Grid { Width = 100, Height = 100 };
 		await UnitTestUIContentHelperEx.SetContentAndWait(root);
 
 		var sentinelRef = SubscribeThenDispose(root);

--- a/src/Uno.Toolkit.RuntimeTests/Tests/FrameworkElementExtensionsLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/FrameworkElementExtensionsLeakTests.cs
@@ -18,7 +18,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests;
 
 /// <summary>
 /// Guards that the disposable returned by
-/// <see cref="FrameworkElementExtensions.SubscribeToNestedElements"/> actually detaches its
+/// <c>FrameworkElementExtensions.SubscribeToNestedElements</c> actually detaches its
 /// <c>Loaded</c> handlers on dispose. Leaving them attached pins the whole subscription closure
 /// (including the caller-supplied callback) to any host-owned element that outlives a previewed app
 /// loaded into a collectible AssemblyLoadContext.

--- a/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarLeakTests.cs
@@ -1,0 +1,65 @@
+#if DEBUG && (!IS_WINUI || HAS_UNO)
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+using Windows.UI.Core;
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+/// <summary>
+/// Guards that <see cref="NavigationBar"/>'s subscription to the process-global
+/// <see cref="SystemNavigationManager.BackRequested"/> is weak. The instance is normally detached on
+/// <c>Unloaded</c>, but <c>Unloaded</c> does not fire when the owner's AssemblyLoadContext is torn down
+/// abruptly (a downstream host that loads previewed apps into their own collectible ALCs). Even in that
+/// case the global singleton must not strongly root the NavigationBar.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+internal class NavigationBarLeakTests
+{
+	[TestMethod]
+	public async Task BackRequested_Subscription_IsWeak_WhenUnloadedNeverFires()
+	{
+		// Subscribe the weak BackRequested handler exactly as OnLoaded does, but without recording the
+		// teardown disposable — modelling an abrupt ALC teardown. The NavigationBar must still be
+		// collectible while the process-global SystemNavigationManager stays alive and subscribed.
+		var navRef = SubscribeWeakThenAbandon();
+
+		await CollectAndWait();
+
+		Assert.IsFalse(
+			navRef.IsAlive,
+			"NavigationBar should be collectible even when Unloaded never fired, because the global " +
+			"SystemNavigationManager.BackRequested subscription is weak. If it survives, the global " +
+			"singleton is strongly rooting it.");
+
+		// Keep the global singleton referenced through the assertion so it cannot be argued away.
+		GC.KeepAlive(SystemNavigationManager.GetForCurrentView());
+	}
+
+	// Kept in a separate non-inlined frame so the NavigationBar is not kept alive by a local on the test
+	// method's stack while we assert collection.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference SubscribeWeakThenAbandon()
+	{
+		var nav = new NavigationBar();
+		nav.TestHook_SubscribeWeakBackRequestedWithoutTeardown();
+		return new WeakReference(nav);
+	}
+
+	private static async Task CollectAndWait()
+	{
+		for (var i = 0; i < 5; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			await UnitTestUIContentHelperEx.WaitForIdle();
+		}
+	}
+}
+#endif

--- a/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/NavigationBarLeakTests.cs
@@ -8,6 +8,12 @@ using Uno.Toolkit.UI;
 using Uno.UI.RuntimeTests;
 using Windows.UI.Core;
 
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Controls;
+#endif
+
 namespace Uno.Toolkit.RuntimeTests.Tests;
 
 /// <summary>
@@ -41,6 +47,25 @@ internal class NavigationBarLeakTests
 		GC.KeepAlive(SystemNavigationManager.GetForCurrentView());
 	}
 
+	[TestMethod]
+#if __ANDROID__ || __IOS__
+	[Ignore("Native NavigationBar hosting differs on mobile platforms.")]
+#endif
+	public async Task NavigationBar_IsCollectible_AfterRemovedFromTree()
+	{
+		// Real-path regression guard: drives the production OnLoaded subscription (not the DEBUG hook), then
+		// removes the bar from the tree. It must be collectible afterwards. This turns red if the whole
+		// BackRequested subscription/teardown wiring regresses (e.g. a strong sub with no working teardown).
+		var navRef = await LoadThenRemoveNavigationBar();
+
+		await CollectAndWait();
+
+		Assert.IsFalse(
+			navRef.IsAlive,
+			"A NavigationBar should be collectible after being removed from the visual tree; if it survives, " +
+			"the BackRequested subscription is not being torn down.");
+	}
+
 	// Kept in a separate non-inlined frame so the NavigationBar is not kept alive by a local on the test
 	// method's stack while we assert collection.
 	[MethodImpl(MethodImplOptions.NoInlining)]
@@ -49,6 +74,22 @@ internal class NavigationBarLeakTests
 		var nav = new NavigationBar();
 		nav.TestHook_SubscribeWeakBackRequestedWithoutTeardown();
 		return new WeakReference(nav);
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static async Task<WeakReference> LoadThenRemoveNavigationBar()
+	{
+		var container = new ContentControl();
+		var nav = new NavigationBar { Content = "Title" };
+		var navRef = new WeakReference(nav);
+
+		container.Content = nav;
+		await UnitTestUIContentHelperEx.SetContentAndWait(container);
+
+		container.Content = null;
+		await UnitTestUIContentHelperEx.WaitForIdle();
+
+		return navRef;
 	}
 
 	private static async Task CollectAndWait()

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveExtensionsLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveExtensionsLeakTests.cs
@@ -69,17 +69,21 @@ internal class ResponsiveExtensionsLeakTests
 	[TestMethod]
 	public async Task Connected_Extension_IsCollectible_WithoutResizeOrExplicitUninstall()
 	{
-		// Neither a resize (fixed preview canvas) nor an explicit Uninstall happens here. The extension
-		// must still be collectible once its host is gone, because the static WindowSizeChanged event only
-		// holds a weak reference to it.
+		// Real-path regression guard. The extension is installed on a loaded host and then the host is
+		// removed from the tree — but no resize (fixed preview canvas) and no explicit Uninstall happen.
+		// It must still be collectible. Pre-fix this pinned: the constructor's HardSelfReferences.Add was
+		// only undone from OnWindowSizeChanged (never fires without a resize) and there was no Unloaded
+		// hook, while the strong WindowSizeChanged subscription rooted it too. The fix collects it via the
+		// weak subscription + the Unloaded teardown + HardSelfReferences pruning together.
 		var extensionRef = await InstallAndAbandon();
 
 		await CollectAndWait();
 
 		Assert.IsFalse(
 			extensionRef.IsAlive,
-			"A connected ResponsiveExtension should be collectible after its host is gone even without a " +
-			"resize or Uninstall; if it survives, the static WindowSizeChanged event is strongly rooting it.");
+			"A connected ResponsiveExtension should be collectible after its host leaves the tree even " +
+			"without a resize or Uninstall; if it survives, it is still rooted by HardSelfReferences or the " +
+			"static WindowSizeChanged event.");
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveExtensionsLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveExtensionsLeakTests.cs
@@ -1,0 +1,117 @@
+#if DEBUG && (HAS_UNO || !IS_UWP)
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+/// <summary>
+/// Guards that <see cref="ResponsiveExtension"/> does not accumulate dead instances in its
+/// process-lifetime statics. In a fixed-size preview canvas the window never resizes, so the
+/// <c>WindowSizeChanged</c>-driven cleanup never runs; dead extensions would otherwise pile up forever,
+/// each pinning its target/host graph (and, across a collectible AssemblyLoadContext boundary, the
+/// previewed app's ALC).
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+internal class ResponsiveExtensionsLeakTests
+{
+	private readonly static ResponsiveLayout DefaultLayout = ResponsiveLayout.Create(150, 300, 600, 800, 1080);
+
+	[TestMethod]
+	public async Task SweepDeadInstances_Prunes_CollectedTrackedInstances()
+	{
+		var before = ResponsiveExtension.TestHook_TrackedInstanceCount;
+
+		// Add a tracked entry whose extension is collectible and then goes away (modelling an extension
+		// abandoned without a graceful Uninstall/Unloaded — e.g. an abrupt ALC teardown). The dead
+		// weak-reference tuple must not linger in the process-lifetime list.
+		AddCollectibleTrackedEntry();
+
+		Assert.AreEqual(
+			before + 1,
+			ResponsiveExtension.TestHook_TrackedInstanceCount,
+			"A tracked entry should have been added.");
+
+		await CollectAndWait();
+		ResponsiveExtension.TestHook_SweepDeadInstances();
+
+		Assert.AreEqual(
+			before,
+			ResponsiveExtension.TestHook_TrackedInstanceCount,
+			"After the extension is collected, SweepDeadInstances should prune the dead tracked entry " +
+			"back to the pre-install count.");
+	}
+
+	// Mirrors the shape of ResponsiveExtension.Initialize()'s TrackedInstances.Add call, but with
+	// throwaway collectible targets so the entry becomes dead once this frame returns. (A real
+	// ResponsiveExtension is also rooted by HardSelfReferences until swept, so a plain object is used
+	// here to isolate the TrackedInstances-pruning behaviour.)
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static void AddCollectibleTrackedEntry()
+	{
+		var owner = new object();
+		var extension = new object();
+		ResponsiveExtension.TrackedInstances.Add((new WeakReference(owner), "Text", new WeakReference(extension, trackResurrection: true)));
+	}
+
+	[TestMethod]
+	public async Task Connected_Extension_IsCollectible_WithoutResizeOrExplicitUninstall()
+	{
+		// Neither a resize (fixed preview canvas) nor an explicit Uninstall happens here. The extension
+		// must still be collectible once its host is gone, because the static WindowSizeChanged event only
+		// holds a weak reference to it.
+		var extensionRef = await InstallAndAbandon();
+
+		await CollectAndWait();
+
+		Assert.IsFalse(
+			extensionRef.IsAlive,
+			"A connected ResponsiveExtension should be collectible after its host is gone even without a " +
+			"resize or Uninstall; if it survives, the static WindowSizeChanged event is strongly rooting it.");
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static async Task<WeakReference> InstallAndAbandon()
+	{
+		var container = new ContentControl();
+		var host = new TextBlock { Text = "Uninitialized" };
+		container.Content = host;
+		await UnitTestUIContentHelperEx.SetContentAndWait(container);
+
+		var markup = new ResponsiveExtension { Layout = DefaultLayout, Narrow = "Narrow", Wide = "Wide" };
+		var extensionRef = new WeakReference(markup);
+
+		// Connect via a loaded host, then unload it — but intentionally never call Uninstall and never resize.
+		ResponsiveExtension.Install(host, null, nameof(host.Text), markup);
+		Assert.IsTrue(markup.IsConnected, "Extension should be connected once installed on a loaded host.");
+
+		container.Content = null;
+		await UnitTestUIContentHelperEx.WaitForIdle();
+
+		return extensionRef;
+	}
+
+	private static async Task CollectAndWait()
+	{
+		for (var i = 0; i < 8; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			await UnitTestUIContentHelperEx.WaitForIdle();
+		}
+	}
+}
+#endif

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveHelperLeakTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ResponsiveHelperLeakTests.cs
@@ -1,0 +1,113 @@
+#if DEBUG
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+/// <summary>
+/// Guards that <see cref="ResponsiveHelper"/> does not permanently root its process-lifetime
+/// default size provider (and, through it, the host <see cref="XamlRoot"/>) via a strong
+/// <see cref="XamlRoot.Changed"/> subscription. This matters for a downstream host that loads
+/// previewed apps into their own collectible AssemblyLoadContexts, where such a pin would keep
+/// the Toolkit ALC alive for the whole process lifetime.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+internal class ResponsiveHelperLeakTests
+{
+	[TestMethod]
+	public async Task Reset_TearsDown_DefaultProvider()
+	{
+		try
+		{
+			var host = new Border();
+			await UnitTestUIContentHelperEx.SetContentAndWait(host);
+
+			var xamlRoot = host.XamlRoot ?? throw new InvalidOperationException("XamlRoot was not available on the loaded host.");
+
+			ResponsiveHelper.InitializeIfNeeded(xamlRoot);
+			Assert.IsTrue(ResponsiveHelper.TestHook_IsDefaultProviderInitialized, "Default provider should be initialized after InitializeIfNeeded.");
+
+			ResponsiveHelper.Reset();
+			Assert.IsFalse(ResponsiveHelper.TestHook_IsDefaultProviderInitialized, "Default provider should be torn down after Reset.");
+
+			// A subsequent initialize must re-create a fresh provider (i.e. Reset did not leave the
+			// singleton in a half-initialized state).
+			ResponsiveHelper.InitializeIfNeeded(xamlRoot);
+			Assert.IsTrue(ResponsiveHelper.TestHook_IsDefaultProviderInitialized, "Default provider should be re-initialized after a Reset + InitializeIfNeeded cycle.");
+		}
+		finally
+		{
+			ResponsiveHelper.Reset();
+		}
+	}
+
+	[TestMethod]
+	public async Task DefaultProvider_IsCollectible_WhileXamlRootAlive()
+	{
+		// The host XamlRoot is process/window-owned and outlives previewed apps. Even while it is kept
+		// alive and subscribed via XamlRoot.Changed, the default size provider must remain collectible
+		// once Reset() drops the static reference — proving the subscription is weak/self-detaching and
+		// not a strong closure pin.
+		try
+		{
+			var host = new Border();
+			await UnitTestUIContentHelperEx.SetContentAndWait(host);
+
+			// Keep the XamlRoot strongly alive for the duration of the test.
+			var xamlRoot = host.XamlRoot ?? throw new InvalidOperationException("XamlRoot was not available on the loaded host.");
+
+			var providerRef = InitializeAndTrack(xamlRoot);
+
+			// Drop the static reference to the default provider (mirrors a host tearing down between app loads).
+			ResponsiveHelper.Reset();
+
+			await CollectAndWait();
+
+			Assert.IsFalse(
+				providerRef.IsAlive,
+				"The default ResponsiveSizeProvider should be collectible after Reset while the XamlRoot is still alive; " +
+				"if it survives, the XamlRoot.Changed subscription is strongly rooting it.");
+		}
+		finally
+		{
+			ResponsiveHelper.Reset();
+		}
+	}
+
+	// Kept in a separate non-inlined frame so the just-created provider is not kept alive by a local
+	// on the test method's stack while we assert collection.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference InitializeAndTrack(XamlRoot xamlRoot)
+	{
+		ResponsiveHelper.InitializeIfNeeded(xamlRoot);
+		var provider = ResponsiveHelper.TestHook_GetDefaultProvider();
+		Assert.IsNotNull(provider, "Default provider should be available immediately after InitializeIfNeeded.");
+		return new WeakReference(provider);
+	}
+
+	private static async Task CollectAndWait()
+	{
+		for (var i = 0; i < 5; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			await UnitTestUIContentHelperEx.WaitForIdle();
+		}
+	}
+}
+#endif

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Android.cs
@@ -96,6 +96,21 @@ public partial class ExtendedSplashScreen
 		}
 	}
 
+	partial void ReleaseNativeSplashResources()
+	{
+		// The captured splash bitmap is only needed while the extended splash screen is displayed. Once
+		// the control unloads, drop and recycle it so it does not linger in the process-lifetime static.
+		if (SplashBitmap is { } bitmap)
+		{
+			SplashBitmap = null;
+
+			if (!bitmap.IsRecycled)
+			{
+				bitmap.Recycle();
+			}
+		}
+	}
+
 	private void OnSourceChanged(DependencyObject sender, DependencyProperty dp)
 	{
 		if (sender is ExtendedSplashScreen extended)

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Android.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.Android.cs
@@ -96,7 +96,7 @@ public partial class ExtendedSplashScreen
 		}
 	}
 
-	partial void ReleaseNativeSplashResources()
+	static partial void ReleaseNativeSplashResources()
 	{
 		// The captured splash bitmap is only needed while the extended splash screen is displayed. Once
 		// the control unloads, drop and recycle it so it does not linger in the process-lifetime static.

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.cs
@@ -57,6 +57,12 @@ public partial class ExtendedSplashScreen : LoadingView
 
 	protected static ExtendedSplashScreen? Instance { get; private set; }
 
+#if DEBUG
+	// Test hook: reports whether the process-lifetime Instance static currently references any splash
+	// screen, so a test can verify it is released on Unloaded.
+	internal static bool TestHook_HasInstance => Instance is not null;
+#endif
+
 	public
 #if __IOS__ || __MACOS__ && !HAS_UNO_WINUI // hides UIView.Window and NSView.Window
 	new
@@ -67,6 +73,7 @@ Window? Window
 	public ExtendedSplashScreen()
 	{
 		Instance = this;
+		Unloaded += OnUnloaded;
 		InitPartial();
 	}
 
@@ -83,6 +90,28 @@ Window? Window
 			_ = LoadNativeSplashScreen();
 		}
 	}
+
+	private void OnUnloaded(object sender, RoutedEventArgs e)
+	{
+		// The splash screen is a one-shot control shown at startup. It keeps a process-lifetime static
+		// Instance reference and holds SplashScreenContent (which, on Android, wraps the retained native
+		// splash bitmap). If those are never released, this ExtendedSplashScreen — and, when it belongs to
+		// a previewed app loaded into a collectible AssemblyLoadContext, that app's whole ALC — is pinned
+		// for the process lifetime. Once the control leaves the tree it is done, so release both.
+		if (ReferenceEquals(Instance, this))
+		{
+			Instance = null;
+		}
+
+		// Setting null on WinUI throws, so drop to an empty placeholder instead.
+		SplashScreenContent = new Border();
+
+		ReleaseNativeSplashResources();
+	}
+
+	// Releases any retained native splash resources (e.g. the Android splash bitmap). No-op where there
+	// are none.
+	partial void ReleaseNativeSplashResources();
 
 	private async Task LoadNativeSplashScreen()
 	{

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.cs
@@ -110,8 +110,8 @@ Window? Window
 	}
 
 	// Releases any retained native splash resources (e.g. the Android splash bitmap). No-op where there
-	// are none.
-	partial void ReleaseNativeSplashResources();
+	// are none. Static because the only implementation (Android) clears a process-lifetime static field.
+	static partial void ReleaseNativeSplashResources();
 
 	private async Task LoadNativeSplashScreen()
 	{

--- a/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.cs
+++ b/src/Uno.Toolkit.UI/Controls/ExtendedSplashScreen/ExtendedSplashScreen.cs
@@ -70,6 +70,8 @@ public partial class ExtendedSplashScreen : LoadingView
 Window? Window
 	{ get; set; }
 
+	private bool _isUnloaded;
+
 	public ExtendedSplashScreen()
 	{
 		Instance = this;
@@ -98,6 +100,8 @@ Window? Window
 		// splash bitmap). If those are never released, this ExtendedSplashScreen — and, when it belongs to
 		// a previewed app loaded into a collectible AssemblyLoadContext, that app's whole ALC — is pinned
 		// for the process lifetime. Once the control leaves the tree it is done, so release both.
+		_isUnloaded = true;
+
 		if (ReferenceEquals(Instance, this))
 		{
 			Instance = null;
@@ -115,13 +119,28 @@ Window? Window
 
 	private async Task LoadNativeSplashScreen()
 	{
-		var splashScreenContent = await GetNativeSplashScreen();
-
-		if (splashScreenContent is not null)
+		try
 		{
-			// Return a non-visible element to make sure some content is set on the ContentPresenter
-			// Setting null on WinUI throws an exception
-			SplashScreenContent = splashScreenContent;
+			var splashScreenContent = await GetNativeSplashScreen();
+
+			// GetNativeSplashScreen can await real I/O (reading the app manifest on Skia/WASM/Windows),
+			// during which the control may unload. If it did, OnUnloaded already released the content, so a
+			// late completion must not re-populate SplashScreenContent and undo that teardown.
+			if (_isUnloaded)
+			{
+				return;
+			}
+
+			if (splashScreenContent is not null)
+			{
+				// Return a non-visible element to make sure some content is set on the ContentPresenter
+				// Setting null on WinUI throws an exception
+				SplashScreenContent = splashScreenContent;
+			}
+		}
+		catch (Exception e)
+		{
+			this.Log().LogError(0, e, "Error while loading native splash screen.");
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
@@ -1,4 +1,4 @@
-﻿#if __IOS__ || __ANDROID__
+#if __IOS__ || __ANDROID__
 #define HAS_NATIVE_NAVBAR
 #endif
 #if !IS_WINUI || HAS_UNO
@@ -194,8 +194,9 @@ namespace Uno.Toolkit.UI
 			// the SerialDisposable below (the fast path), but Unloaded does not fire when the owner's
 			// AssemblyLoadContext is torn down abruptly (e.g. a downstream host that loads previewed apps
 			// into their own collectible ALCs). Subscribe weakly so the global singleton only holds a
-			// WeakReference back; the wrapper self-detaches once this instance is collected.
-			var backRequestedHandler = CreateWeakHandler<NavigationBar, BackRequestedEventArgs>(
+			// WeakReference back; the stale weak wrapper self-detaches on the next BackRequested raised
+			// after this instance is collected (Unloaded is the primary, proactive teardown below).
+			var backRequestedHandler = WeakEventHelper.CreateWeakHandler<NavigationBar, BackRequestedEventArgs>(
 				this,
 				static (self, s, e) => self.OnBackRequested(s, e),
 				static h => SystemNavigationManager.GetForCurrentView().BackRequested -= h);
@@ -248,42 +249,13 @@ namespace Uno.Toolkit.UI
 		// never fires, so a test can verify the global singleton still holds only a weak reference back.
 		internal void TestHook_SubscribeWeakBackRequestedWithoutTeardown()
 		{
-			var backRequestedHandler = CreateWeakHandler<NavigationBar, BackRequestedEventArgs>(
+			var backRequestedHandler = WeakEventHelper.CreateWeakHandler<NavigationBar, BackRequestedEventArgs>(
 				this,
 				static (self, s, e) => self.OnBackRequested(s, e),
 				static h => SystemNavigationManager.GetForCurrentView().BackRequested -= h);
 			SystemNavigationManager.GetForCurrentView().BackRequested += backRequestedHandler;
 		}
 #endif
-
-		// Creates an EventHandler that invokes onEvent against a WeakReference to target, so a
-		// process-global event source cannot strongly root the target. Once the target has been collected
-		// the wrapper detaches itself via detach. onEvent/detach MUST be static (non-capturing) so the
-		// returned delegate captures only the WeakReference — never the target instance.
-		private static EventHandler<TArgs> CreateWeakHandler<TTarget, TArgs>(
-			TTarget target,
-			Action<TTarget, object?, TArgs> onEvent,
-			Action<EventHandler<TArgs>> detach)
-			where TTarget : class
-		{
-			System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
-			System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
-
-			var weakTarget = new WeakReference<TTarget>(target);
-			EventHandler<TArgs> h = null!;
-			h = (s, e) =>
-			{
-				if (weakTarget.TryGetTarget(out var self))
-				{
-					onEvent(self, s, e);
-				}
-				else
-				{
-					detach(h);
-				}
-			};
-			return h;
-		}
 #endif
 
 		private void OnPropertyChanged(DependencyPropertyChangedEventArgs args)

--- a/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/NavigationBar/NavigationBar.cs
@@ -189,8 +189,18 @@ namespace Uno.Toolkit.UI
 			_popupHost = Uno.Toolkit.UI.DependencyObjectExtensions.FindFirstParent<Popup>(this);
 
 #if SYS_NAV_MGR_SUPPORTED
-			SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
-			_backRequestedHandler.Disposable = Disposable.Create(() => SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested);
+			// SystemNavigationManager is a process-global singleton. Subscribing to BackRequested with an
+			// instance-method delegate makes it strongly root this NavigationBar. Unloaded detaches it via
+			// the SerialDisposable below (the fast path), but Unloaded does not fire when the owner's
+			// AssemblyLoadContext is torn down abruptly (e.g. a downstream host that loads previewed apps
+			// into their own collectible ALCs). Subscribe weakly so the global singleton only holds a
+			// WeakReference back; the wrapper self-detaches once this instance is collected.
+			var backRequestedHandler = CreateWeakHandler<NavigationBar, BackRequestedEventArgs>(
+				this,
+				static (self, s, e) => self.OnBackRequested(s, e),
+				static h => SystemNavigationManager.GetForCurrentView().BackRequested -= h);
+			SystemNavigationManager.GetForCurrentView().BackRequested += backRequestedHandler;
+			_backRequestedHandler.Disposable = Disposable.Create(() => SystemNavigationManager.GetForCurrentView().BackRequested -= backRequestedHandler);
 #endif
 
 #if !HAS_NATIVE_NAVBAR
@@ -229,6 +239,50 @@ namespace Uno.Toolkit.UI
 			{
 				e.Handled = TryPerformMainCommand();
 			}
+		}
+
+#if DEBUG
+		// Test hook: subscribes this instance's weak BackRequested handler to the process-global
+		// SystemNavigationManager exactly as OnLoaded does, but deliberately WITHOUT recording the
+		// SerialDisposable teardown. This models an abrupt AssemblyLoadContext teardown where Unloaded
+		// never fires, so a test can verify the global singleton still holds only a weak reference back.
+		internal void TestHook_SubscribeWeakBackRequestedWithoutTeardown()
+		{
+			var backRequestedHandler = CreateWeakHandler<NavigationBar, BackRequestedEventArgs>(
+				this,
+				static (self, s, e) => self.OnBackRequested(s, e),
+				static h => SystemNavigationManager.GetForCurrentView().BackRequested -= h);
+			SystemNavigationManager.GetForCurrentView().BackRequested += backRequestedHandler;
+		}
+#endif
+
+		// Creates an EventHandler that invokes onEvent against a WeakReference to target, so a
+		// process-global event source cannot strongly root the target. Once the target has been collected
+		// the wrapper detaches itself via detach. onEvent/detach MUST be static (non-capturing) so the
+		// returned delegate captures only the WeakReference — never the target instance.
+		private static EventHandler<TArgs> CreateWeakHandler<TTarget, TArgs>(
+			TTarget target,
+			Action<TTarget, object?, TArgs> onEvent,
+			Action<EventHandler<TArgs>> detach)
+			where TTarget : class
+		{
+			System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+			System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+
+			var weakTarget = new WeakReference<TTarget>(target);
+			EventHandler<TArgs> h = null!;
+			h = (s, e) =>
+			{
+				if (weakTarget.TryGetTarget(out var self))
+				{
+					onEvent(self, s, e);
+				}
+				else
+				{
+					detach(h);
+				}
+			};
+			return h;
 		}
 #endif
 

--- a/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/DependencyObjectExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Uno.Disposables;
 using Uno.Extensions;
@@ -25,7 +26,12 @@ namespace Uno.Toolkit.UI
 {
 	internal static class DependencyObjectExtensions
 	{
-		private static Dictionary<(Type Type, string Property), DependencyPropertyInfo?> _dependencyPropertyReflectionCache = new(2);
+		// Keyed weakly by owner Type so a Type from a collectible AssemblyLoadContext (e.g. a downstream
+		// host that loads previewed apps into their own collectible ALCs) is not rooted by this
+		// process-lifetime static cache. A strong Type key would keep the Type's LoaderAllocator alive,
+		// pinning the whole ALC for the process lifetime. When the owner Type is collected, its inner
+		// per-property dictionary (and the DependencyPropertyInfo values it holds) becomes unreachable too.
+		private static readonly ConditionalWeakTable<Type, Dictionary<string, DependencyPropertyInfo?>> _dependencyPropertyReflectionCache = new();
 
 #if HAS_UNO
 		/// <summary>
@@ -210,17 +216,28 @@ namespace Uno.Toolkit.UI
 			propertyName = propertyName.RemoveTail("Property");
 
 			var type = ownerOrDescendantType;
-			var key = (ownerType: type, propertyName);
 
 			// given that we are doing FlattenHierarchy lookup, it is fine that we are storing multiple pairs of (types-to-same-dp)
 			// since it is not worth the trouble to handle the type hierarchy...
-			if (!_dependencyPropertyReflectionCache.TryGetValue(key, out var property))
+			var propertyCache = _dependencyPropertyReflectionCache.GetOrCreateValue(type);
+			DependencyPropertyInfo? property;
+			bool cached;
+			lock (propertyCache)
+			{
+				cached = propertyCache.TryGetValue(propertyName, out property);
+			}
+
+			if (!cached)
 			{
 				property = GetDetails(
 					type.GetProperty($"{propertyName}Property", Public | NonPublic | Static | FlattenHierarchy) as MemberInfo ??
 					type.GetField($"{propertyName}Property", Public | NonPublic | Static | FlattenHierarchy)
 				);
-				_dependencyPropertyReflectionCache[key] = property;
+
+				lock (propertyCache)
+				{
+					propertyCache[propertyName] = property;
+				}
 
 				if (property is null)
 				{
@@ -257,6 +274,14 @@ namespace Uno.Toolkit.UI
 
 			return property;
 		}
+
+#if DEBUG
+		// Test hook: reports whether the reflection cache currently holds an entry for the given owner
+		// Type, so a test can verify the entry (and therefore the Type key) is released once the Type
+		// becomes collectible. Does not create an entry.
+		internal static bool TestHook_ReflectionCacheContains(Type ownerType) =>
+			_dependencyPropertyReflectionCache.TryGetValue(ownerType, out _);
+#endif
 
 		private static bool TryGetValue(this DependencyObject dependencyObject, DependencyProperty dependencyProperty, out DependencyObject? value)
 		{

--- a/src/Uno.Toolkit.UI/Extensions/FrameworkElementExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/FrameworkElementExtensions.cs
@@ -45,7 +45,22 @@ internal static class FrameworkElementExtensions
 		return Disposable.Create(() =>
 		{
 			disposed = true;
-			subscriptions.Clear();
+
+			// Invoke each recorded unsubscribe action so the Loaded handlers are actually detached.
+			// Merely clearing the list left every 'e.Loaded += handler' attached: each subscribed
+			// FrameworkElement kept the handler delegate alive, which captured the whole closure graph
+			// (subscriptions, innerSelectors, onInnerMostLoaded). When any of those elements are owned by
+			// a host that outlives a previewed app loaded into a collectible AssemblyLoadContext, that
+			// closure pins the app's (and the Toolkit's) ALC for the process lifetime.
+			lock (subscriptionsLock)
+			{
+				foreach (var subscription in subscriptions)
+				{
+					subscription.Unsubscribe();
+				}
+
+				subscriptions.Clear();
+			}
 		});
 
 		void Subscribe(FrameworkElement e, int depth)

--- a/src/Uno.Toolkit.UI/Extensions/FrameworkElementExtensions.cs
+++ b/src/Uno.Toolkit.UI/Extensions/FrameworkElementExtensions.cs
@@ -71,9 +71,20 @@ internal static class FrameworkElementExtensions
 			{
 				if ((subscriptions.ElementAt(depth).Element != e))
 				{
-					// elment register at this depth is no longer the same
-					// drop everything from this depth and lower
-					lock (subscriptionsLock) subscriptions.RemoveRange(depth, subscriptions.Count - depth);
+					// element registered at this depth is no longer the same
+					// drop everything from this depth and lower, detaching each Loaded handler first:
+					// without this the removed entries stay subscribed (and, once dropped from the list,
+					// untracked), so Dispose can no longer detach them and their closures leak — exactly
+					// the pin this subscription bookkeeping exists to prevent.
+					lock (subscriptionsLock)
+					{
+						for (var i = depth; i < subscriptions.Count; i++)
+						{
+							subscriptions[i].Unsubscribe();
+						}
+
+						subscriptions.RemoveRange(depth, subscriptions.Count - depth);
+					}
 
 					// and, push a new stack
 					RoutedEventHandler handler = (s, _) => Walk(e, depth);

--- a/src/Uno.Toolkit.UI/Helpers/ResponsiveHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/ResponsiveHelper.cs
@@ -144,17 +144,97 @@ public static class ResponsiveHelper
 	private static ResponsiveSizeProvider? _defaultSizeProvider;
 	private static ResponsiveSizeProvider? _overrideSizeProvider;
 	private static SerialDisposable _overrideSizeProviderDisposable = new();
+	private static SerialDisposable _defaultSizeProviderDisposable = new();
 
 	public static void InitializeIfNeeded(XamlRoot provider) // backdoor
 	{
 		if (_defaultSizeProvider is null)
 		{
-			_defaultSizeProvider = new();
+			var sizeProvider = new ResponsiveSizeProvider();
+			_defaultSizeProvider = sizeProvider;
 
-			provider.Changed += (s, e) => _defaultSizeProvider.Size = s.Size;
-			_defaultSizeProvider.SizeChanged += RaiseSizeChanged;
-			_defaultSizeProvider.Size = provider.Size;
+			// XamlRoot is owned by the window/host and typically outlives any single previewed app.
+			// Subscribing with a strong lambda that captures the process-lifetime static size provider
+			// makes the host XamlRoot root that static chain for the process lifetime; when the Toolkit
+			// is loaded into a collectible AssemblyLoadContext (e.g. a downstream host that loads
+			// previewed apps into their own collectible ALCs) this pins the Toolkit ALC and prevents it
+			// from ever unloading. Subscribe weakly so the host XamlRoot only holds a WeakReference back;
+			// the wrapper self-detaches once the size provider is collected, and Reset() tears it down.
+			var handler = CreateWeakHandler<XamlRoot, XamlRootChangedEventArgs>(
+				sizeProvider,
+				static (self, s, e) => self.Size = s.Size,
+				static (s, h) => s.Changed -= h);
+			provider.Changed += handler;
+			_defaultSizeProviderDisposable.Disposable = Disposable.Create(() => provider.Changed -= handler);
+
+			sizeProvider.SizeChanged += RaiseSizeChanged;
+			sizeProvider.Size = provider.Size;
 		}
+	}
+
+	// Creates a TypedEventHandler that invokes onEvent against a WeakReference to target, so a
+	// process-global event source cannot strongly root the target. Once the target has been collected
+	// the wrapper detaches itself via detach. onEvent/detach MUST be static (non-capturing) so the
+	// returned delegate captures only the WeakReference — never the target instance.
+	private static TypedEventHandler<TSender, TArgs> CreateWeakHandler<TSender, TArgs>(
+		ResponsiveSizeProvider target,
+		Action<ResponsiveSizeProvider, TSender, TArgs> onEvent,
+		Action<TSender, TypedEventHandler<TSender, TArgs>> detach)
+		where TSender : class
+	{
+		// The whole point of this wrapper is that the global event source holds only a WeakReference
+		// back. That guarantee is defeated if a caller passes a capturing lambda: its closure display
+		// class would be rooted by the delegate (Target != null) and would in turn root whatever it
+		// captured. Callers must pass static/non-capturing delegates (Target == null); assert it in
+		// DEBUG so an accidental capture is caught during dev.
+		System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+		System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+
+		var weakTarget = new WeakReference<ResponsiveSizeProvider>(target);
+		TypedEventHandler<TSender, TArgs> h = null!;
+		h = (s, e) =>
+		{
+			if (weakTarget.TryGetTarget(out var self))
+			{
+				onEvent(self, s, e);
+			}
+			else
+			{
+				detach(s, h);
+			}
+		};
+		return h;
+	}
+
+#if DEBUG
+	// Test hook: exposes whether the process-lifetime default size provider is currently initialized,
+	// so tests can verify Reset() tears it down.
+	internal static bool TestHook_IsDefaultProviderInitialized => _defaultSizeProvider is not null;
+
+	// Test hook: exposes the current default provider so tests can build a WeakReference to it and
+	// verify it is collectible (i.e. the XamlRoot.Changed subscription is weak) after Reset().
+	internal static ResponsiveSizeProvider? TestHook_GetDefaultProvider() => _defaultSizeProvider;
+#endif
+
+	/// <summary>
+	/// Tears down the process-lifetime default size provider and its global <see cref="XamlRoot.Changed"/>
+	/// subscription so a subsequent <see cref="InitializeIfNeeded"/> re-initializes against a fresh
+	/// <see cref="XamlRoot"/>. Intended for hosts that unload and reload previewed apps into collectible
+	/// AssemblyLoadContexts, where the previous default provider must not outlive the previous app.
+	/// </summary>
+	internal static void Reset() // backdoor
+	{
+		_defaultSizeProviderDisposable.Disposable = null;
+		if (_defaultSizeProvider is { } provider)
+		{
+			provider.SizeChanged -= RaiseSizeChanged;
+			_defaultSizeProvider = null;
+		}
+
+		_overrideSizeProviderDisposable.Disposable = null;
+		_overrideSizeProvider = null;
+
+		WindowSize = default;
 	}
 	public static void SetOverrideSizeProvider(ResponsiveSizeProvider? provider) // backdoor
 	{

--- a/src/Uno.Toolkit.UI/Helpers/ResponsiveHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/ResponsiveHelper.cs
@@ -143,8 +143,8 @@ public static class ResponsiveHelper
 
 	private static ResponsiveSizeProvider? _defaultSizeProvider;
 	private static ResponsiveSizeProvider? _overrideSizeProvider;
-	private static SerialDisposable _overrideSizeProviderDisposable = new();
-	private static SerialDisposable _defaultSizeProviderDisposable = new();
+	private static readonly SerialDisposable _overrideSizeProviderDisposable = new();
+	private static readonly SerialDisposable _defaultSizeProviderDisposable = new();
 
 	public static void InitializeIfNeeded(XamlRoot provider) // backdoor
 	{
@@ -160,50 +160,27 @@ public static class ResponsiveHelper
 			// previewed apps into their own collectible ALCs) this pins the Toolkit ALC and prevents it
 			// from ever unloading. Subscribe weakly so the host XamlRoot only holds a WeakReference back;
 			// the wrapper self-detaches once the size provider is collected, and Reset() tears it down.
-			var handler = CreateWeakHandler<XamlRoot, XamlRootChangedEventArgs>(
+			var handler = WeakEventHelper.CreateWeakHandler<ResponsiveSizeProvider, XamlRoot, XamlRootChangedEventArgs>(
 				sizeProvider,
 				static (self, s, e) => self.Size = s.Size,
 				static (s, h) => s.Changed -= h);
 			provider.Changed += handler;
-			_defaultSizeProviderDisposable.Disposable = Disposable.Create(() => provider.Changed -= handler);
+
+			// Capture the host XamlRoot weakly in the teardown so this process-lifetime static does not
+			// itself strongly root a (possibly closed) window's XamlRoot. The weak 'handler' above already
+			// keeps the provider from rooting the size provider.
+			var weakProvider = new WeakReference<XamlRoot>(provider);
+			_defaultSizeProviderDisposable.Disposable = Disposable.Create(() =>
+			{
+				if (weakProvider.TryGetTarget(out var p))
+				{
+					p.Changed -= handler;
+				}
+			});
 
 			sizeProvider.SizeChanged += RaiseSizeChanged;
 			sizeProvider.Size = provider.Size;
 		}
-	}
-
-	// Creates a TypedEventHandler that invokes onEvent against a WeakReference to target, so a
-	// process-global event source cannot strongly root the target. Once the target has been collected
-	// the wrapper detaches itself via detach. onEvent/detach MUST be static (non-capturing) so the
-	// returned delegate captures only the WeakReference — never the target instance.
-	private static TypedEventHandler<TSender, TArgs> CreateWeakHandler<TSender, TArgs>(
-		ResponsiveSizeProvider target,
-		Action<ResponsiveSizeProvider, TSender, TArgs> onEvent,
-		Action<TSender, TypedEventHandler<TSender, TArgs>> detach)
-		where TSender : class
-	{
-		// The whole point of this wrapper is that the global event source holds only a WeakReference
-		// back. That guarantee is defeated if a caller passes a capturing lambda: its closure display
-		// class would be rooted by the delegate (Target != null) and would in turn root whatever it
-		// captured. Callers must pass static/non-capturing delegates (Target == null); assert it in
-		// DEBUG so an accidental capture is caught during dev.
-		System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
-		System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
-
-		var weakTarget = new WeakReference<ResponsiveSizeProvider>(target);
-		TypedEventHandler<TSender, TArgs> h = null!;
-		h = (s, e) =>
-		{
-			if (weakTarget.TryGetTarget(out var self))
-			{
-				onEvent(self, s, e);
-			}
-			else
-			{
-				detach(s, h);
-			}
-		};
-		return h;
 	}
 
 #if DEBUG

--- a/src/Uno.Toolkit.UI/Helpers/WeakEventHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/WeakEventHelper.cs
@@ -1,0 +1,79 @@
+using System;
+using Windows.Foundation;
+
+namespace Uno.Toolkit.UI;
+
+/// <summary>
+/// Creates event-handler delegates that reference their target through a <see cref="WeakReference{T}"/>,
+/// so a process-lifetime or otherwise global event source cannot strongly root the target (and, through
+/// it, its host graph — and, across a collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
+/// boundary, a previewed app's ALC). Once the target has been collected the wrapper detaches itself, via
+/// <c>detach</c>, the next time the event is raised.
+/// </summary>
+/// <remarks>
+/// <c>onEvent</c> and <c>detach</c> MUST be static / non-capturing delegates so the returned handler
+/// captures only the <see cref="WeakReference{T}"/> — never the target instance. A capturing lambda would
+/// defeat the purpose by rooting its closure (and whatever it captured) through the returned delegate.
+/// </remarks>
+internal static class WeakEventHelper
+{
+	public static EventHandler<TArgs> CreateWeakHandler<TTarget, TArgs>(
+		TTarget target,
+		Action<TTarget, object?, TArgs> onEvent,
+		Action<EventHandler<TArgs>> detach)
+		where TTarget : class
+	{
+		AssertStatic(onEvent, detach);
+
+		var weakTarget = new WeakReference<TTarget>(target);
+		EventHandler<TArgs> h = null!;
+		h = (s, e) =>
+		{
+			if (weakTarget.TryGetTarget(out var self))
+			{
+				onEvent(self, s, e);
+			}
+			else
+			{
+				detach(h);
+			}
+		};
+		return h;
+	}
+
+	public static TypedEventHandler<TSender, TArgs> CreateWeakHandler<TTarget, TSender, TArgs>(
+		TTarget target,
+		Action<TTarget, TSender, TArgs> onEvent,
+		Action<TSender, TypedEventHandler<TSender, TArgs>> detach)
+		where TTarget : class
+		where TSender : class
+	{
+		AssertStatic(onEvent, detach);
+
+		var weakTarget = new WeakReference<TTarget>(target);
+		TypedEventHandler<TSender, TArgs> h = null!;
+		h = (s, e) =>
+		{
+			if (weakTarget.TryGetTarget(out var self))
+			{
+				onEvent(self, s, e);
+			}
+			else
+			{
+				detach(s, h);
+			}
+		};
+		return h;
+	}
+
+	private static void AssertStatic(Delegate onEvent, Delegate detach)
+	{
+		// The whole point of the wrapper is that the event source holds only a WeakReference back. That
+		// guarantee is defeated if a caller passes a capturing lambda: its closure display class would be
+		// rooted by the returned delegate (Target != null) and would in turn root whatever it captured.
+		// Fully qualified: on net*-android an unqualified `Debug` binds to the inherited
+		// Android.Views.ViewGroup.Debug(int) method (CS0119), not System.Diagnostics.Debug.
+		System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+		System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+	}
+}

--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
@@ -166,15 +166,38 @@ public partial class ResponsiveExtension
 		_disposable.Disposable = null;
 		if (selfOrProxyHost.XamlRoot is null) return;
 
+		// Prune any previously-connected extensions whose host/owner is already gone. In a fixed-size
+		// preview canvas the window never resizes, so OnWindowSizeChanged (the only place that ran
+		// CleanupIfHostDisposed) never fires and dead extensions would otherwise accumulate forever,
+		// each pinning its target/host graph — and, across a collectible AssemblyLoadContext boundary,
+		// the previewed app's ALC. Sweeping here bounds the accumulation to live instances.
+		SweepDeadInstances();
+
 		_hostWeakRef = new WeakReference(selfOrProxyHost);
 		ResponsiveHelper.InitializeIfNeeded(selfOrProxyHost.XamlRoot);
-		ResponsiveHelper.WindowSizeChanged -= OnWindowSizeChanged;
-		ResponsiveHelper.WindowSizeChanged += OnWindowSizeChanged;
+
+		// Subscribe to the process-lifetime static WindowSizeChanged event weakly, so the static event
+		// does not strongly root this extension (and, through it, its target/host). The wrapper
+		// self-detaches once this extension is collected. This is what lets a dead extension be collected
+		// even if neither Unloaded nor a resize ever fires.
+		var handler = CreateWeakHandler(
+			this,
+			static (self, s, e) => self.OnWindowSizeChanged(s, e),
+			static h => ResponsiveHelper.WindowSizeChanged -= h);
+		ResponsiveHelper.WindowSizeChanged -= handler;
+		ResponsiveHelper.WindowSizeChanged += handler;
 		IsConnected = true;
+
+		// Proactively tear down when the host unloads (the common, graceful path). Abrupt ALC teardown
+		// (no Unloaded) is covered by the weak subscription above + the SweepDeadInstances on the next
+		// Connect.
+		selfOrProxyHost.Unloaded -= OnHostUnloaded;
+		selfOrProxyHost.Unloaded += OnHostUnloaded;
 
 		_disposable.Disposable = Disposable.Create(() =>
 		{
-			ResponsiveHelper.WindowSizeChanged -= OnWindowSizeChanged;
+			ResponsiveHelper.WindowSizeChanged -= handler;
+			selfOrProxyHost.Unloaded -= OnHostUnloaded;
 			IsConnected = false;
 		});
 
@@ -182,6 +205,65 @@ public partial class ResponsiveExtension
 		// But because in ProvideValue, the target has not been added to the visual tree yet, we cannot access the "full" .resources yet.
 		// So we need to rectify that here.
 		UpdateBinding(forceApplyValue: true);
+	}
+
+	private void OnHostUnloaded(object sender, RoutedEventArgs e)
+	{
+		// Host left the tree: release the hard self-reference and tracking so this extension can be
+		// collected instead of lingering in the process-lifetime statics.
+		CleanupIfHostDisposed(force: true);
+		Disconnect();
+	}
+
+	// Creates a TypedEventHandler that invokes onEvent against a WeakReference to target, so the
+	// process-lifetime static event source cannot strongly root the target. Once the target has been
+	// collected the wrapper detaches itself via detach. onEvent/detach MUST be static (non-capturing).
+	private static TypedEventHandler<object, Size> CreateWeakHandler(
+		ResponsiveExtension target,
+		Action<ResponsiveExtension, object, Size> onEvent,
+		Action<TypedEventHandler<object, Size>> detach)
+	{
+		System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+		System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
+
+		var weakTarget = new WeakReference<ResponsiveExtension>(target);
+		TypedEventHandler<object, Size> h = null!;
+		h = (s, e) =>
+		{
+			if (weakTarget.TryGetTarget(out var self))
+			{
+				onEvent(self, s, e);
+			}
+			else
+			{
+				detach(h);
+			}
+		};
+		return h;
+	}
+
+	// Prunes dead entries from the process-lifetime statics: TrackedInstances tuples whose extension has
+	// been collected, and (UNO14502) HardSelfReferences whose host is gone. Bounded, cheap, and safe to
+	// call on every Connect.
+	private static void SweepDeadInstances()
+	{
+		for (var i = TrackedInstances.Count - 1; i >= 0; i--)
+		{
+			if (!TrackedInstances[i].Extension.IsAlive)
+			{
+				TrackedInstances.RemoveAt(i);
+			}
+		}
+
+#if UNO14502_WORKAROUND
+		for (var i = HardSelfReferences.Count - 1; i >= 0; i--)
+		{
+			if (HardSelfReferences[i] is { _hostWeakRef.IsAlive: false })
+			{
+				HardSelfReferences.RemoveAt(i);
+			}
+		}
+#endif
 	}
 
 	internal void Disconnect()
@@ -292,10 +374,10 @@ public partial class ResponsiveExtension
 		(TargetWeakRef?.Target as FrameworkElement)?.ResolveLocalResource<ResponsiveLayout>(ResponsiveLayout.DefaultResourceKey) ??
 		Application.Current.ResolveLocalResource<ResponsiveLayout>(ResponsiveLayout.DefaultResourceKey);
 
-	private bool CleanupIfHostDisposed()
+	private bool CleanupIfHostDisposed(bool force = false)
 	{
-		// if self/proxy host was disposed, remove the circular references to allow self-disposal.
-		if (_hostWeakRef is { Target: null })
+		// if self/proxy host was disposed (or the host unloaded), remove the circular references to allow self-disposal.
+		if (force || _hostWeakRef is { Target: null })
 		{
 #if UNO14502_WORKAROUND
 			HardSelfReferences.Remove(this);
@@ -309,6 +391,17 @@ public partial class ResponsiveExtension
 
 		return false;
 	}
+
+#if DEBUG
+	// Test hooks: expose the accumulation state of the process-lifetime statics so tests can verify that
+	// dead instances are swept and that live extensions are not strongly rooted by the WindowSizeChanged
+	// static event.
+	internal static int TestHook_TrackedInstanceCount => TrackedInstances.Count;
+#if UNO14502_WORKAROUND
+	internal static int TestHook_HardSelfReferenceCount => HardSelfReferences.Count;
+#endif
+	internal static void TestHook_SweepDeadInstances() => SweepDeadInstances();
+#endif
 }
 public partial class ResponsiveExtension
 {

--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
@@ -177,15 +177,16 @@ public partial class ResponsiveExtension
 		ResponsiveHelper.InitializeIfNeeded(selfOrProxyHost.XamlRoot);
 
 		// Subscribe to the process-lifetime static WindowSizeChanged event weakly, so the static event
-		// does not strongly root this extension (and, through it, its target/host). The wrapper
-		// self-detaches once this extension is collected. This is what lets a dead extension be collected
-		// even if neither Unloaded nor a resize ever fires.
+		// does not strongly root this extension (and, through it, its target/host) — this is what lets a
+		// dead extension be collected even if neither Unloaded nor a resize ever fires. The stale weak
+		// wrapper left in the event's invocation list self-detaches on the next WindowSizeChanged raised
+		// after the extension has been collected (Unloaded is the primary, proactive teardown below).
 		// Note: a fresh handler instance is created per Connect; the previous one (if any) was already
 		// detached by '_disposable.Disposable = null' above, so no explicit '-=' is needed here.
-		var handler = CreateWeakHandler(
+		var handler = WeakEventHelper.CreateWeakHandler<ResponsiveExtension, object, Size>(
 			this,
 			static (self, s, e) => self.OnWindowSizeChanged(s, e),
-			static h => ResponsiveHelper.WindowSizeChanged -= h);
+			static (s, h) => ResponsiveHelper.WindowSizeChanged -= h);
 		ResponsiveHelper.WindowSizeChanged += handler;
 		IsConnected = true;
 
@@ -214,33 +215,6 @@ public partial class ResponsiveExtension
 		// collected instead of lingering in the process-lifetime statics.
 		CleanupIfHostDisposed(force: true);
 		Disconnect();
-	}
-
-	// Creates a TypedEventHandler that invokes onEvent against a WeakReference to target, so the
-	// process-lifetime static event source cannot strongly root the target. Once the target has been
-	// collected the wrapper detaches itself via detach. onEvent/detach MUST be static (non-capturing).
-	private static TypedEventHandler<object, Size> CreateWeakHandler(
-		ResponsiveExtension target,
-		Action<ResponsiveExtension, object, Size> onEvent,
-		Action<TypedEventHandler<object, Size>> detach)
-	{
-		System.Diagnostics.Debug.Assert(onEvent.Target is null, "CreateWeakHandler: onEvent must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
-		System.Diagnostics.Debug.Assert(detach.Target is null, "CreateWeakHandler: detach must be a static/non-capturing delegate, otherwise it reintroduces a strong reference.");
-
-		var weakTarget = new WeakReference<ResponsiveExtension>(target);
-		TypedEventHandler<object, Size> h = null!;
-		h = (s, e) =>
-		{
-			if (weakTarget.TryGetTarget(out var self))
-			{
-				onEvent(self, s, e);
-			}
-			else
-			{
-				detach(h);
-			}
-		};
-		return h;
 	}
 
 	// Prunes dead entries from the process-lifetime statics: TrackedInstances tuples whose extension has

--- a/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
+++ b/src/Uno.Toolkit.UI/Markup/ResponsiveExtension.cs
@@ -180,11 +180,12 @@ public partial class ResponsiveExtension
 		// does not strongly root this extension (and, through it, its target/host). The wrapper
 		// self-detaches once this extension is collected. This is what lets a dead extension be collected
 		// even if neither Unloaded nor a resize ever fires.
+		// Note: a fresh handler instance is created per Connect; the previous one (if any) was already
+		// detached by '_disposable.Disposable = null' above, so no explicit '-=' is needed here.
 		var handler = CreateWeakHandler(
 			this,
 			static (self, s, e) => self.OnWindowSizeChanged(s, e),
 			static h => ResponsiveHelper.WindowSizeChanged -= h);
-		ResponsiveHelper.WindowSizeChanged -= handler;
 		ResponsiveHelper.WindowSizeChanged += handler;
 		IsConnected = true;
 


### PR DESCRIPTION
## Summary

A batch of low-risk sweeps that stop several Toolkit types from pinning collectible `AssemblyLoadContext`s. These types subscribe to **process-global event sources** or hold **process-lifetime static references** with no teardown (or a teardown path that only runs on an event that may never fire in a fixed-size preview canvas). In an ordinary app this is harmless — process, assembly, window, and app share one lifetime. In a downstream host that loads previewed apps into their own collectible ALCs, these references cross the ALC boundary and keep the ALC's `LoaderAllocator` alive for the process lifetime.

The weak self-detaching handler reuses the `CreateWeakHandler` template established for the `SafeArea` global-event subscriptions: a `WeakReference<T>` to the target plus **static, non-capturing** delegates, so the global source holds only a weak reference and the wrapper detaches itself once the target is collected.

`Closes #1607`

## Findings (see `specs/alc-weak-subscription-sweeps/recap.md`)

- [x] **1. `ResponsiveHelper.InitializeIfNeeded`** — strong `XamlRoot.Changed` lambda → weak self-detaching handler + internal `Reset()` purge hook.
- [x] **2. `DependencyObjectExtensions._dependencyPropertyReflectionCache`** — `Type`-keyed static `Dictionary` → `ConditionalWeakTable<Type, Dictionary<string, …>>` so the owner `Type` (and its ALC) is held weakly.
- [x] **3. `NavigationBar` → `SystemNavigationManager.BackRequested`** — strong sub → weak self-detaching handler (keeps the `Unloaded` fast path).
- [x] **4. `ResponsiveExtension`** — `HardSelfReferences` / static `WindowSizeChanged` / `TrackedInstances` accumulation → weak `WindowSizeChanged` subscription + `Unloaded`-hooked removal + dead-instance sweep on `Connect`.
- [x] **5. `FrameworkElementExtensions.SubscribeToNestedElements`** — disposable never invoked recorded unsubscribe actions → invoke each `Unsubscribe()` on dispose.
- [x] **6. `ExtendedSplashScreen`** — static `Instance` + retained splash bitmap → release `Instance` + splash content on `Unloaded` (Android: recycle the bitmap).

Out of scope (follow-ups): `ShadowsCache` dispose-on-evict, `StatusBar` teardown, `ResponsiveView` slot cache.

## Tests

Each fix ships with red/green runtime leak tests (`#if DEBUG`, under `src/Uno.Toolkit.RuntimeTests/Tests/*LeakTests.cs`) proving the subscription is now weak/detached or that the cache entry dies with its `Type`/ALC. Findings 3 and 4 additionally have real-path integration guards that turn red if the production wiring is reverted (not just the DEBUG hook).

## Build / test status

- `Uno.Toolkit.UI` + `Uno.Toolkit.RuntimeTests` build clean on `net9.0` (0 warnings, 0 errors).
- Runtime tests are validated by the desktop Skia CI stage (`dotnet MaterialSampleApp.dll --runtime-tests=…`). A local headless run on the dev machine could not wire the runtime-test output destination ("Application has not been configured with output destination") — an environment nuance, not a test defect — so runtime green is left to CI, which uses the identical invocation. No greens are fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)