### PR TITLE
docs: Remove dropped Skia GTK/WPF heads from getting-started

### DIFF
--- a/doc/cupertino-getting-started.md
+++ b/doc/cupertino-getting-started.md
@@ -94,6 +94,7 @@ Depending on the type of project template that the Uno Platform application was 
 2. Select the following projects for installation:
     - `PROJECT_NAME.Wasm.csproj`
     - `PROJECT_NAME.Mobile.csproj` (or `PROJECT_NAME.iOS.csproj`, `PROJECT_NAME.Droid.csproj`, and `PROJECT_NAME.macOS.csproj` if you have an existing project)
+    - `PROJECT_NAME.csproj` (the `net*-desktop` Skia Desktop head)
     - `PROJECT_NAME.Windows.csproj` (or `PROJECT_NAME.UWP.csproj` for existing projects)
 3. Add the following resources inside `App.xaml`:
 

--- a/doc/cupertino-getting-started.md
+++ b/doc/cupertino-getting-started.md
@@ -94,8 +94,6 @@ Depending on the type of project template that the Uno Platform application was 
 2. Select the following projects for installation:
     - `PROJECT_NAME.Wasm.csproj`
     - `PROJECT_NAME.Mobile.csproj` (or `PROJECT_NAME.iOS.csproj`, `PROJECT_NAME.Droid.csproj`, and `PROJECT_NAME.macOS.csproj` if you have an existing project)
-    - `PROJECT_NAME.Skia.Gtk.csproj`
-    - `PROJECT_NAME.Skia.WPF.csproj`
     - `PROJECT_NAME.Windows.csproj` (or `PROJECT_NAME.UWP.csproj` for existing projects)
 3. Add the following resources inside `App.xaml`:
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -95,6 +95,7 @@ Depending on the type of project template that the Uno Platform application was 
 2. Select the following projects for installation:
     - `PROJECT_NAME.Wasm.csproj`
     - `PROJECT_NAME.Mobile.csproj` (or `PROJECT_NAME.iOS.csproj`, `PROJECT_NAME.Droid.csproj`, and `PROJECT_NAME.macOS.csproj` if you have an existing project)
+    - `PROJECT_NAME.csproj` (the `net*-desktop` Skia Desktop head)
     - `PROJECT_NAME.Windows.csproj` (or `PROJECT_NAME.UWP.csproj` for existing projects)
 3. Add the following resources inside `App.xaml`:
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -95,8 +95,6 @@ Depending on the type of project template that the Uno Platform application was 
 2. Select the following projects for installation:
     - `PROJECT_NAME.Wasm.csproj`
     - `PROJECT_NAME.Mobile.csproj` (or `PROJECT_NAME.iOS.csproj`, `PROJECT_NAME.Droid.csproj`, and `PROJECT_NAME.macOS.csproj` if you have an existing project)
-    - `PROJECT_NAME.Skia.Gtk.csproj`
-    - `PROJECT_NAME.Skia.WPF.csproj`
     - `PROJECT_NAME.Windows.csproj` (or `PROJECT_NAME.UWP.csproj` for existing projects)
 3. Add the following resources inside `App.xaml`:
 

--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -122,6 +122,7 @@ Depending on the type of project template that the Uno Platform application was 
 2. Select the following projects for installation:
     - `PROJECT_NAME.Wasm.csproj`
     - `PROJECT_NAME.Mobile.csproj` (or `PROJECT_NAME.iOS.csproj`, `PROJECT_NAME.Droid.csproj`, and `PROJECT_NAME.macOS.csproj` if you have an existing project)
+    - `PROJECT_NAME.csproj` (the `net*-desktop` Skia Desktop head)
     - `PROJECT_NAME.Windows.csproj` (or `PROJECT_NAME.UWP.csproj` for existing projects)
 3. Add the following resources inside `App.xaml`:
 

--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -122,8 +122,6 @@ Depending on the type of project template that the Uno Platform application was 
 2. Select the following projects for installation:
     - `PROJECT_NAME.Wasm.csproj`
     - `PROJECT_NAME.Mobile.csproj` (or `PROJECT_NAME.iOS.csproj`, `PROJECT_NAME.Droid.csproj`, and `PROJECT_NAME.macOS.csproj` if you have an existing project)
-    - `PROJECT_NAME.Skia.Gtk.csproj`
-    - `PROJECT_NAME.Skia.WPF.csproj`
     - `PROJECT_NAME.Windows.csproj` (or `PROJECT_NAME.UWP.csproj` for existing projects)
 3. Add the following resources inside `App.xaml`:
 

--- a/doc/simple-getting-started.md
+++ b/doc/simple-getting-started.md
@@ -113,6 +113,7 @@ Depending on the type of project template that the Uno Platform application was 
 2. Select the following projects for installation:
     - `PROJECT_NAME.Wasm.csproj`
     - `PROJECT_NAME.Mobile.csproj` (or `PROJECT_NAME.iOS.csproj`, `PROJECT_NAME.Droid.csproj`, and `PROJECT_NAME.macOS.csproj` if you have an existing project)
+    - `PROJECT_NAME.csproj` (the `net*-desktop` Skia Desktop head)
     - `PROJECT_NAME.Windows.csproj` (or `PROJECT_NAME.UWP.csproj` for existing projects)
 3. Add the following resources inside `App.xaml`:
 

--- a/doc/simple-getting-started.md
+++ b/doc/simple-getting-started.md
@@ -113,8 +113,6 @@ Depending on the type of project template that the Uno Platform application was 
 2. Select the following projects for installation:
     - `PROJECT_NAME.Wasm.csproj`
     - `PROJECT_NAME.Mobile.csproj` (or `PROJECT_NAME.iOS.csproj`, `PROJECT_NAME.Droid.csproj`, and `PROJECT_NAME.macOS.csproj` if you have an existing project)
-    - `PROJECT_NAME.Skia.Gtk.csproj`
-    - `PROJECT_NAME.Skia.WPF.csproj`
     - `PROJECT_NAME.Windows.csproj` (or `PROJECT_NAME.UWP.csproj` for existing projects)
 3. Add the following resources inside `App.xaml`:
 


### PR DESCRIPTION
## What changed?

📚 Documentation content changes

Four getting-started guides listed two Skia desktop heads that no longer exist:

- `PROJECT_NAME.Skia.Gtk.csproj` — the **Skia GTK** runtime was removed in Uno Platform 6.0.
- `PROJECT_NAME.Skia.WPF.csproj` — the **Skia WPF** runtime was removed in Uno Platform 6.6.

Both lines are dropped from the manual project-selection lists in `doc/getting-started.md`, `doc/simple-getting-started.md`, `doc/material-getting-started.md`, and `doc/cupertino-getting-started.md`. Modern Uno apps use the single-project `net*-desktop` (Win32/X11/macOS) Skia Desktop head.

## Related to the dropped targets

- **WPF drop**: unoplatform/uno#23260 (issue) · unoplatform/uno#23261 (PR)
- **GTK drop**: unoplatform/uno#19752 (PR)

Documentation-only change.
