### PR TITLE
docs: update for opt-in seed generation

### DIFF
--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -179,7 +179,7 @@ In `App.xaml`, use the `FontOverrideSource` property on `MaterialToolkitTheme`:
 
 `MaterialToolkitTheme` supports seed-based color generation using the Material Design 3 HCT color space. A single seed color is used to derive the full tonal palette (Primary, Secondary, Tertiary, Neutral, and Error), for both Light and Dark themes.
 
-By default, `MaterialToolkitTheme` generates its palette from the built-in Material seed color (`#5946D2`). You can override this with the `Colors` property:
+By default, no seed is set and `MaterialToolkitTheme` uses the Material color palette. To opt into seed-based generation, set a seed via the `Colors` property:
 
 ```xml
 <MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
@@ -199,7 +199,7 @@ using Windows.UI;
 // Change the primary seed color at runtime
 SemanticThemeHelper.PrimarySeed = Color.FromArgb(0xFF, 0xFF, 0x6B, 0x35);
 
-// Clear the seed to revert to the default (#5946D2)
+// Clear the seed to revert to the default palette
 SemanticThemeHelper.PrimarySeed = null;
 ```
 

--- a/doc/simple-getting-started.md
+++ b/doc/simple-getting-started.md
@@ -194,7 +194,7 @@ The `SimpleToolkitTheme` exposes the base corner radius unit (in pixels) through
 
 `SimpleToolkitTheme` supports seed-based color generation. A single seed color is used to derive tonal palettes for both Light and Dark themes.
 
-`SimpleToolkitTheme` uses seed color generation by default with a neutral gray seed (`#808080`). You can override it by setting the `Colors` property:
+By default, no seed is set and `SimpleToolkitTheme` uses its  grayscale palette. To opt into seed-based generation, set a seed via the `Colors` property:
 
 ```xml
 <SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"

--- a/doc/simple-getting-started.md
+++ b/doc/simple-getting-started.md
@@ -194,7 +194,7 @@ The `SimpleToolkitTheme` exposes the base corner radius unit (in pixels) through
 
 `SimpleToolkitTheme` supports seed-based color generation. A single seed color is used to derive tonal palettes for both Light and Dark themes.
 
-By default, no seed is set and `SimpleToolkitTheme` uses its  grayscale palette. To opt into seed-based generation, set a seed via the `Colors` property:
+By default, no seed is set and `SimpleToolkitTheme` uses its grayscale palette. To opt into seed-based generation, set a seed via the `Colors` property:
 
 ```xml
 <SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"


### PR DESCRIPTION
GitHub Issue (If applicable): related to #1606

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The seed color sections of the Material and Simple getting-started docs state that the toolkit themes use seed color generation by default (`MaterialToolkitTheme` seeded with `#5946D2`, `SimpleToolkitTheme` with `#808080`). Following the investigation of #1606, seed generation is being made opt-in in Uno.Themes (`MaterialTheme.DefaultPrimarySeed` returns `null`, consistent with `SimpleTheme`), so these statements no longer describe the actual behavior: without an explicit seed, the themes use their default palettes, which is also why `ThemeInitTests.Override_Colors` correctly expects `#5946D2`/`#C7BFFF` for a default `Button`.

## What is the new behavior?

`doc/material-getting-started.md` and `doc/simple-getting-started.md` now document seed generation as opt-in: by default no seed is set and the themes use their default palettes (the default Material color palette / the Simple grayscale palette); setting `ThemeColors.PrimarySeed` activates generation, and clearing it reverts to the default palette.

Docs-only change — no code, styles, or tests are modified in this repo. The behavioral fix lives in the companion Uno.Themes PR; once a Themes dev package containing it is consumed, the nightly `ThemeInitTests.Override_Colors` failures from #1606 are resolved without any toolkit code change (verified locally by running the runtime tests against locally packed fixed packages).

## Other information

Companion PR: the actual fix (opt-in seed generation, regression tests) is in unoplatform/Uno.Themes. Verified end-to-end on Skia Desktop: with Uno.Themes `7.0.0-dev.40` the toolkit's `ThemeInitTests.Override_Colors` fails with the values reported in #1606 (`#FFC5BDFF`/`#FF594DB4`); with locally packed Themes packages containing the fix, the same tests pass unchanged (`#FFC7BFFF`/`#FF5946D2`).

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
