### PR TITLE
feat(helpers): add root element and window overloads to SystemThemeHelper

### DIFF
--- a/doc/helpers/SystemThemeHelper.md
+++ b/doc/helpers/SystemThemeHelper.md
@@ -17,7 +17,7 @@ Provides utilities for managing and retrieving the current theme of the operatin
 | `GetCurrentOsTheme()`        | `ApplicationTheme`      | Retrieves the current theme of the operating system.                          |
 | `GetApplicationTheme()`      | `ApplicationTheme`      | **[Obsolete]** Retrieves the current theme of the application. Will be removed in future versions.           |
 | `GetRootTheme(XamlRoot?)`    | `ApplicationTheme`      | Gets the `ApplicationTheme` of the provided `XamlRoot`, or falls back to the operating system theme.          |
-| `GetRootTheme(FrameworkElement?)` | `ApplicationTheme` | Gets the `ApplicationTheme` of the provided root element, or falls back to the operating system theme. **Preferred**: reliable even when the app is hosted under a `XamlRoot` it doesn't own (e.g. Hot Design). |
+| `GetRootTheme(FrameworkElement?)` | `ApplicationTheme` | Gets the `ApplicationTheme` of the provided root element, or falls back to the operating system theme. Use when the app is hosted under a `XamlRoot` it doesn't own (e.g. ALC-hosted), where `XamlRoot.Content` is the host's root. |
 | `GetRootTheme(Window?)`      | `ApplicationTheme`      | Gets the `ApplicationTheme` of the provided window's content, or falls back to the operating system theme.   |
 | `IsAppInDarkMode()`          | `bool`                 | **[Obsolete]** Returns `true` if the application is currently in dark mode, otherwise `false`.               |
 | `IsRootInDarkMode(XamlRoot)` | `bool`                 | Determines if the provided `XamlRoot` is in dark mode.                                                       |
@@ -49,7 +49,7 @@ Console.WriteLine($"Current App Theme: {appTheme}");
 |-------------------------------------|----------------------------------------------------------------------------------------------|
 | `SetApplicationTheme(bool)`         | **[Obsolete]** Sets the application theme to dark mode if `darkMode` is `true`, otherwise light mode. Will be removed in future versions. |
 | `SetRootTheme(XamlRoot?, bool)`     | Sets the theme for the provided `XamlRoot` based on the `darkMode` parameter.              |
-| `SetRootTheme(FrameworkElement?, bool)` | Sets the theme for the provided root element (and its subtree) based on the `darkMode` parameter. **Preferred**: reliable even when the app is hosted under a `XamlRoot` it doesn't own (e.g. Hot Design). |
+| `SetRootTheme(FrameworkElement?, bool)` | Sets the theme for the provided root element (and its subtree) based on the `darkMode` parameter. Use when the app is hosted under a `XamlRoot` it doesn't own (e.g. ALC-hosted), where `XamlRoot.Content` is the host's root. |
 | `SetRootTheme(Window?, bool)`       | Sets the theme for the provided window's content based on the `darkMode` parameter.        |
 | `SetApplicationTheme(XamlRoot?, ElementTheme)` | Sets the `ElementTheme` (`Light` or `Dark`) for the provided `XamlRoot`. |
 | `SetApplicationTheme(FrameworkElement?, ElementTheme)` | Sets the `ElementTheme` (`Light` or `Dark`) on the provided root element, theming its whole subtree. |
@@ -58,7 +58,15 @@ Console.WriteLine($"Current App Theme: {appTheme}");
 
 ### Usage
 
-Set the theme for the app, using its root element (preferred):
+Set the theme for a specific `XamlRoot`:
+
+```csharp
+var xamlRoot = someElement.XamlRoot;
+SystemThemeHelper.SetApplicationTheme(xamlRoot, ElementTheme.Light);
+Console.WriteLine("XamlRoot theme set to Light Mode.");
+```
+
+Set the theme when the app is hosted under a `XamlRoot` it doesn't own (e.g. ALC-hosted):
 
 ```csharp
 // Capture the app's root element once (e.g. in App.xaml.cs, right after setting window.Content):
@@ -71,13 +79,5 @@ SystemThemeHelper.SetApplicationTheme(window, ElementTheme.Dark);
 
 If the resolved root element is `null` (for example, the window content is not set yet, or is not a `FrameworkElement`), the `Set*` overloads are a no-op (a warning is logged when logging is enabled), and the `Get*` overloads fall back to the operating system theme.
 
-Set the theme for a specific `XamlRoot`:
-
-```csharp
-var xamlRoot = someElement.XamlRoot;
-SystemThemeHelper.SetApplicationTheme(xamlRoot, ElementTheme.Light);
-Console.WriteLine("XamlRoot theme set to Light Mode.");
-```
-
 > [!IMPORTANT]
-> The `XamlRoot`-based overloads read and write the theme of `XamlRoot.Content` - the root visual of the `XamlRoot`. When the app's content is hosted under a `XamlRoot` it doesn't own (for example, when running under Hot Design, where the app's content is re-parented into a host's shared `XamlRoot`), `XamlRoot.Content` is the **host's** root visual: theming it re-themes the host instead of the app. In that scenario, use the `Window`- or `FrameworkElement`-based overloads with the app's own window or root element (typically `window.Content`), which behave identically in standalone apps and remain correct when hosted.
+> The `XamlRoot`-based overloads read and write the theme of `XamlRoot.Content` - the root visual of the `XamlRoot` - and are the API to use in normal situations. When the app's content is hosted under a `XamlRoot` it doesn't own (for example, an app loaded into another app via an `AssemblyLoadContext`, with its content re-parented into a shared `XamlRoot`), `XamlRoot.Content` is the **host's** root visual: theming it re-themes the host instead of the app. In that scenario, use the `Window`- or `FrameworkElement`-based overloads with the app's own window or root element (typically `window.Content`).

--- a/doc/helpers/SystemThemeHelper.md
+++ b/doc/helpers/SystemThemeHelper.md
@@ -17,8 +17,12 @@ Provides utilities for managing and retrieving the current theme of the operatin
 | `GetCurrentOsTheme()`        | `ApplicationTheme`      | Retrieves the current theme of the operating system.                          |
 | `GetApplicationTheme()`      | `ApplicationTheme`      | **[Obsolete]** Retrieves the current theme of the application. Will be removed in future versions.           |
 | `GetRootTheme(XamlRoot?)`    | `ApplicationTheme`      | Gets the `ApplicationTheme` of the provided `XamlRoot`, or falls back to the operating system theme.          |
+| `GetRootTheme(FrameworkElement?)` | `ApplicationTheme` | Gets the `ApplicationTheme` of the provided root element, or falls back to the operating system theme. **Preferred**: reliable even when the app is hosted under a `XamlRoot` it doesn't own (e.g. Hot Design). |
+| `GetRootTheme(Window?)`      | `ApplicationTheme`      | Gets the `ApplicationTheme` of the provided window's content, or falls back to the operating system theme.   |
 | `IsAppInDarkMode()`          | `bool`                 | **[Obsolete]** Returns `true` if the application is currently in dark mode, otherwise `false`.               |
 | `IsRootInDarkMode(XamlRoot)` | `bool`                 | Determines if the provided `XamlRoot` is in dark mode.                                                       |
+| `IsRootInDarkMode(FrameworkElement)` | `bool`        | Determines if the provided root element is in dark mode.                                                     |
+| `IsRootInDarkMode(Window)`   | `bool`                 | Determines if the provided window's content is in dark mode.                                                 |
 
 ### Usage
 
@@ -45,10 +49,27 @@ Console.WriteLine($"Current App Theme: {appTheme}");
 |-------------------------------------|----------------------------------------------------------------------------------------------|
 | `SetApplicationTheme(bool)`         | **[Obsolete]** Sets the application theme to dark mode if `darkMode` is `true`, otherwise light mode. Will be removed in future versions. |
 | `SetRootTheme(XamlRoot?, bool)`     | Sets the theme for the provided `XamlRoot` based on the `darkMode` parameter.              |
+| `SetRootTheme(FrameworkElement?, bool)` | Sets the theme for the provided root element (and its subtree) based on the `darkMode` parameter. **Preferred**: reliable even when the app is hosted under a `XamlRoot` it doesn't own (e.g. Hot Design). |
+| `SetRootTheme(Window?, bool)`       | Sets the theme for the provided window's content based on the `darkMode` parameter.        |
 | `SetApplicationTheme(XamlRoot?, ElementTheme)` | Sets the `ElementTheme` (`Light` or `Dark`) for the provided `XamlRoot`. |
+| `SetApplicationTheme(FrameworkElement?, ElementTheme)` | Sets the `ElementTheme` (`Light` or `Dark`) on the provided root element, theming its whole subtree. |
+| `SetApplicationTheme(Window?, ElementTheme)` | Sets the `ElementTheme` (`Light` or `Dark`) on the provided window's content. |
 | `ToggleApplicationTheme()`          | **[Obsolete]** Toggles the application theme between light and dark modes. Will be removed in future versions. |
 
 ### Usage
+
+Set the theme for the app, using its root element (preferred):
+
+```csharp
+// Capture the app's root element once (e.g. in App.xaml.cs, right after setting window.Content):
+var appRoot = window.Content as FrameworkElement;
+SystemThemeHelper.SetApplicationTheme(appRoot, ElementTheme.Dark);
+
+// Or, using the app's Window directly:
+SystemThemeHelper.SetApplicationTheme(window, ElementTheme.Dark);
+```
+
+If the resolved root element is `null` (for example, the window content is not set yet, or is not a `FrameworkElement`), the `Set*` overloads are a no-op (a warning is logged when logging is enabled), and the `Get*` overloads fall back to the operating system theme.
 
 Set the theme for a specific `XamlRoot`:
 
@@ -57,3 +78,6 @@ var xamlRoot = someElement.XamlRoot;
 SystemThemeHelper.SetApplicationTheme(xamlRoot, ElementTheme.Light);
 Console.WriteLine("XamlRoot theme set to Light Mode.");
 ```
+
+> [!IMPORTANT]
+> The `XamlRoot`-based overloads read and write the theme of `XamlRoot.Content` - the root visual of the `XamlRoot`. When the app's content is hosted under a `XamlRoot` it doesn't own (for example, when running under Hot Design, where the app's content is re-parented into a host's shared `XamlRoot`), `XamlRoot.Content` is the **host's** root visual: theming it re-themes the host instead of the app. In that scenario, use the `Window`- or `FrameworkElement`-based overloads with the app's own window or root element (typically `window.Content`), which behave identically in standalone apps and remain correct when hosted.

--- a/doc/helpers/SystemThemeHelper.md
+++ b/doc/helpers/SystemThemeHelper.md
@@ -17,12 +17,8 @@ Provides utilities for managing and retrieving the current theme of the operatin
 | `GetCurrentOsTheme()`        | `ApplicationTheme`      | Retrieves the current theme of the operating system.                          |
 | `GetApplicationTheme()`      | `ApplicationTheme`      | **[Obsolete]** Retrieves the current theme of the application. Will be removed in future versions.           |
 | `GetRootTheme(XamlRoot?)`    | `ApplicationTheme`      | Gets the `ApplicationTheme` of the provided `XamlRoot`, or falls back to the operating system theme.          |
-| `GetRootTheme(FrameworkElement?)` | `ApplicationTheme` | Gets the `ApplicationTheme` of the provided root element, or falls back to the operating system theme. **Preferred**: reliable even when the app is hosted under a `XamlRoot` it doesn't own (e.g. Hot Design). |
-| `GetRootTheme(Window?)`      | `ApplicationTheme`      | Gets the `ApplicationTheme` of the provided window's content, or falls back to the operating system theme.   |
 | `IsAppInDarkMode()`          | `bool`                 | **[Obsolete]** Returns `true` if the application is currently in dark mode, otherwise `false`.               |
 | `IsRootInDarkMode(XamlRoot)` | `bool`                 | Determines if the provided `XamlRoot` is in dark mode.                                                       |
-| `IsRootInDarkMode(FrameworkElement)` | `bool`        | Determines if the provided root element is in dark mode.                                                     |
-| `IsRootInDarkMode(Window)`   | `bool`                 | Determines if the provided window's content is in dark mode.                                                 |
 
 ### Usage
 
@@ -49,27 +45,10 @@ Console.WriteLine($"Current App Theme: {appTheme}");
 |-------------------------------------|----------------------------------------------------------------------------------------------|
 | `SetApplicationTheme(bool)`         | **[Obsolete]** Sets the application theme to dark mode if `darkMode` is `true`, otherwise light mode. Will be removed in future versions. |
 | `SetRootTheme(XamlRoot?, bool)`     | Sets the theme for the provided `XamlRoot` based on the `darkMode` parameter.              |
-| `SetRootTheme(FrameworkElement?, bool)` | Sets the theme for the provided root element (and its subtree) based on the `darkMode` parameter. **Preferred**: reliable even when the app is hosted under a `XamlRoot` it doesn't own (e.g. Hot Design). |
-| `SetRootTheme(Window?, bool)`       | Sets the theme for the provided window's content based on the `darkMode` parameter.        |
 | `SetApplicationTheme(XamlRoot?, ElementTheme)` | Sets the `ElementTheme` (`Light` or `Dark`) for the provided `XamlRoot`. |
-| `SetApplicationTheme(FrameworkElement?, ElementTheme)` | Sets the `ElementTheme` (`Light` or `Dark`) on the provided root element, theming its whole subtree. |
-| `SetApplicationTheme(Window?, ElementTheme)` | Sets the `ElementTheme` (`Light` or `Dark`) on the provided window's content. |
 | `ToggleApplicationTheme()`          | **[Obsolete]** Toggles the application theme between light and dark modes. Will be removed in future versions. |
 
 ### Usage
-
-Set the theme for the app, using its root element (preferred):
-
-```csharp
-// Capture the app's root element once (e.g. in App.xaml.cs, right after setting window.Content):
-var appRoot = window.Content as FrameworkElement;
-SystemThemeHelper.SetApplicationTheme(appRoot, ElementTheme.Dark);
-
-// Or, using the app's Window directly:
-SystemThemeHelper.SetApplicationTheme(window, ElementTheme.Dark);
-```
-
-If the resolved root element is `null` (for example, the window content is not set yet, or is not a `FrameworkElement`), the `Set*` overloads are a no-op (a warning is logged when logging is enabled), and the `Get*` overloads fall back to the operating system theme.
 
 Set the theme for a specific `XamlRoot`:
 
@@ -78,6 +57,3 @@ var xamlRoot = someElement.XamlRoot;
 SystemThemeHelper.SetApplicationTheme(xamlRoot, ElementTheme.Light);
 Console.WriteLine("XamlRoot theme set to Light Mode.");
 ```
-
-> [!IMPORTANT]
-> The `XamlRoot`-based overloads read and write the theme of `XamlRoot.Content` - the root visual of the `XamlRoot`. When the app's content is hosted under a `XamlRoot` it doesn't own (for example, when running under Hot Design, where the app's content is re-parented into a host's shared `XamlRoot`), `XamlRoot.Content` is the **host's** root visual: theming it re-themes the host instead of the app. In that scenario, use the `Window`- or `FrameworkElement`-based overloads with the app's own window or root element (typically `window.Content`), which behave identically in standalone apps and remain correct when hosted.

--- a/doc/helpers/walkthroughs/systemthemehelper.howto.md
+++ b/doc/helpers/walkthroughs/systemthemehelper.howto.md
@@ -45,7 +45,7 @@ var appTheme = SystemThemeHelper.GetRootTheme(xamlRoot);
 **Notes**
 
 * If `xamlRoot` is `null`, the helper falls back to the OS theme.
-* This reads the theme of `XamlRoot.Content` - the root visual of the `XamlRoot`. For the hosted-safe default, prefer the `Window`/`FrameworkElement` overloads (section 8).
+* This reads the theme of `XamlRoot.Content` - the root visual of the `XamlRoot`. If the app is hosted under a `XamlRoot` it doesn't own, use the `Window`/`FrameworkElement` overloads instead (section 8).
 
 ---
 
@@ -106,7 +106,7 @@ SystemThemeHelper.SetApplicationTheme(xamlRoot, ElementTheme.Light);
 * “Preview in Light/Dark” buttons
 
 > [!IMPORTANT]
-> The `XamlRoot`-based overloads target `XamlRoot.Content` - the root visual of the `XamlRoot`. If your app's content is hosted under a `XamlRoot` it doesn't own (for example under Hot Design), that element is the **host's** root, not your app's. Prefer the `Window`/`FrameworkElement` overloads described in section 8 below - they behave identically in standalone apps and remain correct when hosted.
+> The `XamlRoot`-based overloads target `XamlRoot.Content` - the root visual of the `XamlRoot`. If your app's content is hosted under a `XamlRoot` it doesn't own (for example an ALC-hosted app running inside another app), that element is the **host's** root, not your app's. In that case use the `Window`/`FrameworkElement` overloads described in section 8 below.
 
 ---
 
@@ -168,11 +168,11 @@ var theme = SystemThemeHelper.GetApplicationTheme(); // obsolete
 **After (recommended):**
 
 ```csharp
-var theme = SystemThemeHelper.GetRootTheme(appRoot); // the app's root element (see section 8)
-// or, standalone-only: SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
+var theme = SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
+// hosted under a XamlRoot the app doesn't own: use the root element overload (section 8)
 ```
 
-Why: the new version is root-aware, and the element overload stays correct when hosted (section 8).
+Why: the new version is root-aware.
 
 ---
 
@@ -187,11 +187,11 @@ var isDark = SystemThemeHelper.IsAppInDarkMode(); // obsolete
 **After (recommended):**
 
 ```csharp
-var isDark = SystemThemeHelper.IsRootInDarkMode(appRoot); // the app's root element (see section 8)
-// or, standalone-only: SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
+var isDark = SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
+// hosted under a XamlRoot the app doesn't own: use the root element overload (section 8)
 ```
 
-Why: again, this works for the current visual root - and the element overload stays correct when hosted.
+Why: again, this works for the current visual root.
 
 ---
 
@@ -205,19 +205,19 @@ SystemThemeHelper.SetApplicationTheme(true); // dark
 
 **After (recommended):**
 
-Option A – use the app's root element + enum (hosted-safe, see section 8):
+Option A – use `XamlRoot` + enum:
 
 ```csharp
-SystemThemeHelper.SetApplicationTheme(appRoot, ElementTheme.Dark);
+SystemThemeHelper.SetApplicationTheme(MyPage.XamlRoot, ElementTheme.Dark);
 ```
 
-Option B – use the app's root element + bool:
+Option B – use `XamlRoot` + bool:
 
 ```csharp
-SystemThemeHelper.SetRootTheme(appRoot, darkMode: true);
+SystemThemeHelper.SetRootTheme(MyPage.XamlRoot, darkMode: true);
 ```
 
-The `XamlRoot`-based equivalents remain available for standalone apps.
+Hosted under a `XamlRoot` the app doesn't own: use the root element / window overloads (section 8).
 
 ---
 
@@ -232,17 +232,17 @@ SystemThemeHelper.ToggleApplicationTheme(); // obsolete
 **After (manual toggle):**
 
 ```csharp
-var isDark = SystemThemeHelper.IsRootInDarkMode(appRoot); // the app's root element (see section 8)
-SystemThemeHelper.SetRootTheme(appRoot, darkMode: !isDark);
+var isDark = SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
+SystemThemeHelper.SetRootTheme(MyPage.XamlRoot, darkMode: !isDark);
 ```
 
-This keeps the old behavior but on the correct root.
+This keeps the old behavior but on the correct root. Hosted under a `XamlRoot` the app doesn't own: use the root element / window overloads (section 8).
 
 ---
 
 ## 8. Theme the app via its own root element or window (hosted-safe)
 
-All the `XamlRoot`-based members above resolve the target element through `XamlRoot.Content`. In a standalone app that element **is** your app's root, so they work fine. But when your app's content is hosted under a `XamlRoot` it doesn't own - for example under **Hot Design**, where the app's `Window.Content` is re-parented into a host's shared `XamlRoot` - `XamlRoot.Content` is the *host's* root visual. Reading through it reports the host's theme, and writing through it re-themes the host while your app stays unchanged.
+All the `XamlRoot`-based members above resolve the target element through `XamlRoot.Content`. In a standalone app that element **is** your app's root, so they work fine. But when your app's content is hosted under a `XamlRoot` it doesn't own - for example an app loaded into another app via an `AssemblyLoadContext`, with its content re-parented into a host's shared `XamlRoot` - `XamlRoot.Content` is the *host's* root visual. Reading through it reports the host's theme, and writing through it re-themes the host while your app stays unchanged.
 
 For this, the helper offers overloads that take your app's own root element or `Window` directly:
 
@@ -267,7 +267,7 @@ var isDark = SystemThemeHelper.IsRootInDarkMode(window);
 * Pass your app's **root** element (typically `window.Content`), not an arbitrary page - elements outside the page's subtree would otherwise keep the previous theme.
 * Content hosted in the popup root (flyouts, `ContentDialog`, tooltips) renders **outside** the app root's subtree and may not pick up the theme automatically - set `RequestedTheme` on such content explicitly if it doesn't.
 * If your root element gets recreated (e.g. a hot-reload replacing the visual tree), re-apply the theme to the new root.
-* In standalone apps these overloads behave exactly like the `XamlRoot` ones, so they are a safe default everywhere.
+* In standalone apps these overloads behave exactly like the `XamlRoot` ones; the `XamlRoot` API remains the one to use in normal situations.
 * If the resolved root is `null` (window content not set yet, or not a `FrameworkElement`), `Set*` is a no-op (a warning is logged when logging is enabled) and `Get*` falls back to the OS theme.
 
 **Toggle example (hosted-safe):**

--- a/doc/helpers/walkthroughs/systemthemehelper.howto.md
+++ b/doc/helpers/walkthroughs/systemthemehelper.howto.md
@@ -6,7 +6,7 @@ Use this when you just want to know what the operating system is using (Light/Da
 
 ```csharp
 using Uno.Toolkit.UI;
-using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
+using Windows.UI.Xaml;
 
 var osTheme = SystemThemeHelper.GetCurrentOsTheme();
 
@@ -32,7 +32,7 @@ Use this when your app has multiple windows/surfaces and you need the theme **fo
 
 ```csharp
 using Uno.Toolkit.UI;
-using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
+using Windows.UI.Xaml;
 
 // any FrameworkElement you have on screen:
 var xamlRoot = MyPage.XamlRoot;
@@ -45,7 +45,7 @@ var appTheme = SystemThemeHelper.GetRootTheme(xamlRoot);
 **Notes**
 
 * If `xamlRoot` is `null`, the helper falls back to the OS theme.
-* This reads the theme of `XamlRoot.Content` - the root visual of the `XamlRoot`. For the hosted-safe default, prefer the `Window`/`FrameworkElement` overloads (section 8).
+* This is the recommended way when you have a specific visual root.
 
 ---
 
@@ -105,9 +105,6 @@ SystemThemeHelper.SetApplicationTheme(xamlRoot, ElementTheme.Light);
 * Screenshots/exports that must look the same
 * “Preview in Light/Dark” buttons
 
-> [!IMPORTANT]
-> The `XamlRoot`-based overloads target `XamlRoot.Content` - the root visual of the `XamlRoot`. If your app's content is hosted under a `XamlRoot` it doesn't own (for example under Hot Design), that element is the **host's** root, not your app's. Prefer the `Window`/`FrameworkElement` overloads described in section 8 below - they behave identically in standalone apps and remain correct when hosted.
-
 ---
 
 ## 5. Force a view to Dark using a boolean (older style)
@@ -136,7 +133,7 @@ Sometimes you just want to know “what do I have right now?”
 
 ```csharp
 using Uno.Toolkit.UI;
-using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
+using Windows.UI.Xaml;
 
 var osTheme   = SystemThemeHelper.GetCurrentOsTheme();
 var rootTheme = SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
@@ -168,11 +165,10 @@ var theme = SystemThemeHelper.GetApplicationTheme(); // obsolete
 **After (recommended):**
 
 ```csharp
-var theme = SystemThemeHelper.GetRootTheme(appRoot); // the app's root element (see section 8)
-// or, standalone-only: SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
+var theme = SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
 ```
 
-Why: the new version is root-aware, and the element overload stays correct when hosted (section 8).
+Why: the new version is root-aware.
 
 ---
 
@@ -187,11 +183,10 @@ var isDark = SystemThemeHelper.IsAppInDarkMode(); // obsolete
 **After (recommended):**
 
 ```csharp
-var isDark = SystemThemeHelper.IsRootInDarkMode(appRoot); // the app's root element (see section 8)
-// or, standalone-only: SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
+var isDark = SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
 ```
 
-Why: again, this works for the current visual root - and the element overload stays correct when hosted.
+Why: again, this works for the current visual root.
 
 ---
 
@@ -205,19 +200,17 @@ SystemThemeHelper.SetApplicationTheme(true); // dark
 
 **After (recommended):**
 
-Option A – use the app's root element + enum (hosted-safe, see section 8):
+Option A – use `XamlRoot` + enum:
 
 ```csharp
-SystemThemeHelper.SetApplicationTheme(appRoot, ElementTheme.Dark);
+SystemThemeHelper.SetApplicationTheme(MyPage.XamlRoot, ElementTheme.Dark);
 ```
 
-Option B – use the app's root element + bool:
+Option B – use `XamlRoot` + bool:
 
 ```csharp
-SystemThemeHelper.SetRootTheme(appRoot, darkMode: true);
+SystemThemeHelper.SetRootTheme(MyPage.XamlRoot, darkMode: true);
 ```
-
-The `XamlRoot`-based equivalents remain available for standalone apps.
 
 ---
 
@@ -232,47 +225,8 @@ SystemThemeHelper.ToggleApplicationTheme(); // obsolete
 **After (manual toggle):**
 
 ```csharp
-var isDark = SystemThemeHelper.IsRootInDarkMode(appRoot); // the app's root element (see section 8)
-SystemThemeHelper.SetRootTheme(appRoot, darkMode: !isDark);
+var isDark = SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
+SystemThemeHelper.SetRootTheme(MyPage.XamlRoot, darkMode: !isDark);
 ```
 
 This keeps the old behavior but on the correct root.
-
----
-
-## 8. Theme the app via its own root element or window (hosted-safe)
-
-All the `XamlRoot`-based members above resolve the target element through `XamlRoot.Content`. In a standalone app that element **is** your app's root, so they work fine. But when your app's content is hosted under a `XamlRoot` it doesn't own - for example under **Hot Design**, where the app's `Window.Content` is re-parented into a host's shared `XamlRoot` - `XamlRoot.Content` is the *host's* root visual. Reading through it reports the host's theme, and writing through it re-themes the host while your app stays unchanged.
-
-For this, the helper offers overloads that take your app's own root element or `Window` directly:
-
-```csharp
-using Uno.Toolkit.UI;
-
-// Option A - with your app's root element, captured once at startup
-// (e.g. in App.xaml.cs, right after setting window.Content):
-var appRoot = window.Content as FrameworkElement;
-SystemThemeHelper.SetRootTheme(appRoot, darkMode: true);
-var appTheme = SystemThemeHelper.GetRootTheme(appRoot);
-
-// Option B - with your app's Window:
-SystemThemeHelper.SetApplicationTheme(window, ElementTheme.Dark);
-var isDark = SystemThemeHelper.IsRootInDarkMode(window);
-```
-
-**Notes**
-
-* `RequestedTheme` cascades down the subtree: setting it on your app's root themes your whole app and nothing above it.
-* Prefer capturing the root element once (Option A). The `Window` overloads read `window.Content` at call time; capture the root while you know the content is set.
-* Pass your app's **root** element (typically `window.Content`), not an arbitrary page - elements outside the page's subtree would otherwise keep the previous theme.
-* Content hosted in the popup root (flyouts, `ContentDialog`, tooltips) renders **outside** the app root's subtree and may not pick up the theme automatically - set `RequestedTheme` on such content explicitly if it doesn't.
-* If your root element gets recreated (e.g. a hot-reload replacing the visual tree), re-apply the theme to the new root.
-* In standalone apps these overloads behave exactly like the `XamlRoot` ones, so they are a safe default everywhere.
-* If the resolved root is `null` (window content not set yet, or not a `FrameworkElement`), `Set*` is a no-op (a warning is logged when logging is enabled) and `Get*` falls back to the OS theme.
-
-**Toggle example (hosted-safe):**
-
-```csharp
-var isDark = SystemThemeHelper.IsRootInDarkMode(appRoot);
-SystemThemeHelper.SetRootTheme(appRoot, darkMode: !isDark);
-```

--- a/doc/helpers/walkthroughs/systemthemehelper.howto.md
+++ b/doc/helpers/walkthroughs/systemthemehelper.howto.md
@@ -6,7 +6,7 @@ Use this when you just want to know what the operating system is using (Light/Da
 
 ```csharp
 using Uno.Toolkit.UI;
-using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
+using Microsoft.UI.Xaml;
 
 var osTheme = SystemThemeHelper.GetCurrentOsTheme();
 
@@ -32,7 +32,7 @@ Use this when your app has multiple windows/surfaces and you need the theme **fo
 
 ```csharp
 using Uno.Toolkit.UI;
-using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
+using Microsoft.UI.Xaml;
 
 // any FrameworkElement you have on screen:
 var xamlRoot = MyPage.XamlRoot;
@@ -82,7 +82,7 @@ Use this when you want to **override** the OS/user setting for a specific root.
 
 ```csharp
 using Uno.Toolkit.UI;
-using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
+using Microsoft.UI.Xaml;
 
 var xamlRoot = MyPage.XamlRoot;
 
@@ -136,7 +136,7 @@ Sometimes you just want to know “what do I have right now?”
 
 ```csharp
 using Uno.Toolkit.UI;
-using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
+using Microsoft.UI.Xaml;
 
 var osTheme   = SystemThemeHelper.GetCurrentOsTheme();
 var rootTheme = SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
@@ -248,7 +248,7 @@ For this, the helper offers overloads that take your app's own root element or `
 
 ```csharp
 using Uno.Toolkit.UI;
-using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
+using Microsoft.UI.Xaml;
 
 // Option A - with your app's root element, captured once at startup
 // (e.g. in App.xaml.cs, right after setting window.Content):

--- a/doc/helpers/walkthroughs/systemthemehelper.howto.md
+++ b/doc/helpers/walkthroughs/systemthemehelper.howto.md
@@ -248,6 +248,7 @@ For this, the helper offers overloads that take your app's own root element or `
 
 ```csharp
 using Uno.Toolkit.UI;
+using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
 
 // Option A - with your app's root element, captured once at startup
 // (e.g. in App.xaml.cs, right after setting window.Content):

--- a/doc/helpers/walkthroughs/systemthemehelper.howto.md
+++ b/doc/helpers/walkthroughs/systemthemehelper.howto.md
@@ -6,7 +6,7 @@ Use this when you just want to know what the operating system is using (Light/Da
 
 ```csharp
 using Uno.Toolkit.UI;
-using Windows.UI.Xaml;
+using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
 
 var osTheme = SystemThemeHelper.GetCurrentOsTheme();
 
@@ -32,7 +32,7 @@ Use this when your app has multiple windows/surfaces and you need the theme **fo
 
 ```csharp
 using Uno.Toolkit.UI;
-using Windows.UI.Xaml;
+using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
 
 // any FrameworkElement you have on screen:
 var xamlRoot = MyPage.XamlRoot;
@@ -45,7 +45,7 @@ var appTheme = SystemThemeHelper.GetRootTheme(xamlRoot);
 **Notes**
 
 * If `xamlRoot` is `null`, the helper falls back to the OS theme.
-* This is the recommended way when you have a specific visual root.
+* This reads the theme of `XamlRoot.Content` - the root visual of the `XamlRoot`. For the hosted-safe default, prefer the `Window`/`FrameworkElement` overloads (section 8).
 
 ---
 
@@ -105,6 +105,9 @@ SystemThemeHelper.SetApplicationTheme(xamlRoot, ElementTheme.Light);
 * Screenshots/exports that must look the same
 * “Preview in Light/Dark” buttons
 
+> [!IMPORTANT]
+> The `XamlRoot`-based overloads target `XamlRoot.Content` - the root visual of the `XamlRoot`. If your app's content is hosted under a `XamlRoot` it doesn't own (for example under Hot Design), that element is the **host's** root, not your app's. Prefer the `Window`/`FrameworkElement` overloads described in section 8 below - they behave identically in standalone apps and remain correct when hosted.
+
 ---
 
 ## 5. Force a view to Dark using a boolean (older style)
@@ -133,7 +136,7 @@ Sometimes you just want to know “what do I have right now?”
 
 ```csharp
 using Uno.Toolkit.UI;
-using Windows.UI.Xaml;
+using Microsoft.UI.Xaml; // or Windows.UI.Xaml, depending on your target
 
 var osTheme   = SystemThemeHelper.GetCurrentOsTheme();
 var rootTheme = SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
@@ -165,10 +168,11 @@ var theme = SystemThemeHelper.GetApplicationTheme(); // obsolete
 **After (recommended):**
 
 ```csharp
-var theme = SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
+var theme = SystemThemeHelper.GetRootTheme(appRoot); // the app's root element (see section 8)
+// or, standalone-only: SystemThemeHelper.GetRootTheme(MyPage.XamlRoot);
 ```
 
-Why: the new version is root-aware.
+Why: the new version is root-aware, and the element overload stays correct when hosted (section 8).
 
 ---
 
@@ -183,10 +187,11 @@ var isDark = SystemThemeHelper.IsAppInDarkMode(); // obsolete
 **After (recommended):**
 
 ```csharp
-var isDark = SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
+var isDark = SystemThemeHelper.IsRootInDarkMode(appRoot); // the app's root element (see section 8)
+// or, standalone-only: SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
 ```
 
-Why: again, this works for the current visual root.
+Why: again, this works for the current visual root - and the element overload stays correct when hosted.
 
 ---
 
@@ -200,17 +205,19 @@ SystemThemeHelper.SetApplicationTheme(true); // dark
 
 **After (recommended):**
 
-Option A – use `XamlRoot` + enum:
+Option A – use the app's root element + enum (hosted-safe, see section 8):
 
 ```csharp
-SystemThemeHelper.SetApplicationTheme(MyPage.XamlRoot, ElementTheme.Dark);
+SystemThemeHelper.SetApplicationTheme(appRoot, ElementTheme.Dark);
 ```
 
-Option B – use `XamlRoot` + bool:
+Option B – use the app's root element + bool:
 
 ```csharp
-SystemThemeHelper.SetRootTheme(MyPage.XamlRoot, darkMode: true);
+SystemThemeHelper.SetRootTheme(appRoot, darkMode: true);
 ```
+
+The `XamlRoot`-based equivalents remain available for standalone apps.
 
 ---
 
@@ -225,8 +232,47 @@ SystemThemeHelper.ToggleApplicationTheme(); // obsolete
 **After (manual toggle):**
 
 ```csharp
-var isDark = SystemThemeHelper.IsRootInDarkMode(MyPage.XamlRoot);
-SystemThemeHelper.SetRootTheme(MyPage.XamlRoot, darkMode: !isDark);
+var isDark = SystemThemeHelper.IsRootInDarkMode(appRoot); // the app's root element (see section 8)
+SystemThemeHelper.SetRootTheme(appRoot, darkMode: !isDark);
 ```
 
 This keeps the old behavior but on the correct root.
+
+---
+
+## 8. Theme the app via its own root element or window (hosted-safe)
+
+All the `XamlRoot`-based members above resolve the target element through `XamlRoot.Content`. In a standalone app that element **is** your app's root, so they work fine. But when your app's content is hosted under a `XamlRoot` it doesn't own - for example under **Hot Design**, where the app's `Window.Content` is re-parented into a host's shared `XamlRoot` - `XamlRoot.Content` is the *host's* root visual. Reading through it reports the host's theme, and writing through it re-themes the host while your app stays unchanged.
+
+For this, the helper offers overloads that take your app's own root element or `Window` directly:
+
+```csharp
+using Uno.Toolkit.UI;
+
+// Option A - with your app's root element, captured once at startup
+// (e.g. in App.xaml.cs, right after setting window.Content):
+var appRoot = window.Content as FrameworkElement;
+SystemThemeHelper.SetRootTheme(appRoot, darkMode: true);
+var appTheme = SystemThemeHelper.GetRootTheme(appRoot);
+
+// Option B - with your app's Window:
+SystemThemeHelper.SetApplicationTheme(window, ElementTheme.Dark);
+var isDark = SystemThemeHelper.IsRootInDarkMode(window);
+```
+
+**Notes**
+
+* `RequestedTheme` cascades down the subtree: setting it on your app's root themes your whole app and nothing above it.
+* Prefer capturing the root element once (Option A). The `Window` overloads read `window.Content` at call time; capture the root while you know the content is set.
+* Pass your app's **root** element (typically `window.Content`), not an arbitrary page - elements outside the page's subtree would otherwise keep the previous theme.
+* Content hosted in the popup root (flyouts, `ContentDialog`, tooltips) renders **outside** the app root's subtree and may not pick up the theme automatically - set `RequestedTheme` on such content explicitly if it doesn't.
+* If your root element gets recreated (e.g. a hot-reload replacing the visual tree), re-apply the theme to the new root.
+* In standalone apps these overloads behave exactly like the `XamlRoot` ones, so they are a safe default everywhere.
+* If the resolved root is `null` (window content not set yet, or not a `FrameworkElement`), `Set*` is a no-op (a warning is logged when logging is enabled) and `Get*` falls back to the OS theme.
+
+**Toggle example (hosted-safe):**
+
+```csharp
+var isDark = SystemThemeHelper.IsRootInDarkMode(appRoot);
+SystemThemeHelper.SetRootTheme(appRoot, darkMode: !isDark);
+```

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
@@ -58,6 +58,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			SystemThemeHelper.SetApplicationTheme((FrameworkElement?)null, ElementTheme.Dark);
 			SystemThemeHelper.SetApplicationTheme((Window?)null, ElementTheme.Dark);
 			SystemThemeHelper.SetRootTheme((FrameworkElement?)null, darkMode: true);
+			SystemThemeHelper.SetRootTheme((Window?)null, darkMode: true);
 
 			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((FrameworkElement?)null));
 			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((Window?)null));

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
@@ -23,7 +23,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		[DataRow(false, DisplayName = "App goes light, host stays dark")]
 		public async Task When_HostedUnderForeignXamlRoot_ThemesOwnRoot_NotHost(bool appDark)
 		{
-			// Hosted-app topology (e.g. Hot Design): the app root is a nested child, XamlRoot.Content is the host's root.
+			// Hosted-app topology: the app root is a nested child, XamlRoot.Content is the host's root.
 			var hostTheme = appDark ? ElementTheme.Light : ElementTheme.Dark;
 			var appRoot = new Grid();
 			// explicit size: WaitForLoaded requires non-zero ActualWidth/Height
@@ -59,7 +59,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			SystemThemeHelper.SetApplicationTheme((Window?)null, ElementTheme.Dark);
 			SystemThemeHelper.SetRootTheme((FrameworkElement?)null, darkMode: true);
 
-			// null root falls back to the OS theme
 			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((FrameworkElement?)null));
 			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((Window?)null));
 		}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests
+{
+	[TestClass]
+	[RunsOnUIThread]
+	internal class SystemThemeHelperTests
+	{
+		[TestMethod]
+		[DataRow(true, DisplayName = "App goes dark, host stays light")]
+		[DataRow(false, DisplayName = "App goes light, host stays dark")]
+		public async Task When_HostedUnderForeignXamlRoot_ThemesOwnRoot_NotHost(bool appDark)
+		{
+			// Hosted-app topology (e.g. Hot Design): the app root is a nested child, XamlRoot.Content is the host's root.
+			var hostTheme = appDark ? ElementTheme.Light : ElementTheme.Dark;
+			var appRoot = new Grid();
+			// explicit size: WaitForLoaded requires non-zero ActualWidth/Height
+			var hostRoot = new Grid { Width = 200, Height = 200, RequestedTheme = hostTheme, Children = { appRoot } };
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(hostRoot);
+
+			Assert.IsNotNull(appRoot.XamlRoot);
+			Assert.AreNotEqual((object)appRoot, appRoot.XamlRoot!.Content, "test precondition: the XamlRoot content must not be the app root");
+
+			var xamlRootContent = appRoot.XamlRoot.Content as FrameworkElement;
+			Assert.IsNotNull(xamlRootContent);
+			var xamlRootContentTheme = xamlRootContent!.RequestedTheme;
+
+			SystemThemeHelper.SetRootTheme(appRoot, darkMode: appDark);
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			var expectedAppTheme = appDark ? ElementTheme.Dark : ElementTheme.Light;
+			Assert.AreEqual(expectedAppTheme, appRoot.RequestedTheme);
+			Assert.AreEqual(expectedAppTheme, appRoot.ActualTheme);
+			Assert.AreEqual(appDark, SystemThemeHelper.IsRootInDarkMode(appRoot));
+			Assert.AreEqual(appDark ? ApplicationTheme.Dark : ApplicationTheme.Light, SystemThemeHelper.GetRootTheme(appRoot));
+
+			Assert.AreEqual(hostTheme, hostRoot.RequestedTheme);
+			Assert.AreEqual(hostTheme, hostRoot.ActualTheme);
+			Assert.AreEqual(xamlRootContentTheme, xamlRootContent.RequestedTheme);
+		}
+
+		[TestMethod]
+		public void When_NullArguments_NoThrow()
+		{
+			SystemThemeHelper.SetApplicationTheme((FrameworkElement?)null, ElementTheme.Dark);
+			SystemThemeHelper.SetApplicationTheme((Window?)null, ElementTheme.Dark);
+			SystemThemeHelper.SetRootTheme((FrameworkElement?)null, darkMode: true);
+
+			// null root falls back to the OS theme
+			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((FrameworkElement?)null));
+			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((Window?)null));
+		}
+
+		[TestMethod]
+		public async Task When_SetApplicationTheme_OnElement_SubtreeInherits()
+		{
+			var child = new Border();
+			var appRoot = new Grid { Children = { child } };
+			var hostRoot = new Grid { Width = 200, Height = 200, RequestedTheme = ElementTheme.Light, Children = { appRoot } };
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(hostRoot);
+
+			SystemThemeHelper.SetApplicationTheme(appRoot, ElementTheme.Dark);
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.AreEqual(ElementTheme.Dark, child.ActualTheme);
+			Assert.AreEqual(ElementTheme.Light, hostRoot.ActualTheme);
+		}
+
+		[TestMethod]
+		public async Task When_WindowOverload_TargetsWindowContent()
+		{
+			var window = UnitTestsUIContentHelper.CurrentTestWindow;
+			Assert.IsNotNull(window);
+			var windowRoot = window!.Content as FrameworkElement;
+			Assert.IsNotNull(windowRoot);
+
+			var initialRequested = windowRoot!.RequestedTheme;
+			var initialIsDark = SystemThemeHelper.IsRootInDarkMode(window);
+			try
+			{
+				SystemThemeHelper.SetRootTheme(window, darkMode: !initialIsDark);
+				await UnitTestsUIContentHelper.WaitForIdle();
+
+				Assert.AreEqual(!initialIsDark ? ElementTheme.Dark : ElementTheme.Light, windowRoot.RequestedTheme);
+				Assert.AreEqual(!initialIsDark, SystemThemeHelper.IsRootInDarkMode(window));
+				Assert.AreEqual(SystemThemeHelper.GetRootTheme(windowRoot), SystemThemeHelper.GetRootTheme(window));
+			}
+			finally
+			{
+				windowRoot.RequestedTheme = initialRequested;
+				await UnitTestsUIContentHelper.WaitForIdle();
+			}
+		}
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
@@ -21,9 +21,9 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		[TestMethod]
 		[DataRow(true, DisplayName = "App goes dark, host stays light")]
 		[DataRow(false, DisplayName = "App goes light, host stays dark")]
-		public async Task When_AppRootOverride_ThemesAppRoot_NotHost(bool appDark)
+		public async Task When_HostedUnderForeignXamlRoot_ThemesOwnRoot_NotHost(bool appDark)
 		{
-			// Hosted-app topology: the app root is a nested child, XamlRoot.Content is the host's root.
+			// Hosted-app topology (e.g. Hot Design): the app root is a nested child, XamlRoot.Content is the host's root.
 			var hostTheme = appDark ? ElementTheme.Light : ElementTheme.Dark;
 			var appRoot = new Grid();
 			// explicit size: WaitForLoaded requires non-zero ActualWidth/Height
@@ -32,104 +32,78 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			await UnitTestUIContentHelperEx.SetContentAndWait(hostRoot);
 
 			Assert.IsNotNull(appRoot.XamlRoot);
-			var xamlRoot = appRoot.XamlRoot!;
-			Assert.AreNotEqual((object)appRoot, xamlRoot.Content, "test precondition: the XamlRoot content must not be the app root");
+			Assert.AreNotEqual((object)appRoot, appRoot.XamlRoot!.Content, "test precondition: the XamlRoot content must not be the app root");
 
-			var xamlRootContent = xamlRoot.Content as FrameworkElement;
+			var xamlRootContent = appRoot.XamlRoot.Content as FrameworkElement;
 			Assert.IsNotNull(xamlRootContent);
 			var xamlRootContentTheme = xamlRootContent!.RequestedTheme;
 
-			SystemThemeHelper.SetAppRootOverride(xamlRoot, appRoot);
-			try
-			{
-				SystemThemeHelper.SetRootTheme(xamlRoot, darkMode: appDark);
-				await UnitTestsUIContentHelper.WaitForIdle();
+			SystemThemeHelper.SetRootTheme(appRoot, darkMode: appDark);
+			await UnitTestsUIContentHelper.WaitForIdle();
 
-				var expectedAppTheme = appDark ? ElementTheme.Dark : ElementTheme.Light;
-				Assert.AreEqual(expectedAppTheme, appRoot.RequestedTheme);
-				Assert.AreEqual(expectedAppTheme, appRoot.ActualTheme);
-				Assert.AreEqual(appDark, SystemThemeHelper.IsRootInDarkMode(xamlRoot));
-				Assert.AreEqual(appDark ? ApplicationTheme.Dark : ApplicationTheme.Light, SystemThemeHelper.GetRootTheme(xamlRoot));
+			var expectedAppTheme = appDark ? ElementTheme.Dark : ElementTheme.Light;
+			Assert.AreEqual(expectedAppTheme, appRoot.RequestedTheme);
+			Assert.AreEqual(expectedAppTheme, appRoot.ActualTheme);
+			Assert.AreEqual(appDark, SystemThemeHelper.IsRootInDarkMode(appRoot));
+			Assert.AreEqual(appDark ? ApplicationTheme.Dark : ApplicationTheme.Light, SystemThemeHelper.GetRootTheme(appRoot));
 
-				Assert.AreEqual(hostTheme, hostRoot.RequestedTheme);
-				Assert.AreEqual(hostTheme, hostRoot.ActualTheme);
-				Assert.AreEqual(xamlRootContentTheme, xamlRootContent.RequestedTheme);
-			}
-			finally
-			{
-				SystemThemeHelper.SetAppRootOverride(xamlRoot, null);
-			}
+			Assert.AreEqual(hostTheme, hostRoot.RequestedTheme);
+			Assert.AreEqual(hostTheme, hostRoot.ActualTheme);
+			Assert.AreEqual(xamlRootContentTheme, xamlRootContent.RequestedTheme);
 		}
 
 		[TestMethod]
-		public async Task When_NoOverride_TargetsXamlRootContent()
+		public void When_NullArguments_NoThrow()
 		{
-			var content = new Grid { Width = 100, Height = 100 };
-			await UnitTestUIContentHelperEx.SetContentAndWait(content);
+			SystemThemeHelper.SetApplicationTheme((FrameworkElement?)null, ElementTheme.Dark);
+			SystemThemeHelper.SetApplicationTheme((Window?)null, ElementTheme.Dark);
+			SystemThemeHelper.SetRootTheme((FrameworkElement?)null, darkMode: true);
 
-			var xamlRoot = content.XamlRoot!;
-			var target = xamlRoot.Content as FrameworkElement;
-			Assert.IsNotNull(target);
-
-			var initialRequested = target!.RequestedTheme;
-			var initialIsDark = SystemThemeHelper.IsRootInDarkMode(xamlRoot);
-			try
-			{
-				SystemThemeHelper.SetRootTheme(xamlRoot, darkMode: !initialIsDark);
-				await UnitTestsUIContentHelper.WaitForIdle();
-
-				Assert.AreEqual(!initialIsDark ? ElementTheme.Dark : ElementTheme.Light, target.RequestedTheme);
-				Assert.AreEqual(!initialIsDark, SystemThemeHelper.IsRootInDarkMode(xamlRoot));
-			}
-			finally
-			{
-				target.RequestedTheme = initialRequested;
-				await UnitTestsUIContentHelper.WaitForIdle();
-			}
+			// null root falls back to the OS theme
+			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((FrameworkElement?)null));
+			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((Window?)null));
 		}
 
 		[TestMethod]
-		public async Task When_OverrideNotAttached_FallsBackToXamlRootContent()
+		public async Task When_SetApplicationTheme_OnElement_SubtreeInherits()
 		{
-			var content = new Grid { Width = 100, Height = 100 };
-			await UnitTestUIContentHelperEx.SetContentAndWait(content);
+			var child = new Border();
+			var appRoot = new Grid { Children = { child } };
+			var hostRoot = new Grid { Width = 200, Height = 200, RequestedTheme = ElementTheme.Light, Children = { appRoot } };
 
-			var xamlRoot = content.XamlRoot!;
-			var detached = new Grid(); // never attached: XamlRoot is null, so the override must be ignored
-			SystemThemeHelper.SetAppRootOverride(xamlRoot, detached);
-			try
-			{
-				var target = xamlRoot.Content as FrameworkElement;
-				Assert.IsNotNull(target);
-				var initialRequested = target!.RequestedTheme;
-				var initialIsDark = SystemThemeHelper.IsRootInDarkMode(xamlRoot);
-				try
-				{
-					SystemThemeHelper.SetRootTheme(xamlRoot, darkMode: !initialIsDark);
-					await UnitTestsUIContentHelper.WaitForIdle();
+			await UnitTestUIContentHelperEx.SetContentAndWait(hostRoot);
 
-					Assert.AreEqual(!initialIsDark ? ElementTheme.Dark : ElementTheme.Light, target.RequestedTheme);
-					Assert.AreEqual(ElementTheme.Default, detached.RequestedTheme);
-				}
-				finally
-				{
-					target.RequestedTheme = initialRequested;
-					await UnitTestsUIContentHelper.WaitForIdle();
-				}
-			}
-			finally
-			{
-				SystemThemeHelper.SetAppRootOverride(xamlRoot, null);
-			}
+			SystemThemeHelper.SetApplicationTheme(appRoot, ElementTheme.Dark);
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.AreEqual(ElementTheme.Dark, child.ActualTheme);
+			Assert.AreEqual(ElementTheme.Light, hostRoot.ActualTheme);
 		}
 
 		[TestMethod]
-		public void When_NullXamlRoot_NoThrow()
+		public async Task When_WindowOverload_TargetsWindowContent()
 		{
-			SystemThemeHelper.SetApplicationTheme(null, ElementTheme.Dark);
-			SystemThemeHelper.SetRootTheme(null, darkMode: true);
+			var window = UnitTestsUIContentHelper.CurrentTestWindow;
+			Assert.IsNotNull(window);
+			var windowRoot = window!.Content as FrameworkElement;
+			Assert.IsNotNull(windowRoot);
 
-			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme(null));
+			var initialRequested = windowRoot!.RequestedTheme;
+			var initialIsDark = SystemThemeHelper.IsRootInDarkMode(window);
+			try
+			{
+				SystemThemeHelper.SetRootTheme(window, darkMode: !initialIsDark);
+				await UnitTestsUIContentHelper.WaitForIdle();
+
+				Assert.AreEqual(!initialIsDark ? ElementTheme.Dark : ElementTheme.Light, windowRoot.RequestedTheme);
+				Assert.AreEqual(!initialIsDark, SystemThemeHelper.IsRootInDarkMode(window));
+				Assert.AreEqual(SystemThemeHelper.GetRootTheme(windowRoot), SystemThemeHelper.GetRootTheme(window));
+			}
+			finally
+			{
+				windowRoot.RequestedTheme = initialRequested;
+				await UnitTestsUIContentHelper.WaitForIdle();
+			}
 		}
 	}
 }

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
@@ -23,7 +23,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		[DataRow(false, DisplayName = "App goes light, host stays dark")]
 		public async Task When_AppRootOverride_ThemesAppRoot_NotHost(bool appDark)
 		{
-			// Hosted-app topology (e.g. Hot Design): the app root is a nested child, XamlRoot.Content is the host's root.
+			// Hosted-app topology: the app root is a nested child, XamlRoot.Content is the host's root.
 			var hostTheme = appDark ? ElementTheme.Light : ElementTheme.Dark;
 			var appRoot = new Grid();
 			// explicit size: WaitForLoaded requires non-zero ActualWidth/Height
@@ -129,7 +129,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			SystemThemeHelper.SetApplicationTheme(null, ElementTheme.Dark);
 			SystemThemeHelper.SetRootTheme(null, darkMode: true);
 
-			// null root falls back to the OS theme
 			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme(null));
 		}
 	}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/SystemThemeHelperTests.cs
@@ -21,7 +21,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		[TestMethod]
 		[DataRow(true, DisplayName = "App goes dark, host stays light")]
 		[DataRow(false, DisplayName = "App goes light, host stays dark")]
-		public async Task When_HostedUnderForeignXamlRoot_ThemesOwnRoot_NotHost(bool appDark)
+		public async Task When_AppRootOverride_ThemesAppRoot_NotHost(bool appDark)
 		{
 			// Hosted-app topology (e.g. Hot Design): the app root is a nested child, XamlRoot.Content is the host's root.
 			var hostTheme = appDark ? ElementTheme.Light : ElementTheme.Dark;
@@ -32,78 +32,105 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			await UnitTestUIContentHelperEx.SetContentAndWait(hostRoot);
 
 			Assert.IsNotNull(appRoot.XamlRoot);
-			Assert.AreNotEqual((object)appRoot, appRoot.XamlRoot!.Content, "test precondition: the XamlRoot content must not be the app root");
+			var xamlRoot = appRoot.XamlRoot!;
+			Assert.AreNotEqual((object)appRoot, xamlRoot.Content, "test precondition: the XamlRoot content must not be the app root");
 
-			var xamlRootContent = appRoot.XamlRoot.Content as FrameworkElement;
+			var xamlRootContent = xamlRoot.Content as FrameworkElement;
 			Assert.IsNotNull(xamlRootContent);
 			var xamlRootContentTheme = xamlRootContent!.RequestedTheme;
 
-			SystemThemeHelper.SetRootTheme(appRoot, darkMode: appDark);
-			await UnitTestsUIContentHelper.WaitForIdle();
-
-			var expectedAppTheme = appDark ? ElementTheme.Dark : ElementTheme.Light;
-			Assert.AreEqual(expectedAppTheme, appRoot.RequestedTheme);
-			Assert.AreEqual(expectedAppTheme, appRoot.ActualTheme);
-			Assert.AreEqual(appDark, SystemThemeHelper.IsRootInDarkMode(appRoot));
-			Assert.AreEqual(appDark ? ApplicationTheme.Dark : ApplicationTheme.Light, SystemThemeHelper.GetRootTheme(appRoot));
-
-			Assert.AreEqual(hostTheme, hostRoot.RequestedTheme);
-			Assert.AreEqual(hostTheme, hostRoot.ActualTheme);
-			Assert.AreEqual(xamlRootContentTheme, xamlRootContent.RequestedTheme);
-		}
-
-		[TestMethod]
-		public void When_NullArguments_NoThrow()
-		{
-			SystemThemeHelper.SetApplicationTheme((FrameworkElement?)null, ElementTheme.Dark);
-			SystemThemeHelper.SetApplicationTheme((Window?)null, ElementTheme.Dark);
-			SystemThemeHelper.SetRootTheme((FrameworkElement?)null, darkMode: true);
-
-			// null root falls back to the OS theme
-			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((FrameworkElement?)null));
-			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme((Window?)null));
-		}
-
-		[TestMethod]
-		public async Task When_SetApplicationTheme_OnElement_SubtreeInherits()
-		{
-			var child = new Border();
-			var appRoot = new Grid { Children = { child } };
-			var hostRoot = new Grid { Width = 200, Height = 200, RequestedTheme = ElementTheme.Light, Children = { appRoot } };
-
-			await UnitTestUIContentHelperEx.SetContentAndWait(hostRoot);
-
-			SystemThemeHelper.SetApplicationTheme(appRoot, ElementTheme.Dark);
-			await UnitTestsUIContentHelper.WaitForIdle();
-
-			Assert.AreEqual(ElementTheme.Dark, child.ActualTheme);
-			Assert.AreEqual(ElementTheme.Light, hostRoot.ActualTheme);
-		}
-
-		[TestMethod]
-		public async Task When_WindowOverload_TargetsWindowContent()
-		{
-			var window = UnitTestsUIContentHelper.CurrentTestWindow;
-			Assert.IsNotNull(window);
-			var windowRoot = window!.Content as FrameworkElement;
-			Assert.IsNotNull(windowRoot);
-
-			var initialRequested = windowRoot!.RequestedTheme;
-			var initialIsDark = SystemThemeHelper.IsRootInDarkMode(window);
+			SystemThemeHelper.SetAppRootOverride(xamlRoot, appRoot);
 			try
 			{
-				SystemThemeHelper.SetRootTheme(window, darkMode: !initialIsDark);
+				SystemThemeHelper.SetRootTheme(xamlRoot, darkMode: appDark);
 				await UnitTestsUIContentHelper.WaitForIdle();
 
-				Assert.AreEqual(!initialIsDark ? ElementTheme.Dark : ElementTheme.Light, windowRoot.RequestedTheme);
-				Assert.AreEqual(!initialIsDark, SystemThemeHelper.IsRootInDarkMode(window));
-				Assert.AreEqual(SystemThemeHelper.GetRootTheme(windowRoot), SystemThemeHelper.GetRootTheme(window));
+				var expectedAppTheme = appDark ? ElementTheme.Dark : ElementTheme.Light;
+				Assert.AreEqual(expectedAppTheme, appRoot.RequestedTheme);
+				Assert.AreEqual(expectedAppTheme, appRoot.ActualTheme);
+				Assert.AreEqual(appDark, SystemThemeHelper.IsRootInDarkMode(xamlRoot));
+				Assert.AreEqual(appDark ? ApplicationTheme.Dark : ApplicationTheme.Light, SystemThemeHelper.GetRootTheme(xamlRoot));
+
+				Assert.AreEqual(hostTheme, hostRoot.RequestedTheme);
+				Assert.AreEqual(hostTheme, hostRoot.ActualTheme);
+				Assert.AreEqual(xamlRootContentTheme, xamlRootContent.RequestedTheme);
 			}
 			finally
 			{
-				windowRoot.RequestedTheme = initialRequested;
+				SystemThemeHelper.SetAppRootOverride(xamlRoot, null);
+			}
+		}
+
+		[TestMethod]
+		public async Task When_NoOverride_TargetsXamlRootContent()
+		{
+			var content = new Grid { Width = 100, Height = 100 };
+			await UnitTestUIContentHelperEx.SetContentAndWait(content);
+
+			var xamlRoot = content.XamlRoot!;
+			var target = xamlRoot.Content as FrameworkElement;
+			Assert.IsNotNull(target);
+
+			var initialRequested = target!.RequestedTheme;
+			var initialIsDark = SystemThemeHelper.IsRootInDarkMode(xamlRoot);
+			try
+			{
+				SystemThemeHelper.SetRootTheme(xamlRoot, darkMode: !initialIsDark);
+				await UnitTestsUIContentHelper.WaitForIdle();
+
+				Assert.AreEqual(!initialIsDark ? ElementTheme.Dark : ElementTheme.Light, target.RequestedTheme);
+				Assert.AreEqual(!initialIsDark, SystemThemeHelper.IsRootInDarkMode(xamlRoot));
+			}
+			finally
+			{
+				target.RequestedTheme = initialRequested;
 				await UnitTestsUIContentHelper.WaitForIdle();
 			}
+		}
+
+		[TestMethod]
+		public async Task When_OverrideNotAttached_FallsBackToXamlRootContent()
+		{
+			var content = new Grid { Width = 100, Height = 100 };
+			await UnitTestUIContentHelperEx.SetContentAndWait(content);
+
+			var xamlRoot = content.XamlRoot!;
+			var detached = new Grid(); // never attached: XamlRoot is null, so the override must be ignored
+			SystemThemeHelper.SetAppRootOverride(xamlRoot, detached);
+			try
+			{
+				var target = xamlRoot.Content as FrameworkElement;
+				Assert.IsNotNull(target);
+				var initialRequested = target!.RequestedTheme;
+				var initialIsDark = SystemThemeHelper.IsRootInDarkMode(xamlRoot);
+				try
+				{
+					SystemThemeHelper.SetRootTheme(xamlRoot, darkMode: !initialIsDark);
+					await UnitTestsUIContentHelper.WaitForIdle();
+
+					Assert.AreEqual(!initialIsDark ? ElementTheme.Dark : ElementTheme.Light, target.RequestedTheme);
+					Assert.AreEqual(ElementTheme.Default, detached.RequestedTheme);
+				}
+				finally
+				{
+					target.RequestedTheme = initialRequested;
+					await UnitTestsUIContentHelper.WaitForIdle();
+				}
+			}
+			finally
+			{
+				SystemThemeHelper.SetAppRootOverride(xamlRoot, null);
+			}
+		}
+
+		[TestMethod]
+		public void When_NullXamlRoot_NoThrow()
+		{
+			SystemThemeHelper.SetApplicationTheme(null, ElementTheme.Dark);
+			SystemThemeHelper.SetRootTheme(null, darkMode: true);
+
+			// null root falls back to the OS theme
+			Assert.AreEqual(SystemThemeHelper.GetCurrentOsTheme(), SystemThemeHelper.GetRootTheme(null));
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -164,7 +164,7 @@ namespace Uno.Toolkit.UI
 
 		private static FrameworkElement GetWindowRoot() =>
 #if IS_WINUI
-			throw new NotSupportedException($"This method is not supported with WinUI, use methods that take a XamlRoot as a parameter");
+			throw new NotSupportedException($"This method is not supported with WinUI, use the overloads that take the app's Window or root FrameworkElement (or a XamlRoot).");
 #else
 			XamlWindow.Current?.Content as FrameworkElement ??
 			throw new InvalidOperationException($"The current window content is not {(XamlWindow.Current?.Content == null ? "set" : "a FrameworkElement")}.");

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -2,6 +2,9 @@
 using Windows.UI;
 using Windows.UI.ViewManagement;
 using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+using Uno.Logging;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -16,6 +19,8 @@ namespace Uno.Toolkit.UI
 {
 	public static class SystemThemeHelper
 	{
+		private static readonly ILogger Logger = typeof(SystemThemeHelper).Log();
+
 		/// <summary>
 		/// Get the current theme of the operating system.
 		/// </summary>
@@ -31,16 +36,24 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Get the current theme of the application.
 		/// </summary>
-		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(XamlRoot root) instead.")]
+		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(Window window) or GetRootTheme(FrameworkElement root) instead.")]
 		public static ApplicationTheme GetApplicationTheme()
 			=> GetRootTheme(GetWindowRoot()?.XamlRoot);
 
 		/// <summary>
 		/// Gets a <see cref="ApplicationTheme"/> from the provided XamlRoot.
 		/// </summary>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="GetRootTheme(FrameworkElement?)"/> there.</remarks>
 		public static ApplicationTheme GetRootTheme(XamlRoot? root)
+			=> GetRootTheme(root?.Content as FrameworkElement);
+
+		/// <summary>
+		/// Gets a <see cref="ApplicationTheme"/> from the provided root element.
+		/// </summary>
+		/// <param name="root">The app's root element, typically the window's content.</param>
+		public static ApplicationTheme GetRootTheme(FrameworkElement? root)
 		{
-			return (root?.Content as FrameworkElement)?.ActualTheme switch
+			return root?.ActualTheme switch
 			{
 				ElementTheme.Light => ApplicationTheme.Light,
 				ElementTheme.Dark => ApplicationTheme.Dark,
@@ -50,36 +63,102 @@ namespace Uno.Toolkit.UI
 		}
 
 		/// <summary>
+		/// Gets a <see cref="ApplicationTheme"/> from the content of the provided window.
+		/// </summary>
+		/// <param name="window">The app's window.</param>
+		public static ApplicationTheme GetRootTheme(XamlWindow? window)
+			=> GetRootTheme(window?.Content as FrameworkElement);
+
+		/// <summary>
 		/// Get if the application is currently in dark mode.
 		/// </summary>
-		[Obsolete("IsAppInDarkMode is obsolete. Use IsRootInDarkMode(XamlRoot root) instead.")]
+		[Obsolete("IsAppInDarkMode is obsolete. Use IsRootInDarkMode(Window window) or IsRootInDarkMode(FrameworkElement root) instead.")]
 		public static bool IsAppInDarkMode()
 			=> GetRootTheme(GetWindowRoot().XamlRoot) == ApplicationTheme.Dark;
 
+		/// <summary>
+		/// Gets whether the content of the provided XamlRoot is currently in dark mode.
+		/// </summary>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="IsRootInDarkMode(FrameworkElement)"/> there.</remarks>
 		public static bool IsRootInDarkMode(XamlRoot root)
 			=> GetRootTheme(root) == ApplicationTheme.Dark;
 
-		[Obsolete("SetApplicationTheme(bool darkMode) is obsolete. Use SetApplicationTheme(XamlRoot? root, ElementTheme theme) instead.")]
+		/// <summary>
+		/// Gets whether the provided root element is currently in dark mode.
+		/// </summary>
+		/// <param name="root">The app's root element, typically the window's content.</param>
+		public static bool IsRootInDarkMode(FrameworkElement root)
+			=> GetRootTheme(root) == ApplicationTheme.Dark;
+
+		/// <summary>
+		/// Gets whether the content of the provided window is currently in dark mode.
+		/// </summary>
+		/// <param name="window">The app's window.</param>
+		public static bool IsRootInDarkMode(XamlWindow window)
+			=> GetRootTheme(window) == ApplicationTheme.Dark;
+
+		[Obsolete("SetApplicationTheme(bool darkMode) is obsolete. Use SetApplicationTheme(Window? window, ElementTheme theme) or SetApplicationTheme(FrameworkElement? root, ElementTheme theme) instead.")]
 		public static void SetApplicationTheme(bool darkMode)
 			=> SetRootTheme(GetWindowRoot().XamlRoot, darkMode);
 
 		/// <summary>
 		/// Sets the theme for the provided XamlRoot
 		/// </summary>
-		/// <param name="root"></param>
-		/// <param name="darkMode"></param>
+		/// <param name="root">The XamlRoot whose content to theme.</param>
+		/// <param name="darkMode">Whether to apply the dark theme.</param>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="SetRootTheme(FrameworkElement?, bool)"/> there.</remarks>
 		public static void SetRootTheme(XamlRoot? root, bool darkMode)
+			=> SetRootTheme(root?.Content as FrameworkElement, darkMode);
+
+		/// <summary>
+		/// Sets the theme for the provided root element and its subtree.
+		/// </summary>
+		/// <param name="root">The app's root element, typically the window's content.</param>
+		/// <param name="darkMode">Whether to apply the dark theme.</param>
+		public static void SetRootTheme(FrameworkElement? root, bool darkMode)
 			=> SetApplicationTheme(root, darkMode ? ElementTheme.Dark : ElementTheme.Light);
 
+		/// <summary>
+		/// Sets the theme for the content of the provided window.
+		/// </summary>
+		/// <param name="window">The app's window.</param>
+		/// <param name="darkMode">Whether to apply the dark theme.</param>
+		public static void SetRootTheme(XamlWindow? window, bool darkMode)
+			=> SetRootTheme(window?.Content as FrameworkElement, darkMode);
+
+		/// <summary>
+		/// Sets the theme for the content of the provided XamlRoot.
+		/// </summary>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="SetApplicationTheme(FrameworkElement?, ElementTheme)"/> there.</remarks>
 		public static void SetApplicationTheme(XamlRoot? root, ElementTheme theme)
+			=> SetApplicationTheme(root?.Content as FrameworkElement, theme);
+
+		/// <summary>
+		/// Sets the theme for the provided root element and its subtree.
+		/// </summary>
+		/// <param name="root">The app's root element, typically the window's content.</param>
+		/// <param name="theme">The theme to apply.</param>
+		public static void SetApplicationTheme(FrameworkElement? root, ElementTheme theme)
 		{
-			if (root?.Content is FrameworkElement fe)
+			if (root is not null)
 			{
-				fe.RequestedTheme = theme;
+				root.RequestedTheme = theme;
+			}
+			else
+			{
+				Logger.WarnIfEnabled(() => "No root element to apply the theme to (window/XamlRoot content not set, or not a FrameworkElement).");
 			}
 		}
 
-		[Obsolete("ToggleApplicationTheme() is obsolete. Use SetApplicationTheme(XamlRoot? root, ElementTheme theme) instead.")]
+		/// <summary>
+		/// Sets the theme for the content of the provided window.
+		/// </summary>
+		/// <param name="window">The app's window.</param>
+		/// <param name="theme">The theme to apply.</param>
+		public static void SetApplicationTheme(XamlWindow? window, ElementTheme theme)
+			=> SetApplicationTheme(window?.Content as FrameworkElement, theme);
+
+		[Obsolete("ToggleApplicationTheme() is obsolete. Use IsRootInDarkMode + SetRootTheme with the app's Window or root element instead.")]
 		public static void ToggleApplicationTheme()
 			=> SetApplicationTheme(darkMode: !IsAppInDarkMode());
 

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -22,17 +22,13 @@ namespace Uno.Toolkit.UI
 	{
 		private static readonly ILogger Logger = typeof(SystemThemeHelper).Log();
 
-		// Maps a XamlRoot to the app's own root element, for apps hosted under a XamlRoot they don't
-		// own (e.g. Hot Design re-parents the app's Window.Content into the host's shared XamlRoot,
-		// so XamlRoot.Content resolves to the host's root, not the app's). Registered by the hosting
-		// integration via SetAppRootOverride. Both key and value are held weakly so an unloaded app
-		// (collectible ALC) is not kept alive.
+		// Maps a XamlRoot to the app's own root element, for apps hosted under a XamlRoot they
+		// don't own. Held weakly on both sides so an unloaded app is not kept alive.
 		private static readonly ConditionalWeakTable<XamlRoot, WeakReference<FrameworkElement>> _appRootOverrides = new();
 
 		/// <summary>
-		/// Registers the element to be treated as the app's root for the given XamlRoot, in place of
-		/// <see cref="XamlRoot.Content"/>. Used by hosting integrations (e.g. Hot Design) when an app's
-		/// content is re-parented under a XamlRoot it doesn't own. Pass null to clear the override.
+		/// Registers the element to treat as the app's root for the given XamlRoot, in place of
+		/// <see cref="XamlRoot.Content"/>. Pass null to clear the override.
 		/// </summary>
 		internal static void SetAppRootOverride(XamlRoot root, FrameworkElement? appRoot)
 		{
@@ -46,8 +42,6 @@ namespace Uno.Toolkit.UI
 			}
 		}
 
-		// Resolves the element whose theme is read/written for the given XamlRoot: the registered
-		// app-root override when it is alive and still attached to that XamlRoot, else XamlRoot.Content.
 		internal static FrameworkElement? ResolveThemeTarget(XamlRoot? root)
 		{
 			if (root is null)

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -36,7 +36,7 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Get the current theme of the application.
 		/// </summary>
-		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(Window window) or GetRootTheme(FrameworkElement root) instead.")]
+		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(XamlRoot root) instead, or GetRootTheme(FrameworkElement root) when hosted under a XamlRoot the app doesn't own.")]
 		public static ApplicationTheme GetApplicationTheme()
 			=> GetRootTheme(GetWindowRoot().XamlRoot);
 
@@ -72,7 +72,7 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Get if the application is currently in dark mode.
 		/// </summary>
-		[Obsolete("IsAppInDarkMode is obsolete. Use IsRootInDarkMode(Window window) or IsRootInDarkMode(FrameworkElement root) instead.")]
+		[Obsolete("IsAppInDarkMode is obsolete. Use IsRootInDarkMode(XamlRoot root) instead, or IsRootInDarkMode(FrameworkElement root) when hosted under a XamlRoot the app doesn't own.")]
 		public static bool IsAppInDarkMode()
 			=> GetRootTheme(GetWindowRoot().XamlRoot) == ApplicationTheme.Dark;
 
@@ -97,7 +97,7 @@ namespace Uno.Toolkit.UI
 		public static bool IsRootInDarkMode(XamlWindow window)
 			=> GetRootTheme(window) == ApplicationTheme.Dark;
 
-		[Obsolete("SetApplicationTheme(bool darkMode) is obsolete. Use SetApplicationTheme(Window? window, ElementTheme theme) or SetApplicationTheme(FrameworkElement? root, ElementTheme theme) instead.")]
+		[Obsolete("SetApplicationTheme(bool darkMode) is obsolete. Use SetApplicationTheme(XamlRoot? root, ElementTheme theme) instead, or SetApplicationTheme(FrameworkElement? root, ElementTheme theme) when hosted under a XamlRoot the app doesn't own.")]
 		public static void SetApplicationTheme(bool darkMode)
 			=> SetRootTheme(GetWindowRoot().XamlRoot, darkMode);
 
@@ -158,13 +158,13 @@ namespace Uno.Toolkit.UI
 		public static void SetApplicationTheme(XamlWindow? window, ElementTheme theme)
 			=> SetApplicationTheme(window?.Content as FrameworkElement, theme);
 
-		[Obsolete("ToggleApplicationTheme() is obsolete. Use IsRootInDarkMode + SetRootTheme with the app's Window or root element instead.")]
+		[Obsolete("ToggleApplicationTheme() is obsolete. Use SetApplicationTheme(XamlRoot? root, ElementTheme theme) instead.")]
 		public static void ToggleApplicationTheme()
 			=> SetApplicationTheme(darkMode: !IsAppInDarkMode());
 
 		private static FrameworkElement GetWindowRoot() =>
 #if IS_WINUI
-			throw new NotSupportedException($"This method is not supported with WinUI, use the overloads that take the app's Window or root FrameworkElement (or a XamlRoot).");
+			throw new NotSupportedException($"This method is not supported with WinUI, use methods that take a XamlRoot as a parameter");
 #else
 			XamlWindow.Current?.Content as FrameworkElement ??
 			throw new InvalidOperationException($"The current window content is not {(XamlWindow.Current?.Content == null ? "set" : "a FrameworkElement")}.");

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Runtime.CompilerServices;
+﻿using System;
 using Windows.UI;
 using Windows.UI.ViewManagement;
 using System.ComponentModel;
@@ -22,43 +21,6 @@ namespace Uno.Toolkit.UI
 	{
 		private static readonly ILogger Logger = typeof(SystemThemeHelper).Log();
 
-		// Maps a XamlRoot to the app's own root element, for apps hosted under a XamlRoot they
-		// don't own. Held weakly on both sides so an unloaded app is not kept alive.
-		private static readonly ConditionalWeakTable<XamlRoot, WeakReference<FrameworkElement>> _appRootOverrides = new();
-
-		/// <summary>
-		/// Registers the element to treat as the app's root for the given XamlRoot, in place of
-		/// <see cref="XamlRoot.Content"/>. Pass null to clear the override.
-		/// </summary>
-		internal static void SetAppRootOverride(XamlRoot root, FrameworkElement? appRoot)
-		{
-			if (appRoot is null)
-			{
-				_appRootOverrides.Remove(root);
-			}
-			else
-			{
-				_appRootOverrides.AddOrUpdate(root, new WeakReference<FrameworkElement>(appRoot));
-			}
-		}
-
-		internal static FrameworkElement? ResolveThemeTarget(XamlRoot? root)
-		{
-			if (root is null)
-			{
-				return null;
-			}
-
-			if (_appRootOverrides.TryGetValue(root, out var weakAppRoot) &&
-				weakAppRoot.TryGetTarget(out var appRoot) &&
-				appRoot.XamlRoot == root)
-			{
-				return appRoot;
-			}
-
-			return root.Content as FrameworkElement;
-		}
-
 		/// <summary>
 		/// Get the current theme of the operating system.
 		/// </summary>
@@ -74,16 +36,24 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Get the current theme of the application.
 		/// </summary>
-		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(XamlRoot root) instead.")]
+		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(Window window) or GetRootTheme(FrameworkElement root) instead.")]
 		public static ApplicationTheme GetApplicationTheme()
 			=> GetRootTheme(GetWindowRoot()?.XamlRoot);
 
 		/// <summary>
 		/// Gets a <see cref="ApplicationTheme"/> from the provided XamlRoot.
 		/// </summary>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="GetRootTheme(FrameworkElement?)"/> there.</remarks>
 		public static ApplicationTheme GetRootTheme(XamlRoot? root)
+			=> GetRootTheme(root?.Content as FrameworkElement);
+
+		/// <summary>
+		/// Gets a <see cref="ApplicationTheme"/> from the provided root element.
+		/// </summary>
+		/// <param name="root">The app's root element, typically the window's content.</param>
+		public static ApplicationTheme GetRootTheme(FrameworkElement? root)
 		{
-			return ResolveThemeTarget(root)?.ActualTheme switch
+			return root?.ActualTheme switch
 			{
 				ElementTheme.Light => ApplicationTheme.Light,
 				ElementTheme.Dark => ApplicationTheme.Dark,
@@ -93,46 +63,108 @@ namespace Uno.Toolkit.UI
 		}
 
 		/// <summary>
+		/// Gets a <see cref="ApplicationTheme"/> from the content of the provided window.
+		/// </summary>
+		/// <param name="window">The app's window.</param>
+		public static ApplicationTheme GetRootTheme(XamlWindow? window)
+			=> GetRootTheme(window?.Content as FrameworkElement);
+
+		/// <summary>
 		/// Get if the application is currently in dark mode.
 		/// </summary>
-		[Obsolete("IsAppInDarkMode is obsolete. Use IsRootInDarkMode(XamlRoot root) instead.")]
+		[Obsolete("IsAppInDarkMode is obsolete. Use IsRootInDarkMode(Window window) or IsRootInDarkMode(FrameworkElement root) instead.")]
 		public static bool IsAppInDarkMode()
 			=> GetRootTheme(GetWindowRoot().XamlRoot) == ApplicationTheme.Dark;
 
+		/// <summary>
+		/// Gets whether the content of the provided XamlRoot is currently in dark mode.
+		/// </summary>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="IsRootInDarkMode(FrameworkElement)"/> there.</remarks>
 		public static bool IsRootInDarkMode(XamlRoot root)
 			=> GetRootTheme(root) == ApplicationTheme.Dark;
 
-		[Obsolete("SetApplicationTheme(bool darkMode) is obsolete. Use SetApplicationTheme(XamlRoot? root, ElementTheme theme) instead.")]
+		/// <summary>
+		/// Gets whether the provided root element is currently in dark mode.
+		/// </summary>
+		/// <param name="root">The app's root element, typically the window's content.</param>
+		public static bool IsRootInDarkMode(FrameworkElement root)
+			=> GetRootTheme(root) == ApplicationTheme.Dark;
+
+		/// <summary>
+		/// Gets whether the content of the provided window is currently in dark mode.
+		/// </summary>
+		/// <param name="window">The app's window.</param>
+		public static bool IsRootInDarkMode(XamlWindow window)
+			=> GetRootTheme(window) == ApplicationTheme.Dark;
+
+		[Obsolete("SetApplicationTheme(bool darkMode) is obsolete. Use SetApplicationTheme(Window? window, ElementTheme theme) or SetApplicationTheme(FrameworkElement? root, ElementTheme theme) instead.")]
 		public static void SetApplicationTheme(bool darkMode)
 			=> SetRootTheme(GetWindowRoot().XamlRoot, darkMode);
 
 		/// <summary>
 		/// Sets the theme for the provided XamlRoot
 		/// </summary>
-		/// <param name="root"></param>
-		/// <param name="darkMode"></param>
+		/// <param name="root">The XamlRoot whose content to theme.</param>
+		/// <param name="darkMode">Whether to apply the dark theme.</param>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="SetRootTheme(FrameworkElement?, bool)"/> there.</remarks>
 		public static void SetRootTheme(XamlRoot? root, bool darkMode)
+			=> SetRootTheme(root?.Content as FrameworkElement, darkMode);
+
+		/// <summary>
+		/// Sets the theme for the provided root element and its subtree.
+		/// </summary>
+		/// <param name="root">The app's root element, typically the window's content.</param>
+		/// <param name="darkMode">Whether to apply the dark theme.</param>
+		public static void SetRootTheme(FrameworkElement? root, bool darkMode)
 			=> SetApplicationTheme(root, darkMode ? ElementTheme.Dark : ElementTheme.Light);
 
+		/// <summary>
+		/// Sets the theme for the content of the provided window.
+		/// </summary>
+		/// <param name="window">The app's window.</param>
+		/// <param name="darkMode">Whether to apply the dark theme.</param>
+		public static void SetRootTheme(XamlWindow? window, bool darkMode)
+			=> SetRootTheme(window?.Content as FrameworkElement, darkMode);
+
+		/// <summary>
+		/// Sets the theme for the content of the provided XamlRoot.
+		/// </summary>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="SetApplicationTheme(FrameworkElement?, ElementTheme)"/> there.</remarks>
 		public static void SetApplicationTheme(XamlRoot? root, ElementTheme theme)
+			=> SetApplicationTheme(root?.Content as FrameworkElement, theme);
+
+		/// <summary>
+		/// Sets the theme for the provided root element and its subtree.
+		/// </summary>
+		/// <param name="root">The app's root element, typically the window's content.</param>
+		/// <param name="theme">The theme to apply.</param>
+		public static void SetApplicationTheme(FrameworkElement? root, ElementTheme theme)
 		{
-			if (ResolveThemeTarget(root) is { } target)
+			if (root is not null)
 			{
-				target.RequestedTheme = theme;
+				root.RequestedTheme = theme;
 			}
 			else
 			{
-				Logger.WarnIfEnabled(() => "No root element to apply the theme to (XamlRoot is null, or its content is not a FrameworkElement).");
+				Logger.WarnIfEnabled(() => "No root element to apply the theme to (window/XamlRoot content not set, or not a FrameworkElement).");
 			}
 		}
 
-		[Obsolete("ToggleApplicationTheme() is obsolete. Use SetApplicationTheme(XamlRoot? root, ElementTheme theme) instead.")]
+		/// <summary>
+		/// Sets the theme for the content of the provided window.
+		/// </summary>
+		/// <param name="window">The app's window.</param>
+		/// <param name="theme">The theme to apply.</param>
+		public static void SetApplicationTheme(XamlWindow? window, ElementTheme theme)
+			=> SetApplicationTheme(window?.Content as FrameworkElement, theme);
+
+		[Obsolete("ToggleApplicationTheme() is obsolete. Use IsRootInDarkMode + SetRootTheme with the app's Window or root element instead.")]
 		public static void ToggleApplicationTheme()
 			=> SetApplicationTheme(darkMode: !IsAppInDarkMode());
 
 		private static FrameworkElement GetWindowRoot() =>
 #if IS_WINUI
-			throw new NotSupportedException($"This method is not supported with WinUI, use methods that take a XamlRoot as a parameter");
+			throw new NotSupportedException($"This method is not supported with WinUI, use the overloads that take the app's Window or root FrameworkElement (or a XamlRoot).");
 #else
 			XamlWindow.Current?.Content as FrameworkElement ??
 			throw new InvalidOperationException($"The current window content is not {(XamlWindow.Current?.Content == null ? "set" : "a FrameworkElement")}.");

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -43,7 +43,7 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Gets a <see cref="ApplicationTheme"/> from the provided XamlRoot.
 		/// </summary>
-		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="GetRootTheme(FrameworkElement?)"/> there.</remarks>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root when the app is hosted under a XamlRoot it does not own; use <see cref="GetRootTheme(FrameworkElement?)"/> in that case.</remarks>
 		public static ApplicationTheme GetRootTheme(XamlRoot? root)
 			=> GetRootTheme(root?.Content as FrameworkElement);
 
@@ -79,7 +79,7 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Gets whether the content of the provided XamlRoot is currently in dark mode.
 		/// </summary>
-		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="IsRootInDarkMode(FrameworkElement)"/> there.</remarks>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root when the app is hosted under a XamlRoot it does not own; use <see cref="IsRootInDarkMode(FrameworkElement)"/> in that case.</remarks>
 		public static bool IsRootInDarkMode(XamlRoot root)
 			=> GetRootTheme(root) == ApplicationTheme.Dark;
 
@@ -106,7 +106,7 @@ namespace Uno.Toolkit.UI
 		/// </summary>
 		/// <param name="root">The XamlRoot whose content to theme.</param>
 		/// <param name="darkMode">Whether to apply the dark theme.</param>
-		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="SetRootTheme(FrameworkElement?, bool)"/> there.</remarks>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root when the app is hosted under a XamlRoot it does not own; use <see cref="SetRootTheme(FrameworkElement?, bool)"/> in that case.</remarks>
 		public static void SetRootTheme(XamlRoot? root, bool darkMode)
 			=> SetRootTheme(root?.Content as FrameworkElement, darkMode);
 
@@ -129,7 +129,7 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Sets the theme for the content of the provided XamlRoot.
 		/// </summary>
-		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="SetApplicationTheme(FrameworkElement?, ElementTheme)"/> there.</remarks>
+		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root when the app is hosted under a XamlRoot it does not own; use <see cref="SetApplicationTheme(FrameworkElement?, ElementTheme)"/> in that case.</remarks>
 		public static void SetApplicationTheme(XamlRoot? root, ElementTheme theme)
 			=> SetApplicationTheme(root?.Content as FrameworkElement, theme);
 

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -38,7 +38,7 @@ namespace Uno.Toolkit.UI
 		/// </summary>
 		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(Window window) or GetRootTheme(FrameworkElement root) instead.")]
 		public static ApplicationTheme GetApplicationTheme()
-			=> GetRootTheme(GetWindowRoot()?.XamlRoot);
+			=> GetRootTheme(GetWindowRoot().XamlRoot);
 
 		/// <summary>
 		/// Gets a <see cref="ApplicationTheme"/> from the provided XamlRoot.

--- a/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
+++ b/src/Uno.Toolkit.UI/Helpers/SystemThemeHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Runtime.CompilerServices;
 using Windows.UI;
 using Windows.UI.ViewManagement;
 using System.ComponentModel;
@@ -21,6 +22,49 @@ namespace Uno.Toolkit.UI
 	{
 		private static readonly ILogger Logger = typeof(SystemThemeHelper).Log();
 
+		// Maps a XamlRoot to the app's own root element, for apps hosted under a XamlRoot they don't
+		// own (e.g. Hot Design re-parents the app's Window.Content into the host's shared XamlRoot,
+		// so XamlRoot.Content resolves to the host's root, not the app's). Registered by the hosting
+		// integration via SetAppRootOverride. Both key and value are held weakly so an unloaded app
+		// (collectible ALC) is not kept alive.
+		private static readonly ConditionalWeakTable<XamlRoot, WeakReference<FrameworkElement>> _appRootOverrides = new();
+
+		/// <summary>
+		/// Registers the element to be treated as the app's root for the given XamlRoot, in place of
+		/// <see cref="XamlRoot.Content"/>. Used by hosting integrations (e.g. Hot Design) when an app's
+		/// content is re-parented under a XamlRoot it doesn't own. Pass null to clear the override.
+		/// </summary>
+		internal static void SetAppRootOverride(XamlRoot root, FrameworkElement? appRoot)
+		{
+			if (appRoot is null)
+			{
+				_appRootOverrides.Remove(root);
+			}
+			else
+			{
+				_appRootOverrides.AddOrUpdate(root, new WeakReference<FrameworkElement>(appRoot));
+			}
+		}
+
+		// Resolves the element whose theme is read/written for the given XamlRoot: the registered
+		// app-root override when it is alive and still attached to that XamlRoot, else XamlRoot.Content.
+		internal static FrameworkElement? ResolveThemeTarget(XamlRoot? root)
+		{
+			if (root is null)
+			{
+				return null;
+			}
+
+			if (_appRootOverrides.TryGetValue(root, out var weakAppRoot) &&
+				weakAppRoot.TryGetTarget(out var appRoot) &&
+				appRoot.XamlRoot == root)
+			{
+				return appRoot;
+			}
+
+			return root.Content as FrameworkElement;
+		}
+
 		/// <summary>
 		/// Get the current theme of the operating system.
 		/// </summary>
@@ -36,24 +80,16 @@ namespace Uno.Toolkit.UI
 		/// <summary>
 		/// Get the current theme of the application.
 		/// </summary>
-		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(Window window) or GetRootTheme(FrameworkElement root) instead.")]
+		[Obsolete("GetApplicationTheme is obsolete. Use GetRootTheme(XamlRoot root) instead.")]
 		public static ApplicationTheme GetApplicationTheme()
 			=> GetRootTheme(GetWindowRoot()?.XamlRoot);
 
 		/// <summary>
 		/// Gets a <see cref="ApplicationTheme"/> from the provided XamlRoot.
 		/// </summary>
-		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="GetRootTheme(FrameworkElement?)"/> there.</remarks>
 		public static ApplicationTheme GetRootTheme(XamlRoot? root)
-			=> GetRootTheme(root?.Content as FrameworkElement);
-
-		/// <summary>
-		/// Gets a <see cref="ApplicationTheme"/> from the provided root element.
-		/// </summary>
-		/// <param name="root">The app's root element, typically the window's content.</param>
-		public static ApplicationTheme GetRootTheme(FrameworkElement? root)
 		{
-			return root?.ActualTheme switch
+			return ResolveThemeTarget(root)?.ActualTheme switch
 			{
 				ElementTheme.Light => ApplicationTheme.Light,
 				ElementTheme.Dark => ApplicationTheme.Dark,
@@ -63,108 +99,46 @@ namespace Uno.Toolkit.UI
 		}
 
 		/// <summary>
-		/// Gets a <see cref="ApplicationTheme"/> from the content of the provided window.
-		/// </summary>
-		/// <param name="window">The app's window.</param>
-		public static ApplicationTheme GetRootTheme(XamlWindow? window)
-			=> GetRootTheme(window?.Content as FrameworkElement);
-
-		/// <summary>
 		/// Get if the application is currently in dark mode.
 		/// </summary>
-		[Obsolete("IsAppInDarkMode is obsolete. Use IsRootInDarkMode(Window window) or IsRootInDarkMode(FrameworkElement root) instead.")]
+		[Obsolete("IsAppInDarkMode is obsolete. Use IsRootInDarkMode(XamlRoot root) instead.")]
 		public static bool IsAppInDarkMode()
 			=> GetRootTheme(GetWindowRoot().XamlRoot) == ApplicationTheme.Dark;
 
-		/// <summary>
-		/// Gets whether the content of the provided XamlRoot is currently in dark mode.
-		/// </summary>
-		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="IsRootInDarkMode(FrameworkElement)"/> there.</remarks>
 		public static bool IsRootInDarkMode(XamlRoot root)
 			=> GetRootTheme(root) == ApplicationTheme.Dark;
 
-		/// <summary>
-		/// Gets whether the provided root element is currently in dark mode.
-		/// </summary>
-		/// <param name="root">The app's root element, typically the window's content.</param>
-		public static bool IsRootInDarkMode(FrameworkElement root)
-			=> GetRootTheme(root) == ApplicationTheme.Dark;
-
-		/// <summary>
-		/// Gets whether the content of the provided window is currently in dark mode.
-		/// </summary>
-		/// <param name="window">The app's window.</param>
-		public static bool IsRootInDarkMode(XamlWindow window)
-			=> GetRootTheme(window) == ApplicationTheme.Dark;
-
-		[Obsolete("SetApplicationTheme(bool darkMode) is obsolete. Use SetApplicationTheme(Window? window, ElementTheme theme) or SetApplicationTheme(FrameworkElement? root, ElementTheme theme) instead.")]
+		[Obsolete("SetApplicationTheme(bool darkMode) is obsolete. Use SetApplicationTheme(XamlRoot? root, ElementTheme theme) instead.")]
 		public static void SetApplicationTheme(bool darkMode)
 			=> SetRootTheme(GetWindowRoot().XamlRoot, darkMode);
 
 		/// <summary>
 		/// Sets the theme for the provided XamlRoot
 		/// </summary>
-		/// <param name="root">The XamlRoot whose content to theme.</param>
-		/// <param name="darkMode">Whether to apply the dark theme.</param>
-		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="SetRootTheme(FrameworkElement?, bool)"/> there.</remarks>
+		/// <param name="root"></param>
+		/// <param name="darkMode"></param>
 		public static void SetRootTheme(XamlRoot? root, bool darkMode)
-			=> SetRootTheme(root?.Content as FrameworkElement, darkMode);
-
-		/// <summary>
-		/// Sets the theme for the provided root element and its subtree.
-		/// </summary>
-		/// <param name="root">The app's root element, typically the window's content.</param>
-		/// <param name="darkMode">Whether to apply the dark theme.</param>
-		public static void SetRootTheme(FrameworkElement? root, bool darkMode)
 			=> SetApplicationTheme(root, darkMode ? ElementTheme.Dark : ElementTheme.Light);
 
-		/// <summary>
-		/// Sets the theme for the content of the provided window.
-		/// </summary>
-		/// <param name="window">The app's window.</param>
-		/// <param name="darkMode">Whether to apply the dark theme.</param>
-		public static void SetRootTheme(XamlWindow? window, bool darkMode)
-			=> SetRootTheme(window?.Content as FrameworkElement, darkMode);
-
-		/// <summary>
-		/// Sets the theme for the content of the provided XamlRoot.
-		/// </summary>
-		/// <remarks>Targets <see cref="XamlRoot.Content"/>, which is the host's root under a foreign XamlRoot (e.g. Hot Design); prefer <see cref="SetApplicationTheme(FrameworkElement?, ElementTheme)"/> there.</remarks>
 		public static void SetApplicationTheme(XamlRoot? root, ElementTheme theme)
-			=> SetApplicationTheme(root?.Content as FrameworkElement, theme);
-
-		/// <summary>
-		/// Sets the theme for the provided root element and its subtree.
-		/// </summary>
-		/// <param name="root">The app's root element, typically the window's content.</param>
-		/// <param name="theme">The theme to apply.</param>
-		public static void SetApplicationTheme(FrameworkElement? root, ElementTheme theme)
 		{
-			if (root is not null)
+			if (ResolveThemeTarget(root) is { } target)
 			{
-				root.RequestedTheme = theme;
+				target.RequestedTheme = theme;
 			}
 			else
 			{
-				Logger.WarnIfEnabled(() => "No root element to apply the theme to (window/XamlRoot content not set, or not a FrameworkElement).");
+				Logger.WarnIfEnabled(() => "No root element to apply the theme to (XamlRoot is null, or its content is not a FrameworkElement).");
 			}
 		}
 
-		/// <summary>
-		/// Sets the theme for the content of the provided window.
-		/// </summary>
-		/// <param name="window">The app's window.</param>
-		/// <param name="theme">The theme to apply.</param>
-		public static void SetApplicationTheme(XamlWindow? window, ElementTheme theme)
-			=> SetApplicationTheme(window?.Content as FrameworkElement, theme);
-
-		[Obsolete("ToggleApplicationTheme() is obsolete. Use IsRootInDarkMode + SetRootTheme with the app's Window or root element instead.")]
+		[Obsolete("ToggleApplicationTheme() is obsolete. Use SetApplicationTheme(XamlRoot? root, ElementTheme theme) instead.")]
 		public static void ToggleApplicationTheme()
 			=> SetApplicationTheme(darkMode: !IsAppInDarkMode());
 
 		private static FrameworkElement GetWindowRoot() =>
 #if IS_WINUI
-			throw new NotSupportedException($"This method is not supported with WinUI, use the overloads that take the app's Window or root FrameworkElement (or a XamlRoot).");
+			throw new NotSupportedException($"This method is not supported with WinUI, use methods that take a XamlRoot as a parameter");
 #else
 			XamlWindow.Current?.Content as FrameworkElement ??
 			throw new InvalidOperationException($"The current window content is not {(XamlWindow.Current?.Content == null ? "set" : "a FrameworkElement")}.");


### PR DESCRIPTION
GitHub Issue (If applicable): related to unoplatform/uno.extensions#3120 (this is the Toolkit counterpart)

## PR Type

- Feature (additive API; fixes theming for ALC-hosted apps)

## What is the current behavior?

All `SystemThemeHelper` members resolve theme reads/writes through `XamlRoot.Content` - the root visual of the XamlRoot. When an app is hosted under a XamlRoot it does not own (an inner Uno app loaded via a collectible AssemblyLoadContext, whose content is re-parented into the host's shared XamlRoot - the inner app has no XamlRoot of its own), `XamlRoot.Content` is the **host's** root: toggling the theme re-themes the host and reads report the host's theme. Standalone apps are unaffected (`window.Content == XamlRoot.Content`).

unoplatform/uno.extensions#3121 fixes the same bug in `ThemeService`.

## What is the new behavior?

Additive `FrameworkElement` and `Window` overloads of `GetRootTheme` / `IsRootInDarkMode` / `SetRootTheme` / `SetApplicationTheme` that read/write the theme on the caller-supplied app root (typically `window.Content`).

- The `XamlRoot` overloads remain the non-obsolete, default API for normal situations (nothing is obsoleted); their behavior is unchanged, and they now delegate internally to the element overloads.
- In ALC-hosted situations the app passes its own root element or window to the new overloads.
- Null root: `Set*` is a no-op with a warning log; `Get*` falls back to the OS theme.
- Docs updated accordingly (XamlRoot as default; root/window overloads for hosted apps).
- Interim solution until Uno itself exposes app-content-root resolution (e.g. `GetAppContentRoot(this FrameworkElement)` walking up to an `AlcContentHost` boundary), at which point resolution can move to the platform API.

Runtime tests (Skia desktop head, all green): hosted topology in both directions (theme lands on the app root; host and `XamlRoot.Content` untouched; reads observe it), subtree inheritance, `Window` overload, null arguments; pre-existing `ThemeInitTests` still green.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current supported SDKs
- [x] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI (Skia desktop runtime tests)
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed (doc/helpers + walkthrough)
- [x] Runtime Tests for the changes have been added
- [x] Contains **NO** breaking changes (see note below)
- [x] Associated with an issue (internal SL-2740; related unoplatform/uno.extensions#3120)
- [x] Commits follow Conventional Commits

**Compatibility note:** binary-compatible, additive minor. One theoretical source-compat edge inherent to adding overloads: a literal `null` first argument (e.g. `SetRootTheme(null, true)`, previously a no-op) now fails with CS0121 ambiguity; workaround is a cast such as `(XamlRoot?)null`. Method groups of these members also lose their natural type.

## Other information

Internal Issue (If applicable): SL-2740

🤖 Generated with [Claude Code](https://claude.com/claude-code)