### PR TITLE
Version bump after 9.0 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "9.0-dev.{height}",
+  "version": "9.0",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "9.0-dev.{height}",
+  "version": "9.1-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/9.0, based on #1611