### PR TITLE
feat(tabbar): add built-in accessibility support

### DIFF
--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
@@ -569,9 +569,9 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 
 			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
 
-			var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as TabBarAutomationPeer;
-			Assert.IsNotNull(peer, "TabBar should expose a TabBarAutomationPeer");
-			Assert.AreEqual(AutomationControlType.Tab, peer!.GetAutomationControlType());
+			var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as TabBarAutomationPeer
+				?? throw new AssertFailedException("TabBar should expose a TabBarAutomationPeer");
+			Assert.AreEqual(AutomationControlType.Tab, peer.GetAutomationControlType());
 
 			var selectionProvider = peer.GetPattern(PatternInterface.Selection) as ISelectionProvider;
 			Assert.IsNotNull(selectionProvider, "TabBar peer should support the Selection pattern");
@@ -638,14 +638,14 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			var item0 = (TabBarItem)SUT.ContainerFromIndex(0);
 			var item1 = (TabBarItem)SUT.ContainerFromIndex(1);
 
-			var peer0 = FrameworkElementAutomationPeer.CreatePeerForElement(item0) as TabBarItemAutomationPeer;
-			var peer1 = FrameworkElementAutomationPeer.CreatePeerForElement(item1) as TabBarItemAutomationPeer;
-			Assert.IsNotNull(peer0, "TabBarItem should expose a TabBarItemAutomationPeer");
-			Assert.IsNotNull(peer1, "TabBarItem should expose a TabBarItemAutomationPeer");
-			Assert.AreEqual(AutomationControlType.TabItem, peer0!.GetAutomationControlType());
+			var peer0 = FrameworkElementAutomationPeer.CreatePeerForElement(item0) as TabBarItemAutomationPeer
+				?? throw new AssertFailedException("TabBarItem should expose a TabBarItemAutomationPeer");
+			var peer1 = FrameworkElementAutomationPeer.CreatePeerForElement(item1) as TabBarItemAutomationPeer
+				?? throw new AssertFailedException("TabBarItem should expose a TabBarItemAutomationPeer");
+			Assert.AreEqual(AutomationControlType.TabItem, peer0.GetAutomationControlType());
 
 			var selectionItem0 = peer0.GetPattern(PatternInterface.SelectionItem) as ISelectionItemProvider;
-			var selectionItem1 = peer1!.GetPattern(PatternInterface.SelectionItem) as ISelectionItemProvider;
+			var selectionItem1 = peer1.GetPattern(PatternInterface.SelectionItem) as ISelectionItemProvider;
 			Assert.IsNotNull(selectionItem0, "TabBarItem peer should support the SelectionItem pattern");
 			Assert.IsNotNull(selectionItem1, "TabBarItem peer should support the SelectionItem pattern");
 

--- a/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/TabBarTests.cs
@@ -17,6 +17,9 @@ using System.ComponentModel;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI;
@@ -24,6 +27,9 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
@@ -550,6 +556,180 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			Assert.AreEqual(0, setup.SelectedIndex, "SelectedIndex is expected to be 0");
 			Assert.AreEqual(selected, setup.SelectedItem, "SelectedItem is expected to be container#0");
 			Assert.AreEqual(true, selected.IsSelected, "Container#0 should be selected");
+		}
+
+		[TestMethod]
+		public async Task Verify_TabBar_AutomationPeer_ControlType_And_Selection_Pattern()
+		{
+			var source = Enumerable.Range(0, 3).ToArray();
+			var SUT = new TabBar
+			{
+				ItemsSource = source,
+			};
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as TabBarAutomationPeer;
+			Assert.IsNotNull(peer, "TabBar should expose a TabBarAutomationPeer");
+			Assert.AreEqual(AutomationControlType.Tab, peer!.GetAutomationControlType());
+
+			var selectionProvider = peer.GetPattern(PatternInterface.Selection) as ISelectionProvider;
+			Assert.IsNotNull(selectionProvider, "TabBar peer should support the Selection pattern");
+			Assert.IsFalse(selectionProvider!.CanSelectMultiple);
+			Assert.IsFalse(selectionProvider.IsSelectionRequired);
+
+			// No selection yet: GetSelection should be empty.
+			Assert.AreEqual(0, selectionProvider.GetSelection().Length);
+
+			SUT.SelectedIndex = 1;
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			var selection = selectionProvider.GetSelection();
+			Assert.AreEqual(1, selection.Length);
+			Assert.IsNotNull(selection[0]);
+
+			var selectedItem = (TabBarItem)SUT.ContainerFromIndex(1);
+			var nonSelectableItem = (TabBarItem)SUT.ContainerFromIndex(2);
+			nonSelectableItem.IsSelectable = false;
+			SUT.SelectedIndex = 2;
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.IsTrue(selectedItem.IsSelected);
+			Assert.IsFalse(nonSelectableItem.IsSelected);
+			Assert.AreEqual(1, selectionProvider.GetSelection().Length, "GetSelection should return the actual selected item");
+		}
+
+		[TestMethod]
+		public async Task Verify_TabBar_AutomationPeer_Selection_With_TabBarItem_ItemTemplate()
+		{
+			var source = new[] { new TestRecord("Home", true) };
+			var SUT = new TabBar
+			{
+				ItemsSource = source,
+				ItemTemplate = XamlHelper.LoadXaml<DataTemplate>("""
+					<DataTemplate>
+						<utu:TabBarItem Content="{Binding Name}" />
+					</DataTemplate>
+				"""),
+				SelectedIndex = 0,
+			};
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as TabBarAutomationPeer;
+			Assert.IsNotNull(peer);
+
+			var selectionProvider = peer!.GetPattern(PatternInterface.Selection) as ISelectionProvider;
+			Assert.IsNotNull(selectionProvider);
+			Assert.AreEqual(1, selectionProvider!.GetSelection().Length);
+		}
+
+		[TestMethod]
+		public async Task Verify_TabBarItem_AutomationPeer_ControlType_And_Selection_State()
+		{
+			var source = Enumerable.Range(0, 2).ToArray();
+			var SUT = new TabBar
+			{
+				ItemsSource = source,
+			};
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			var item0 = (TabBarItem)SUT.ContainerFromIndex(0);
+			var item1 = (TabBarItem)SUT.ContainerFromIndex(1);
+
+			var peer0 = FrameworkElementAutomationPeer.CreatePeerForElement(item0) as TabBarItemAutomationPeer;
+			var peer1 = FrameworkElementAutomationPeer.CreatePeerForElement(item1) as TabBarItemAutomationPeer;
+			Assert.IsNotNull(peer0, "TabBarItem should expose a TabBarItemAutomationPeer");
+			Assert.IsNotNull(peer1, "TabBarItem should expose a TabBarItemAutomationPeer");
+			Assert.AreEqual(AutomationControlType.TabItem, peer0!.GetAutomationControlType());
+
+			var selectionItem0 = peer0.GetPattern(PatternInterface.SelectionItem) as ISelectionItemProvider;
+			var selectionItem1 = peer1!.GetPattern(PatternInterface.SelectionItem) as ISelectionItemProvider;
+			Assert.IsNotNull(selectionItem0, "TabBarItem peer should support the SelectionItem pattern");
+			Assert.IsNotNull(selectionItem1, "TabBarItem peer should support the SelectionItem pattern");
+
+			Assert.IsFalse(selectionItem0!.IsSelected);
+			Assert.IsFalse(selectionItem1!.IsSelected);
+			Assert.IsNotNull(selectionItem0.SelectionContainer);
+
+			item0.IsSelectable = false;
+			SUT.SelectedIndex = 0;
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.IsFalse(selectionItem0.IsSelected);
+			selectionItem1.AddToSelection();
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.IsTrue(selectionItem1.IsSelected, "A rejected SelectedIndex must not count as an existing selection");
+			selectionItem1.RemoveFromSelection();
+			item0.IsSelectable = true;
+
+			selectionItem0.AddToSelection();
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.IsTrue(selectionItem0.IsSelected, "AddToSelection should select when the TabBar has no selection");
+			Assert.IsFalse(selectionItem1.IsSelected);
+			Assert.AreEqual(0, SUT.SelectedIndex);
+			Assert.ThrowsException<InvalidOperationException>(
+				selectionItem1.AddToSelection,
+				"AddToSelection should reject a second selection");
+
+			selectionItem1.Select();
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.IsFalse(selectionItem0.IsSelected, "Select should replace the current selection");
+			Assert.IsTrue(selectionItem1.IsSelected);
+			Assert.AreEqual(1, SUT.SelectedIndex);
+
+			selectionItem1.RemoveFromSelection();
+			await UnitTestsUIContentHelper.WaitForIdle();
+
+			Assert.IsFalse(selectionItem1.IsSelected, "RemoveFromSelection should clear an optional selection");
+			Assert.AreEqual(-1, SUT.SelectedIndex);
+			Assert.IsNull(SUT.SelectedItem);
+
+			item0.IsSelectable = false;
+			Assert.ThrowsException<InvalidOperationException>(
+				selectionItem0.Select,
+				"Select should reject a non-selectable TabBarItem");
+		}
+
+		[TestMethod]
+		public async Task Verify_TabBarItem_AutomationPeer_Name_Honors_Explicit_And_Falls_Back_To_Content()
+		{
+			var plainItem = new TabBarItem { Content = "Home" };
+			var namedItem = new TabBarItem { Content = "Home" };
+			var templatedItem = new TabBarItem
+			{
+				Content = new TestRecord("Settings", true),
+				ContentTemplate = XamlHelper.LoadXaml<DataTemplate>("""
+					<DataTemplate>
+						<Grid>
+							<TextBlock Text="{Binding Name}" />
+						</Grid>
+					</DataTemplate>
+				"""),
+			};
+			AutomationProperties.SetName(namedItem, "Go to home screen");
+
+			var SUT = new TabBar();
+			SUT.Items.Add(plainItem);
+			SUT.Items.Add(namedItem);
+			SUT.Items.Add(templatedItem);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+			var plainPeer = FrameworkElementAutomationPeer.CreatePeerForElement(plainItem) as TabBarItemAutomationPeer;
+			var namedPeer = FrameworkElementAutomationPeer.CreatePeerForElement(namedItem) as TabBarItemAutomationPeer;
+			var templatedPeer = FrameworkElementAutomationPeer.CreatePeerForElement(templatedItem) as TabBarItemAutomationPeer;
+			Assert.IsNotNull(plainPeer);
+			Assert.IsNotNull(namedPeer);
+			Assert.IsNotNull(templatedPeer);
+
+			Assert.AreEqual("Home", plainPeer!.GetName(), "Name should fall back to the item's textual content");
+			Assert.AreEqual("Go to home screen", namedPeer!.GetName(), "Explicit AutomationProperties.Name should be honored");
+			Assert.AreEqual("Settings", templatedPeer!.GetName(), "Name should use text rendered by the ContentTemplate");
 		}
 	}
 	

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBar.cs
@@ -11,6 +11,7 @@ using Windows.Foundation.Collections;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Data;
@@ -19,6 +20,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
@@ -58,6 +60,9 @@ namespace Uno.Toolkit.UI
 			UpdateOrientation();
 			UpdateIndicatorPlacement();
 		}
+
+		/// <inheritdoc />
+		protected override AutomationPeer OnCreateAutomationPeer() => new TabBarAutomationPeer(this);
 
 		protected override bool IsItemItsOwnContainerOverride(object? item) => item is TabBarItem;
 
@@ -447,6 +452,31 @@ namespace Uno.Toolkit.UI
 			}
 		}
 
+		internal bool TryClearSelection(TabBarItem item)
+		{
+			if (!ReferenceEquals(item, GetSelectedTabBarItem()))
+			{
+				return false;
+			}
+
+			var previouslySelectedItem = SelectedItem;
+
+			try
+			{
+				_isSynchronizingSelection = true;
+				item.IsSelected = false;
+				SetValue(SelectedItemProperty, null);
+				SelectedIndex = -1;
+			}
+			finally
+			{
+				_isSynchronizingSelection = false;
+			}
+
+			RaiseSelectionChangedEvent(previouslySelectedItem, null);
+			return true;
+		}
+
 		private void RaiseSelectionChangedEvent(object? prevItem, object? nextItem)
 		{
 			var eventArgs = new TabBarSelectionChangedEventArgs
@@ -469,6 +499,27 @@ namespace Uno.Toolkit.UI
 			}
 
 			return container as TabBarItem;
+		}
+
+		internal TabBarItem? FindTabBarItem(object? item) =>
+			GetInnerContainer(this.FindContainer<DependencyObject>(item));
+
+		internal TabBarItem? GetSelectedTabBarItem()
+		{
+			if (FindTabBarItem(SelectedItem) is { IsSelected: true } selectedItem)
+			{
+				return selectedItem;
+			}
+
+			foreach (var container in this.GetItemContainers<UIElement>())
+			{
+				if (GetInnerContainer(container) is { IsSelected: true } selectedContainer)
+				{
+					return selectedContainer;
+				}
+			}
+
+			return null;
 		}
 
 		internal DependencyObject? InnerContainerFromIndex(int index)

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarAutomationPeer.cs
@@ -1,0 +1,64 @@
+using System;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+#else
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes <see cref="TabBar"/> to Microsoft UI Automation.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="FrameworkElementAutomationPeer"/> is intentional: a <see cref="TabBarItem"/>
+	/// can be nested inside a generated <c>ContentPresenter</c>,
+	/// and the dedicated item peer must remain the element exposed in the automation tree.
+	/// </remarks>
+	public partial class TabBarAutomationPeer : FrameworkElementAutomationPeer, ISelectionProvider
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TabBarAutomationPeer"/> class.
+		/// </summary>
+		/// <param name="owner">The <see cref="TabBar"/> instance to create the peer for.</param>
+		public TabBarAutomationPeer(TabBar owner) : base(owner)
+		{
+		}
+
+		protected override string GetClassNameCore() => nameof(TabBar);
+
+		protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Tab;
+
+		protected override object? GetPatternCore(PatternInterface patternInterface) =>
+			patternInterface == PatternInterface.Selection ? this : base.GetPatternCore(patternInterface);
+
+		/// <inheritdoc />
+		public bool CanSelectMultiple => false;
+
+		/// <inheritdoc />
+		public bool IsSelectionRequired => false;
+
+		/// <inheritdoc />
+		public IRawElementProviderSimple[] GetSelection()
+		{
+			if (Owner is not TabBar tabBar ||
+				tabBar.GetSelectedTabBarItem() is not { } selected)
+			{
+				return Array.Empty<IRawElementProviderSimple>();
+			}
+
+			if (FrameworkElementAutomationPeer.CreatePeerForElement(selected) is not { } peer)
+			{
+				return Array.Empty<IRawElementProviderSimple>();
+			}
+
+			var provider = ProviderFromPeer(peer);
+			return provider is null
+				? Array.Empty<IRawElementProviderSimple>()
+				: new[] { provider };
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItem.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItem.cs
@@ -1,14 +1,20 @@
 ﻿#if IS_WINUI
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
 
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Media;
 
 #endif
 using System;
@@ -22,6 +28,8 @@ namespace Uno.Toolkit.UI
 	/// </summary>
 	public partial class TabBarItem : SelectorItem
 	{
+		private const string ContentPresenterName = "ContentPresenter";
+
 		private static class CommonStates
 		{
 			public const string Selected = "Selected";
@@ -48,6 +56,7 @@ namespace Uno.Toolkit.UI
 
 		private bool _isPointerOver;
 		private bool _isPointerPressed;
+		private bool _wasAutomationSelected;
 
 		public TabBarItem()
 		{
@@ -55,6 +64,32 @@ namespace Uno.Toolkit.UI
 			Unloaded += OnUnloaded;
 			Tapped += OnTap;
 			this.RegisterPropertyChangedCallback(SelectorItem.IsSelectedProperty, OnIsSelectedChanged);
+		}
+
+		/// <inheritdoc />
+		protected override AutomationPeer OnCreateAutomationPeer() => new TabBarItemAutomationPeer(this);
+
+		internal UIElement? GetContentTemplateRoot()
+		{
+			// ContentControl.ContentTemplateRoot is typed as the native view on
+			// some platforms (UIView on iOS/macOS, View on Android), so it needs
+			// a cast rather than an implicit conversion. On those platforms
+			// UIElement derives from the native type, so the cast succeeds for
+			// XAML content.
+			if (ContentTemplateRoot as UIElement is { } root)
+			{
+				return root;
+			}
+
+			// ContentPresenter.ContentTemplateRoot is Uno-specific and does not
+			// exist on WinUI, so walk the visual tree instead.
+			if (GetTemplateChild(ContentPresenterName) is ContentPresenter presenter &&
+				VisualTreeHelper.GetChildrenCount(presenter) > 0)
+			{
+				return VisualTreeHelper.GetChild(presenter, 0) as UIElement;
+			}
+
+			return null;
 		}
 
 		private void OnTap(object sender, TappedRoutedEventArgs e)
@@ -73,8 +108,23 @@ namespace Uno.Toolkit.UI
 		{
 			if (dp == SelectorItem.IsSelectedProperty)
 			{
+				var isSelected = IsSelected;
+
 				IsSelectedChanged?.Invoke(this, null);
 				UpdateCommonStates();
+
+				if (isSelected != _wasAutomationSelected)
+				{
+					var oldValue = _wasAutomationSelected;
+					_wasAutomationSelected = isSelected;
+
+					// Screen readers rely on this to announce selection changes (WinUI parity).
+					if (AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged) &&
+						FrameworkElementAutomationPeer.CreatePeerForElement(this) is TabBarItemAutomationPeer peer)
+					{
+						peer.RaisePropertyChangedEvent(SelectionItemPatternIdentifiers.IsSelectedProperty, oldValue, isSelected);
+					}
+				}
 			}
 		}
 

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItemAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItemAutomationPeer.cs
@@ -1,0 +1,151 @@
+using System;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Media;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+using Windows.UI.Xaml.Media;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes <see cref="TabBarItem"/> to Microsoft UI Automation.
+	/// </summary>
+	public partial class TabBarItemAutomationPeer : FrameworkElementAutomationPeer, ISelectionItemProvider
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TabBarItemAutomationPeer"/> class.
+		/// </summary>
+		/// <param name="owner">The <see cref="TabBarItem"/> instance to create the peer for.</param>
+		public TabBarItemAutomationPeer(TabBarItem owner) : base(owner)
+		{
+		}
+
+		protected override string GetClassNameCore() => nameof(TabBarItem);
+
+		protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.TabItem;
+
+		protected override string GetNameCore()
+		{
+			var name = base.GetNameCore();
+			if (Owner is not TabBarItem item ||
+				!string.IsNullOrEmpty(AutomationProperties.GetName(item)) ||
+				AutomationProperties.GetLabeledBy(item) is not null ||
+				item.GetContentTemplateRoot() is not { } contentTemplateRoot)
+			{
+				return name;
+			}
+
+			var contentName = GetContentName(contentTemplateRoot);
+			return string.IsNullOrEmpty(contentName) ? name : contentName;
+		}
+
+		protected override object? GetPatternCore(PatternInterface patternInterface) =>
+			patternInterface == PatternInterface.SelectionItem ? this : base.GetPatternCore(patternInterface);
+
+		/// <inheritdoc />
+		public bool IsSelected => (Owner as TabBarItem)?.IsSelected ?? false;
+
+		/// <inheritdoc />
+		public IRawElementProviderSimple? SelectionContainer
+		{
+			get
+			{
+				if (Owner is not TabBarItem tbi ||
+					tbi.FindFirstParent<TabBar>() is not { } tabBar ||
+					FrameworkElementAutomationPeer.CreatePeerForElement(tabBar) is not { } peer)
+				{
+					return null;
+				}
+
+				return ProviderFromPeer(peer);
+			}
+		}
+
+		/// <inheritdoc />
+		public void Select()
+		{
+			if (Owner is not TabBarItem tbi)
+			{
+				return;
+			}
+
+			if (tbi.IsSelected)
+			{
+				return;
+			}
+
+			if (!tbi.IsSelectable)
+			{
+				throw new InvalidOperationException("The TabBarItem is not selectable.");
+			}
+
+			tbi.IsSelected = true;
+		}
+
+		/// <inheritdoc />
+		public void AddToSelection()
+		{
+			if (Owner is not TabBarItem tbi || tbi.IsSelected)
+			{
+				return;
+			}
+
+			if (tbi.FindFirstParent<TabBar>() is { } tabBar &&
+				tabBar.GetSelectedTabBarItem() is not null)
+			{
+				throw new InvalidOperationException("TabBar does not support multiple selection.");
+			}
+
+			Select();
+		}
+
+		/// <inheritdoc />
+		public void RemoveFromSelection()
+		{
+			if (Owner is not TabBarItem { IsSelected: true } tbi)
+			{
+				return;
+			}
+
+			if (tbi.FindFirstParent<TabBar>()?.TryClearSelection(tbi) != true)
+			{
+				tbi.IsSelected = false;
+			}
+		}
+
+		private static string GetContentName(UIElement element)
+		{
+			if (FrameworkElementAutomationPeer.CreatePeerForElement(element) is { } peer)
+			{
+				var name = peer.GetName();
+				if (!string.IsNullOrEmpty(name))
+				{
+					return name;
+				}
+			}
+
+			for (var i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
+			{
+				if (VisualTreeHelper.GetChild(element, i) is UIElement child)
+				{
+					var name = GetContentName(child);
+					if (!string.IsNullOrEmpty(name))
+					{
+						return name;
+					}
+				}
+			}
+
+			return string.Empty;
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItemAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/TabBar/TabBarItemAutomationPeer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
@@ -94,7 +95,7 @@ namespace Uno.Toolkit.UI
 		/// <inheritdoc />
 		public void AddToSelection()
 		{
-			if (Owner is not TabBarItem tbi || tbi.IsSelected)
+			if (Owner is not TabBarItem { IsSelected: false } tbi)
 			{
 				return;
 			}
@@ -116,7 +117,8 @@ namespace Uno.Toolkit.UI
 				return;
 			}
 
-			if (tbi.FindFirstParent<TabBar>()?.TryClearSelection(tbi) != true)
+			var tabBar = tbi.FindFirstParent<TabBar>();
+			if (tabBar is null || !tabBar.TryClearSelection(tbi))
 			{
 				tbi.IsSelected = false;
 			}
@@ -124,23 +126,23 @@ namespace Uno.Toolkit.UI
 
 		private static string GetContentName(UIElement element)
 		{
-			if (FrameworkElementAutomationPeer.CreatePeerForElement(element) is { } peer)
+			var pending = new Stack<UIElement>();
+			pending.Push(element);
+
+			while (pending.Count > 0)
 			{
-				var name = peer.GetName();
-				if (!string.IsNullOrEmpty(name))
+				var current = pending.Pop();
+				if (FrameworkElementAutomationPeer.CreatePeerForElement(current) is { } peer &&
+					peer.GetName() is { Length: > 0 } name)
 				{
 					return name;
 				}
-			}
 
-			for (var i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
-			{
-				if (VisualTreeHelper.GetChild(element, i) is UIElement child)
+				for (var i = VisualTreeHelper.GetChildrenCount(current) - 1; i >= 0; i--)
 				{
-					var name = GetContentName(child);
-					if (!string.IsNullOrEmpty(name))
+					if (VisualTreeHelper.GetChild(current, i) is UIElement child)
 					{
-						return name;
+						pending.Push(child);
 					}
 				}
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/kahua-private#507

## PR Type

- Bugfix

## What is the current behavior?

`TabBar` and `TabBarItem` never override `OnCreateAutomationPeer()`. WinUI only creates a peer for a plain `FrameworkElement` when `AutomationProperties.Name` or `LabeledBy` is explicitly set, and even then the result is a generic peer reporting `AutomationControlType.Group`.

The practical consequences are:

- The tab strip is not identified as a tab control to assistive technology.
- Tab items are not identified as tab items, and the selected item exposes no selection state.
- Setting an automation name on a `TabBarItem` appears to do nothing, which is what the linked issue reports.

## What is the new behavior?

Two dedicated automation peers are added under `Controls/TabBar/`, and both controls now override `OnCreateAutomationPeer()`:

- `TabBarAutomationPeer` reports `AutomationControlType.Tab` and implements `ISelectionProvider`. `CanSelectMultiple` is `false` and `IsSelectionRequired` is `false`, matching `SelectedIndex` defaulting to `-1`.
- `TabBarItemAutomationPeer` reports `AutomationControlType.TabItem` and implements `ISelectionItemProvider`. `IsSelected` reflects `TabBarItem.IsSelected`, `Select()` selects the item, `AddToSelection()` is rejected when it would create a multi-selection, and `RemoveFromSelection()` clears the selection when permitted.
- Selection changes raise `SelectionItemPatternIdentifiers.IsSelectedProperty` on the item peer.
- `GetNameCore()` honours an explicit `AutomationProperties.Name` or `LabeledBy`, and otherwise resolves a name from the rendered content template rather than falling back to `ToString()` on the data object.

`TabBarAutomationPeer` intentionally derives from `FrameworkElementAutomationPeer` rather than `ItemsControlAutomationPeer`. `ItemsControlAutomationPeer` creates its own `ItemAutomationPeer` instances for items, which would compete with the dedicated `TabBarItemAutomationPeer` returned by `TabBarItem.OnCreateAutomationPeer()`. Deriving from `FrameworkElementAutomationPeer` keeps a single, stable identity per item.

## Verification

Built on macOS with the single-platform desktop override:

- `dotnet build src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj -c Debug -p:TargetFrameworkOverride=desktop` — 0 warnings, 0 errors
- `dotnet build src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj -c Release -p:TargetFrameworkOverride=desktop` — 0 warnings, 0 errors (Release treats warnings as errors)
- `dotnet build src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.csproj -c Debug -p:TargetFrameworkOverride=desktop` — 0 warnings, 0 errors

Runtime tests were added to `TabBarTests.cs` covering the control types, the selection pattern before and after selection, selection toggling across items, rejection of invalid multi-selection, and both the explicit-name and templated-content naming paths.

## Not verified

- Announcement text and event routing with a real screen reader (Narrator, VoiceOver, TalkBack) have not been checked.
- Only the desktop target was built and exercised; Windows, iOS, Android and WASM heads were not.

## PR Checklist

- [x] Tested code with current supported SDKs
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed
- [x] Runtime Tests and/or UI Tests for the changes have been added
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
