### PR TITLE
fix(deps): Pin UnoThemesVersion to 7.0.3 for 6.6 SR2

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<SkiaSharpVersion>3.119.2</SkiaSharpVersion>
-		<UnoThemesVersion>7.0.1</UnoThemesVersion>
+		<UnoThemesVersion>7.0.3</UnoThemesVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <UnoThemesVersion>7.0.1</UnoThemesVersion>
+    <UnoThemesVersion>7.0.3</UnoThemesVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.14" />


### PR DESCRIPTION
> **Draft** — waiting on the Uno.Themes `7.0.3` stable to finish publishing ([build 224627](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=224627&view=results)) before this can build/merge.

## Summary

Re-pin `UnoThemesVersion` from `7.0.1` to **`7.0.3`** in `src/` and `samples/` `Directory.Packages.props`, for the **6.6 SR2** Simple design system.

`7.0.1` was never published to nuget.org (the phantom-stable class fixed on `main` in #1616); the real published Themes stable for SR2 is **`7.0.3`** (from `uno.fonts`… Uno.Themes [`release/stable/7.0`](https://github.com/unoplatform/Uno.Themes/tree/release/stable/7.0), which just re-pinned `Uno.Fonts.Inter → 2.9.4`).

Via the Uno.Sdk `ImplicitPackagesResolver`, `$(UnoThemesVersion)` overrides the whole Themes group, so this points the toolkit's flavor packages — `Uno.Toolkit.WinUI.Simple` (`Uno.Simple.WinUI`), `.Material`, `.Cupertino`, and `Uno.Themes.WinUI` — at the **published** `7.0.3` stable.

## Scope

Only `UnoThemesVersion`. The remaining `-dev` pins are intentionally left (same rationale as the Themes PR):
- `Uno.XamlMerge.Task 1.32.0-dev.61` — `PrivateAssets="All"` (build-time, doesn't flow).
- `Uno.UI.RuntimeTests.Engine` / `Uno.WinUI.DevServer` / `Uno.UITest*` — test-project only, don't ship in the toolkit packages.

Related to https://github.com/unoplatform/private/issues/1102