### PR TITLE
chore: bump uno.sdk.private and themes to latest stable

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
 	"msbuild-sdks": {
 		"Uno.Sdk": "6.5.31",
-		"Uno.Sdk.Private": "6.6.0-dev.982"
+		"Uno.Sdk.Private": "6.6.166"
 	},
   "sdk":{
     "allowPrerelease": false

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<SkiaSharpVersion>3.119.2</SkiaSharpVersion>
-		<UnoThemesVersion>7.0.0-dev.35</UnoThemesVersion>
+		<UnoThemesVersion>7.0.1</UnoThemesVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <UnoThemesVersion>7.0.0-dev.35</UnoThemesVersion>
+    <UnoThemesVersion>7.0.1</UnoThemesVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.14" />


### PR DESCRIPTION
This pull request updates dependency versions to use stable releases for both the Uno Themes library and the Uno SDK in the project configuration files. These changes help ensure greater stability and compatibility across the codebase.

**Dependency version updates:**

* Updated `UnoThemesVersion` from `7.0.0-dev.35` to the stable `7.0.1` in both `samples/Directory.Packages.props` and `src/Directory.Packages.props` to use the latest stable Uno Themes package. [[1]](diffhunk://#diff-8f89fce241ca6b7cc6aadbd5301d1568306ec7cc6b53117a6ed2b48816991e11L5-R5) [[2]](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11L4-R4)
* Updated `Uno.Sdk.Private` from `6.6.0-dev.982` to stable `6.6.166` in `global.json` for improved SDK stability.