### PR TITLE
fix(ZoomContentControl): re-fit/center when AdditionalMargin changes

### DIFF
--- a/build/workflow/cspell.json
+++ b/build/workflow/cspell.json
@@ -78,6 +78,7 @@
 		"roadmap",
 		"safearea",
 		"sandboxed",
+		"scrollbars",
 		"Segoe",
 		"Silverlight",
 		"Skia",

--- a/doc/controls/ZoomContentControl.md
+++ b/doc/controls/ZoomContentControl.md
@@ -43,7 +43,7 @@ xmlns:utu="using:Uno.Toolkit.UI"
 | `AutoFitToCanvas`   | `bool`                              | Gets or sets a value indicating whether the content should be automatically scaled to fit within the viewport. |
 | `AutoCenterContent` | `bool`                              | Gets or sets a value indicating whether the content should be automatically centered within the viewport.      |
 | `AllowFreePanning`  | `bool`                              | Gets or sets a value indicating whether content can be panned outside of the viewport.                         |
-| `AdditionalMargin`  | `Thickness`                         | Gets or sets additional margins around the content.                                                            |
+| `AdditionalMargin`  | `Thickness`                         | Gets or sets additional margins that inset the usable viewport around the content. Changing it re-runs the auto fit/center pass (honoring `AutoFitToCanvas`/`AutoCenterContent`), like a viewport-size change. |
 | `ScrollBarLayout`   | `ZoomContentControlScrollBarLayout` | Gets or sets the layout style of the scroll bars.                                                              |
 | `ElementOnFocus`    | `FrameworkElement`                  | Gets or sets the focused element which auto-zoom and auto-fit will be centered around.                         |
 

--- a/specs/zoomcontentcontrol-refit-on-additionalmargin/spec.md
+++ b/specs/zoomcontentcontrol-refit-on-additionalmargin/spec.md
@@ -1,0 +1,70 @@
+# Feature: `ZoomContentControl` re-fits/re-centers when `AdditionalMargin` changes
+
+**Area**: `Uno.Toolkit.UI` — `Controls/ZoomContentControl`
+**Type**: Bug fix / behavioral consistency
+
+## Summary
+
+`ZoomContentControl.AdditionalMargin` insets the usable viewport — it is subtracted from the viewport in `FitToCanvas` and in the centering math (`ClippedViewportSize`, `PaddedScaledContentSize`). Changing every *other* input that affects the fitted/centered layout (viewport size, content size, content reload) re-runs the auto fit/center pass, but changing `AdditionalMargin` does not. As a result, after a margin change the content stays fitted/centered against the **previous** margin until some unrelated size/zoom change happens to re-fit.
+
+This request makes an `AdditionalMargin` change re-run the auto fit/center pass, consistent with the other layout-affecting inputs.
+
+## Current behavior
+
+`OnAdditionalMarginChanged` only refreshes the scrollbars and raises the outward viewport event:
+
+```csharp
+private void OnAdditionalMarginChanged()
+{
+    UpdateScrollBars();
+    ViewportSizeChanged?.Invoke(this, EventArgs.Empty);
+}
+```
+
+It does **not** call `FitToCanvas` / `CenterContent`. By contrast, `OnViewportSizeChanged`, `OnSizeChanged`, and the content-size/loaded handlers all route through `UpdateScrollDetails()`, which applies `AutoFitToCanvas` → `FitToCanvas()` and `AutoCenterContent` → `CenterContent()`.
+
+### Consequence
+
+With `AutoFitToCanvas="True"` (and/or `AutoCenterContent="True"`), setting or changing `AdditionalMargin` after the content is laid out leaves the content at the zoom/position computed for the *old* margin. When the new margin is larger, the content can extend into (overlap) the region the margin was meant to reserve. A subsequent viewport/content/zoom change corrects it — so the symptom "fixes itself on the next resize," which is the tell-tale of a missing re-fit trigger.
+
+## Expected behavior
+
+Changing `AdditionalMargin` MUST re-run the auto fit/center pass, exactly as a viewport-size change does:
+
+- When `AutoFitToCanvas` is `true`, the content is re-fitted so it fits within the viewport **minus the new margin** (`ZoomLevel` recomputed).
+- When `AutoCenterContent` is `true`, the content is re-centered within the viewport minus the new margin.
+- When both auto flags are `false`, `ZoomLevel` and position are left unchanged (the margin still affects scrollbars/clipping, but no automatic re-fit is forced — same opt-in contract as size changes).
+- Scrollbars continue to update, and `ViewportSizeChanged` is still raised (the usable — clipped — viewport did change).
+
+## Design
+
+A margin change is effectively a change to the usable viewport (`ClippedViewportSize = ViewportSize.Subtract(AdditionalMargin)`), so `OnAdditionalMarginChanged` should mirror `OnViewportSizeChanged`:
+
+```csharp
+private void OnAdditionalMarginChanged()
+{
+    UpdateScrollDetails();               // applies AutoFitToCanvas / AutoCenterContent, then scrollbars
+    ViewportSizeChanged?.Invoke(this, EventArgs.Empty);
+}
+```
+
+`UpdateScrollDetails()` already gates the fit/center on the `AutoFitToCanvas` / `AutoCenterContent` flags, so the opt-in contract is preserved and no new state is introduced. This reuses the single existing "re-apply layout" path rather than duplicating fit/center logic.
+
+## Requirements
+
+- **FR-1** — A change to `AdditionalMargin` re-runs the auto fit/center pass (via `UpdateScrollDetails`).
+- **FR-2** — With `AutoFitToCanvas="True"`, increasing `AdditionalMargin` decreases the fitted `ZoomLevel` (content fits the reduced usable viewport); decreasing it increases the fitted `ZoomLevel`.
+- **FR-3** — With `AutoFitToCanvas="False"`, an `AdditionalMargin` change does not alter `ZoomLevel` (no forced re-fit).
+- **FR-4** — Scrollbars are still updated and `ViewportSizeChanged` is still raised on an `AdditionalMargin` change (no regression).
+
+## Tests
+
+Runtime tests (`src/Uno.Toolkit.RuntimeTests/Tests/`), red/fix/green:
+
+- `When_AdditionalMarginIncreases_AndAutoFit_ThenRefitsToSmallerZoom` — the repro/regression guard for FR-1/FR-2: fit a small content in a fixed viewport, capture the fitted `ZoomLevel`, then set a large `AdditionalMargin` and assert the fitted `ZoomLevel` decreases (fails before the fix — margin change did not re-fit — passes after).
+- `When_AdditionalMarginChanges_AndAutoFitDisabled_ThenZoomUnchanged` — guard for FR-3: with `AutoFitToCanvas=false`, a margin change leaves `ZoomLevel` unchanged.
+
+## Out of scope
+
+- No public API additions or changes; `AdditionalMargin`, `AutoFitToCanvas`, and `AutoCenterContent` are unchanged.
+- No change to how the fit/center math itself works — only to when it re-runs.

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ZoomContentControlAdditionalMarginTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ZoomContentControlAdditionalMarginTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Windows.Foundation;
+using FluentAssertions;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+#else
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class ZoomContentControlAdditionalMarginTests
+	{
+		// Repro + regression guard: a change to AdditionalMargin must re-run the auto fit/center pass,
+		// consistent with a viewport-size change. Before the fix, OnAdditionalMarginChanged only refreshed
+		// the scrollbars, so the content stayed fitted against the previous margin (zoom unchanged).
+		[TestMethod]
+		public async Task When_AdditionalMarginIncreases_AndAutoFit_ThenRefitsToSmallerZoom()
+		{
+			var SUT = new ZoomContentControl
+			{
+				Width = 400,
+				Height = 400,
+				MinZoomLevel = 0.1,
+				MaxZoomLevel = 10,
+				AutoFitToCanvas = true,
+				Content = new Border
+				{
+					Width = 100,
+					Height = 100,
+					Background = new SolidColorBrush(Colors.Blue),
+				},
+			};
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			// The content (smaller than the viewport) is fitted on load.
+			var fittedZoom = SUT.ZoomLevel;
+			fittedZoom.Should().BeGreaterThan(0, "the content should be fitted into the viewport on load");
+
+			// Act — reserve a large inset on every side, shrinking the usable viewport.
+			SUT.AdditionalMargin = new Thickness(100);
+
+			// Assert — the content is re-fitted into the reduced usable viewport, so the fitted zoom
+			// decreases. Before the fix the margin change did not re-fit and the zoom stayed at fittedZoom.
+			SUT.ZoomLevel.Should().BeLessThan(
+				fittedZoom,
+				"a larger AdditionalMargin reduces the usable viewport, so AutoFitToCanvas must re-fit to a smaller zoom");
+		}
+
+		// Guard: the re-fit is opt-in. With AutoFitToCanvas disabled, a margin change must not force a
+		// re-fit (same contract as a viewport-size change).
+		[TestMethod]
+		public async Task When_AdditionalMarginChanges_AndAutoFitDisabled_ThenZoomUnchanged()
+		{
+			var SUT = new ZoomContentControl
+			{
+				Width = 400,
+				Height = 400,
+				MinZoomLevel = 0.1,
+				MaxZoomLevel = 10,
+				AutoFitToCanvas = false,
+				Content = new Border
+				{
+					Width = 100,
+					Height = 100,
+					Background = new SolidColorBrush(Colors.Blue),
+				},
+			};
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			var zoomBefore = SUT.ZoomLevel;
+
+			// Act
+			SUT.AdditionalMargin = new Thickness(100);
+
+			// Assert — no forced re-fit when AutoFitToCanvas is off.
+			SUT.ZoomLevel.Should().Be(
+				zoomBefore,
+				"with AutoFitToCanvas disabled, a margin change must not change the zoom");
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.cs
@@ -345,7 +345,12 @@ partial class ZoomContentControl
 
 	private void OnAdditionalMarginChanged()
 	{
-		UpdateScrollBars();
+		// AdditionalMargin insets the usable viewport (see ClippedViewportSize) and participates in
+		// FitToCanvas/CenterContent, so a margin change is effectively a viewport change. Mirror
+		// OnViewportSizeChanged and re-run the auto fit/center pass (gated on AutoFitToCanvas/
+		// AutoCenterContent inside UpdateScrollDetails); otherwise the content stays fitted/centered
+		// against the previous margin until an unrelated size/zoom change happens to re-fit.
+		UpdateScrollDetails();
 
 		ViewportSizeChanged?.Invoke(this, EventArgs.Empty);
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

- Bugfix

## What is the current behavior?

`ZoomContentControl.AdditionalMargin` insets the usable viewport — it is subtracted from the viewport in `FitToCanvas` and participates in the centering math (`ClippedViewportSize`, `PaddedScaledContentSize`). Every other input that affects the fitted/centered layout (viewport size, content size, content reload) re-runs the auto fit/center pass via `UpdateScrollDetails()`, but a change to `AdditionalMargin` does not — `OnAdditionalMarginChanged` only refreshed the scrollbars:

```csharp
private void OnAdditionalMarginChanged()
{
    UpdateScrollBars();
    ViewportSizeChanged?.Invoke(this, EventArgs.Empty);
}
```

As a result, with `AutoFitToCanvas="True"` (and/or `AutoCenterContent="True"`), setting/changing `AdditionalMargin` after layout leaves the content fitted/centered against the **previous** margin. When the new margin is larger, the content can extend into the region the margin was meant to reserve; a later viewport/content/zoom change corrects it (the tell-tale "fixes itself on the next resize").

## What is the new behavior?

A change to `AdditionalMargin` now re-runs the auto fit/center pass, consistent with a viewport-size change (a margin change *is* effectively a change to the usable viewport). `OnAdditionalMarginChanged` mirrors `OnViewportSizeChanged`:

```csharp
private void OnAdditionalMarginChanged()
{
    UpdateScrollDetails();               // applies AutoFitToCanvas / AutoCenterContent, then scrollbars
    ViewportSizeChanged?.Invoke(this, EventArgs.Empty);
}
```

`UpdateScrollDetails()` already gates the fit/center on `AutoFitToCanvas` / `AutoCenterContent`, so the opt-in contract is preserved (no re-fit is forced when those are `false`), no new state is introduced, and the single existing "re-apply layout" path is reused. Scrollbars still update and `ViewportSizeChanged` is still raised.

**Runtime tests** (`ZoomContentControlAdditionalMarginTests`, red/fix/green):
- `When_AdditionalMarginIncreases_AndAutoFit_ThenRefitsToSmallerZoom` — repro/regression guard: fit a small content in a fixed viewport, then set a large `AdditionalMargin`; the fitted `ZoomLevel` must decrease. Verified **red** (fails on the previous code — margin change did not re-fit) → **green** (passes with the fix), run headless via the Material sample under `xvfb`.
- `When_AdditionalMarginChanges_AndAutoFitDisabled_ThenZoomUnchanged` — guard: with `AutoFitToCanvas="False"`, a margin change does not alter `ZoomLevel`.

Design spec: `specs/zoomcontentcontrol-refit-on-additionalmargin/spec.md`.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current supported SDKs
- [x] Tested the changes where applicable:
	- [x] WinUI (skia-desktop, runtime tests headless via the Material sample)
- [x] Updated the documentation as needed:
	- [x] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls) — `doc/controls/ZoomContentControl.md` (`AdditionalMargin` row)
- [x] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) — self-contained toolkit behavioral fix; no external issue
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

- Release build is clean (0 warnings / 0 errors under `TreatWarningsAsErrors`); Debug build clean.
- No public API change — `AdditionalMargin`, `AutoFitToCanvas`, `AutoCenterContent` are unchanged; only *when* the fit/center re-runs.
- Draft while the full multi-platform runtime matrix is pending (verified on skia-desktop).
