### PR TITLE
feat: add built-in accessibility support to Toolkit controls

### DIFF
--- a/doc/controls/CardAndCardContentControl.md
+++ b/doc/controls/CardAndCardContentControl.md
@@ -21,6 +21,8 @@ Depending on the amount of user attention you want to draw to the content you ca
 - `FilledCardStyle` or `FilledCardContentControlStyle` to display a simple background color without any elevation or border for the card.
 - `OutlinedCardStyle` or `OutlinedCardContentControlStyle` to display a simple solid stroke along the border of the card.
 
+When `IsClickable` is `true` (the default), both controls are tab stops, support Enter and Space activation, expose the UI Automation Invoke pattern as buttons, and raise `Click`. Set `AutomationProperties.Name` or `AutomationProperties.LabeledBy` when the rendered header or content does not provide a suitable accessible name. When `IsClickable` is `false`, the controls remain structural groups without the Invoke pattern.
+
 ## Card
 
 The `Card` control is based on `Control` and allows you to customize the control's content through [additional properties](#properties) to fit your needs.
@@ -70,10 +72,16 @@ The `Card` control comes with all the built-in properties of a `Control`, and al
 | `IconsContentTemplate`      | `DataTemplate` | Gets or sets the data template used to display the content of the control's icons.            |
 | `Elevation`                 | `double`       | Gets or sets the elevation of the control.                                                    |
 | `ShadowColor`               | `Color`        | Gets or sets the color to use for the shadow of the control.                                  |
-| `IsClickable`               | `bool`         | Gets or sets a value indicating whether the control will respond to pointer and focus events. |
+| `IsClickable`               | `bool`         | Gets or sets whether the control supports pointer, keyboard, and automation activation.       |
 
 > [!TIP]
 > Consider using [CardContentControl](#cardcontentcontrol) if you need full control over the content layout.
+
+### Events
+
+| Event   | Description                                                               |
+|---------|---------------------------------------------------------------------------|
+| `Click` | Occurs when the card is activated by pointer, keyboard, or UI Automation. |
 
 ### Usage
 
@@ -187,7 +195,13 @@ The `Card` control comes with all the built-in properties of a `ContentControl`,
 |---------------|----------|-----------------------------------------------------------------------------------------------|
 | `Elevation`   | `double` | Gets or sets the elevation of the control.                                                    |
 | `ShadowColor` | `Color`  | Gets or sets the color to use for the shadow of the control.                                  |
-| `IsClickable` | `bool`   | Gets or sets a value indicating whether the control will respond to pointer and focus events. |
+| `IsClickable` | `bool`   | Gets or sets whether the control supports pointer, keyboard, and automation activation.       |
+
+### Events
+
+| Event   | Description                                                               |
+|---------|---------------------------------------------------------------------------|
+| `Click` | Occurs when the card is activated by pointer, keyboard, or UI Automation. |
 
 ### Usage
 

--- a/doc/controls/DrawerControl.md
+++ b/doc/controls/DrawerControl.md
@@ -10,6 +10,12 @@ uid: Toolkit.Controls.DrawerControl
 
 `DrawerControl` is a container with two views; one view for the main content, and another view that can be revealed with a swipe gesture.
 
+## Accessibility
+
+When open, the drawer pane is exposed as a window-like automation element and the light-dismiss surface is exposed as an invocable button. Keyboard focus moves into the pane, remains contained while tabbing, and returns to the previously focused control when the drawer closes. <kbd>Esc</kbd> closes the drawer when `IsLightDismissEnabled` is `true`.
+
+When closed, the pane is collapsed and removed from keyboard and assistive-technology navigation. Set `AutomationProperties.Name` on `DrawerControl` to provide the pane's accessible name.
+
 ## Remarks
 
 Due to the lack of clipping, this control should be used as a full window-sized control or, at least, the side where the drawer opens from should be placed on the edge of the screen.

--- a/doc/controls/ZoomContentControl.md
+++ b/doc/controls/ZoomContentControl.md
@@ -81,3 +81,7 @@ The `PanWheelRatio` property determines how many pixels to move per mouse wheel 
 Press and hold the middle button.
 Drag to move the content.
 Release the mouse button to stop panning.
+
+#### Keyboard
+
+When the control has focus, use the arrow keys to pan by a small amount and Page Up/Page Down to pan by a viewport. Use the numeric keypad plus and minus keys to zoom in and out.

--- a/src/Uno.Toolkit.RuntimeTests/Tests/CardAutomationTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/CardAutomationTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Extensions;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests
+{
+	[TestClass]
+	[RunsOnUIThread]
+	internal class CardAutomationTests
+	{
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task Card_AutomationPeer_Reflects_Clickability_And_Invokes()
+		{
+			var root = XamlHelper.LoadXaml<StackPanel>("""
+				<StackPanel>
+					<utu:Card x:Name="ClickableCard"
+							  HeaderContent="Open details"
+							  IsClickable="True"
+							  Style="{StaticResource FilledCardStyle}" />
+					<utu:Card x:Name="StructuralCard"
+							  HeaderContent="Details"
+							  IsClickable="False"
+							  Style="{StaticResource FilledCardStyle}" />
+				</StackPanel>
+			""");
+			var clickableCard = (Card)root.FindName("ClickableCard");
+			var structuralCard = (Card)root.FindName("StructuralCard");
+			var clickCount = 0;
+			clickableCard.Click += (_, _) => clickCount++;
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+			var clickablePeer = FrameworkElementAutomationPeer.CreatePeerForElement(clickableCard) as CardAutomationPeer;
+			var structuralPeer = FrameworkElementAutomationPeer.CreatePeerForElement(structuralCard) as CardAutomationPeer;
+
+			Assert.IsNotNull(clickablePeer);
+			Assert.IsNotNull(structuralPeer);
+			Assert.AreEqual(AutomationControlType.Button, clickablePeer!.GetAutomationControlType());
+			Assert.AreEqual(AutomationControlType.Group, structuralPeer!.GetAutomationControlType());
+			Assert.IsTrue(clickableCard.IsTabStop);
+			Assert.IsFalse(structuralCard.IsTabStop);
+
+			var invokeProvider = clickablePeer.GetPattern(PatternInterface.Invoke) as IInvokeProvider;
+			Assert.IsNotNull(invokeProvider);
+			Assert.IsNull(structuralPeer.GetPattern(PatternInterface.Invoke));
+
+			invokeProvider!.Invoke();
+
+			Assert.AreEqual(1, clickCount);
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task CardContentControl_AutomationPeer_Reflects_Clickability_And_Invokes()
+		{
+			var root = XamlHelper.LoadXaml<StackPanel>("""
+				<StackPanel>
+					<utu:CardContentControl x:Name="ClickableCard"
+											IsClickable="True"
+											Style="{StaticResource FilledCardContentControlStyle}">
+						<TextBlock Text="Open details" />
+					</utu:CardContentControl>
+					<utu:CardContentControl x:Name="StructuralCard"
+											IsClickable="False"
+											Style="{StaticResource FilledCardContentControlStyle}">
+						<TextBlock Text="Details" />
+					</utu:CardContentControl>
+				</StackPanel>
+			""");
+			var clickableCard = (CardContentControl)root.FindName("ClickableCard");
+			var structuralCard = (CardContentControl)root.FindName("StructuralCard");
+			var clickCount = 0;
+			clickableCard.Click += (_, _) => clickCount++;
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+			var clickablePeer = FrameworkElementAutomationPeer.CreatePeerForElement(clickableCard) as CardContentControlAutomationPeer;
+			var structuralPeer = FrameworkElementAutomationPeer.CreatePeerForElement(structuralCard) as CardContentControlAutomationPeer;
+
+			Assert.IsNotNull(clickablePeer);
+			Assert.IsNotNull(structuralPeer);
+			Assert.AreEqual(AutomationControlType.Button, clickablePeer!.GetAutomationControlType());
+			Assert.AreEqual(AutomationControlType.Group, structuralPeer!.GetAutomationControlType());
+			Assert.IsTrue(clickableCard.IsTabStop);
+			Assert.IsFalse(structuralCard.IsTabStop);
+
+			var invokeProvider = clickablePeer.GetPattern(PatternInterface.Invoke) as IInvokeProvider;
+			Assert.IsNotNull(invokeProvider);
+			Assert.IsNull(structuralPeer.GetPattern(PatternInterface.Invoke));
+
+			invokeProvider!.Invoke();
+
+			Assert.AreEqual(1, clickCount);
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task Card_AutomationPeer_Name_Honors_Explicit_Name_And_Rendered_Header()
+		{
+			var root = XamlHelper.LoadXaml<StackPanel>("""
+				<StackPanel>
+					<utu:Card x:Name="ExplicitNameCard"
+							  HeaderContent="Ignored header"
+							  Style="{StaticResource FilledCardStyle}" />
+					<utu:Card x:Name="RenderedHeaderCard"
+							  Style="{StaticResource FilledCardStyle}">
+						<utu:Card.HeaderContentTemplate>
+							<DataTemplate>
+								<Grid>
+									<TextBlock Text="{Binding Name}" />
+								</Grid>
+							</DataTemplate>
+						</utu:Card.HeaderContentTemplate>
+					</utu:Card>
+				</StackPanel>
+			""");
+			var explicitNameCard = (Card)root.FindName("ExplicitNameCard");
+			var renderedHeaderCard = (Card)root.FindName("RenderedHeaderCard");
+			AutomationProperties.SetName(explicitNameCard, "Open account");
+			renderedHeaderCard.HeaderContent = new CardTestData("Rendered account");
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+			var explicitNamePeer = FrameworkElementAutomationPeer.CreatePeerForElement(explicitNameCard) as CardAutomationPeer;
+			var renderedHeaderPeer = FrameworkElementAutomationPeer.CreatePeerForElement(renderedHeaderCard) as CardAutomationPeer;
+
+			Assert.IsNotNull(explicitNamePeer);
+			Assert.IsNotNull(renderedHeaderPeer);
+			Assert.AreEqual("Open account", explicitNamePeer!.GetName());
+			Assert.AreEqual("Rendered account", renderedHeaderPeer!.GetName());
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task CardContentControl_AutomationPeer_Name_Honors_LabeledBy_And_Rendered_Content()
+		{
+			var label = new TextBlock
+			{
+				Text = "Open settings",
+			};
+			var labeledCard = new CardContentControl
+			{
+				Content = "Ignored content",
+			};
+			AutomationProperties.SetLabeledBy(labeledCard, label);
+
+			var renderedContentCard = new CardContentControl
+			{
+				Content = new CardTestData("Rendered settings"),
+				ContentTemplate = XamlHelper.LoadXaml<DataTemplate>("""
+					<DataTemplate>
+						<Grid>
+							<TextBlock Text="{Binding Name}" />
+						</Grid>
+					</DataTemplate>
+				"""),
+			};
+			var root = new StackPanel();
+			root.Children.Add(label);
+			root.Children.Add(labeledCard);
+			root.Children.Add(renderedContentCard);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+			var labeledPeer = FrameworkElementAutomationPeer.CreatePeerForElement(labeledCard) as CardContentControlAutomationPeer;
+			var renderedContentPeer = FrameworkElementAutomationPeer.CreatePeerForElement(renderedContentCard) as CardContentControlAutomationPeer;
+
+			Assert.IsNotNull(labeledPeer);
+			Assert.IsNotNull(renderedContentPeer);
+			Assert.AreEqual("Open settings", labeledPeer!.GetName());
+			Assert.AreEqual("Rendered settings", renderedContentPeer!.GetName());
+		}
+
+		private sealed record CardTestData(string Name);
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/CardAutomationTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/CardAutomationTests.cs
@@ -45,13 +45,13 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 
 			await UnitTestUIContentHelperEx.SetContentAndWait(root);
 
-			var clickablePeer = FrameworkElementAutomationPeer.CreatePeerForElement(clickableCard) as CardAutomationPeer;
-			var structuralPeer = FrameworkElementAutomationPeer.CreatePeerForElement(structuralCard) as CardAutomationPeer;
+			var clickablePeer = FrameworkElementAutomationPeer.CreatePeerForElement(clickableCard) as CardAutomationPeer
+				?? throw new AssertFailedException("Card should expose a CardAutomationPeer.");
+			var structuralPeer = FrameworkElementAutomationPeer.CreatePeerForElement(structuralCard) as CardAutomationPeer
+				?? throw new AssertFailedException("Card should expose a CardAutomationPeer.");
 
-			Assert.IsNotNull(clickablePeer);
-			Assert.IsNotNull(structuralPeer);
-			Assert.AreEqual(AutomationControlType.Button, clickablePeer!.GetAutomationControlType());
-			Assert.AreEqual(AutomationControlType.Group, structuralPeer!.GetAutomationControlType());
+			Assert.AreEqual(AutomationControlType.Button, clickablePeer.GetAutomationControlType());
+			Assert.AreEqual(AutomationControlType.Group, structuralPeer.GetAutomationControlType());
 			Assert.IsTrue(clickableCard.IsTabStop);
 			Assert.IsFalse(structuralCard.IsTabStop);
 
@@ -89,13 +89,13 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 
 			await UnitTestUIContentHelperEx.SetContentAndWait(root);
 
-			var clickablePeer = FrameworkElementAutomationPeer.CreatePeerForElement(clickableCard) as CardContentControlAutomationPeer;
-			var structuralPeer = FrameworkElementAutomationPeer.CreatePeerForElement(structuralCard) as CardContentControlAutomationPeer;
+			var clickablePeer = FrameworkElementAutomationPeer.CreatePeerForElement(clickableCard) as CardContentControlAutomationPeer
+				?? throw new AssertFailedException("CardContentControl should expose a CardContentControlAutomationPeer.");
+			var structuralPeer = FrameworkElementAutomationPeer.CreatePeerForElement(structuralCard) as CardContentControlAutomationPeer
+				?? throw new AssertFailedException("CardContentControl should expose a CardContentControlAutomationPeer.");
 
-			Assert.IsNotNull(clickablePeer);
-			Assert.IsNotNull(structuralPeer);
-			Assert.AreEqual(AutomationControlType.Button, clickablePeer!.GetAutomationControlType());
-			Assert.AreEqual(AutomationControlType.Group, structuralPeer!.GetAutomationControlType());
+			Assert.AreEqual(AutomationControlType.Button, clickablePeer.GetAutomationControlType());
+			Assert.AreEqual(AutomationControlType.Group, structuralPeer.GetAutomationControlType());
 			Assert.IsTrue(clickableCard.IsTabStop);
 			Assert.IsFalse(structuralCard.IsTabStop);
 

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ChipGroupTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ChipGroupTests.cs
@@ -306,9 +306,9 @@ internal class ChipGroupTests
 
 		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
 
-		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as ChipGroupAutomationPeer;
-		Assert.IsNotNull(peer, "ChipGroup should expose a ChipGroupAutomationPeer.");
-		Assert.AreEqual(AutomationControlType.List, peer!.GetAutomationControlType());
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as ChipGroupAutomationPeer
+			?? throw new AssertFailedException("ChipGroup should expose a ChipGroupAutomationPeer.");
+		Assert.AreEqual(AutomationControlType.List, peer.GetAutomationControlType());
 
 		var selectionProvider = peer.GetPattern(PatternInterface.Selection) as ISelectionProvider;
 		if (!supportsSelection)
@@ -341,9 +341,9 @@ internal class ChipGroupTests
 		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
 
 		var chip = (ChipControl)SUT.ContainerFromIndex(0);
-		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(chip) as ChipAutomationPeer;
-		Assert.IsNotNull(peer, "Chip should expose a ChipAutomationPeer.");
-		Assert.IsNull(peer!.GetPattern(PatternInterface.Toggle), "A ChipGroup item should not expose Toggle.");
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(chip) as ChipAutomationPeer
+			?? throw new AssertFailedException("Chip should expose a ChipAutomationPeer.");
+		Assert.IsNull(peer.GetPattern(PatternInterface.Toggle), "A ChipGroup item should not expose Toggle.");
 
 		var invokeProvider = peer.GetPattern(PatternInterface.Invoke) as IInvokeProvider;
 		var selectionItem = peer.GetPattern(PatternInterface.SelectionItem) as ISelectionItemProvider;
@@ -377,9 +377,9 @@ internal class ChipGroupTests
 
 		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
 
-		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as ChipAutomationPeer;
-		Assert.IsNotNull(peer);
-		Assert.AreEqual(AutomationControlType.Button, peer!.GetAutomationControlType());
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as ChipAutomationPeer
+			?? throw new AssertFailedException("Chip should expose a ChipAutomationPeer.");
+		Assert.AreEqual(AutomationControlType.Button, peer.GetAutomationControlType());
 		Assert.IsNull(peer.GetPattern(PatternInterface.SelectionItem));
 
 		var toggleProvider = peer.GetPattern(PatternInterface.Toggle) as IToggleProvider;

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ChipGroupTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ChipGroupTests.cs
@@ -10,6 +10,18 @@ using Uno.Toolkit.UI;
 using Uno.UI.RuntimeTests;
 using ChipControl = Uno.Toolkit.UI.Chip; // ios/macos: to avoid collision with `global::Chip` namespace...
 
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+using Windows.UI.Xaml.Controls;
+#endif
+
 namespace Uno.Toolkit.RuntimeTests.Tests;
 
 [TestClass]
@@ -269,6 +281,202 @@ internal class ChipGroupTests
 
 		SUT.SelectionMode = ChipSelectionMode.Single;
 		Assert.AreEqual(selected.First(), SUT.SelectedItem);
+	}
+
+	#endregion
+
+	#region Automation
+
+	[TestMethod]
+	[DataRow(ChipSelectionMode.None, false, false, false)]
+	[DataRow(ChipSelectionMode.SingleOrNone, true, false, false)]
+	[DataRow(ChipSelectionMode.Single, true, false, true)]
+	[DataRow(ChipSelectionMode.Multiple, true, true, false)]
+	public async Task AutomationPeer_SelectionPattern_MatchesSelectionMode(
+		ChipSelectionMode mode,
+		bool supportsSelection,
+		bool canSelectMultiple,
+		bool isSelectionRequired)
+	{
+		var SUT = new ChipGroup
+		{
+			SelectionMode = mode,
+			ItemsSource = new[] { "One", "Two" },
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as ChipGroupAutomationPeer;
+		Assert.IsNotNull(peer, "ChipGroup should expose a ChipGroupAutomationPeer.");
+		Assert.AreEqual(AutomationControlType.List, peer!.GetAutomationControlType());
+
+		var selectionProvider = peer.GetPattern(PatternInterface.Selection) as ISelectionProvider;
+		if (!supportsSelection)
+		{
+			Assert.IsNull(selectionProvider, "Selection mode None should not expose the Selection pattern.");
+			return;
+		}
+
+		Assert.IsNotNull(selectionProvider);
+		Assert.AreEqual(canSelectMultiple, selectionProvider!.CanSelectMultiple);
+		Assert.AreEqual(isSelectionRequired, selectionProvider.IsSelectionRequired);
+		Assert.AreEqual(mode == ChipSelectionMode.Single ? 1 : 0, selectionProvider.GetSelection().Length);
+	}
+
+	[TestMethod]
+	[DataRow(ChipSelectionMode.None, false)]
+	[DataRow(ChipSelectionMode.SingleOrNone, true)]
+	[DataRow(ChipSelectionMode.Single, true)]
+	[DataRow(ChipSelectionMode.Multiple, true)]
+	public async Task ChipAutomationPeer_PatternsAndState_AreModeAware(
+		ChipSelectionMode mode,
+		bool supportsSelectionItem)
+	{
+		var SUT = new ChipGroup
+		{
+			SelectionMode = mode,
+			ItemsSource = new[] { "One", "Two" },
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var chip = (ChipControl)SUT.ContainerFromIndex(0);
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(chip) as ChipAutomationPeer;
+		Assert.IsNotNull(peer, "Chip should expose a ChipAutomationPeer.");
+		Assert.IsNull(peer!.GetPattern(PatternInterface.Toggle), "A ChipGroup item should not expose Toggle.");
+
+		var invokeProvider = peer.GetPattern(PatternInterface.Invoke) as IInvokeProvider;
+		var selectionItem = peer.GetPattern(PatternInterface.SelectionItem) as ISelectionItemProvider;
+		if (!supportsSelectionItem)
+		{
+			Assert.IsNotNull(invokeProvider, "Selection mode None should expose Invoke.");
+			Assert.IsNull(selectionItem, "Selection mode None should not expose SelectionItem.");
+			Assert.AreEqual(AutomationControlType.Button, peer.GetAutomationControlType());
+
+			var clickCount = 0;
+			chip.Click += (_, _) => clickCount++;
+			invokeProvider!.Invoke();
+			Assert.AreEqual(false, chip.IsChecked);
+			Assert.AreEqual(1, clickCount);
+			return;
+		}
+
+		Assert.IsNull(invokeProvider, "Selectable ChipGroup items should expose SelectionItem instead of Invoke.");
+		Assert.IsNotNull(selectionItem);
+		Assert.AreEqual(AutomationControlType.ListItem, peer.GetAutomationControlType());
+		Assert.AreEqual(mode == ChipSelectionMode.Single, selectionItem!.IsSelected);
+		Assert.IsNotNull(selectionItem.SelectionContainer);
+	}
+
+	[TestMethod]
+	public async Task StandaloneChipAutomationPeer_PreservesTogglePattern()
+	{
+		var SUT = new ChipControl { Content = "Standalone" };
+		var clickCount = 0;
+		SUT.Click += (_, _) => clickCount++;
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as ChipAutomationPeer;
+		Assert.IsNotNull(peer);
+		Assert.AreEqual(AutomationControlType.Button, peer!.GetAutomationControlType());
+		Assert.IsNull(peer.GetPattern(PatternInterface.SelectionItem));
+
+		var toggleProvider = peer.GetPattern(PatternInterface.Toggle) as IToggleProvider;
+		Assert.IsNotNull(toggleProvider);
+		Assert.AreEqual(ToggleState.Off, toggleProvider!.ToggleState);
+
+		toggleProvider.Toggle();
+
+		Assert.AreEqual(ToggleState.On, toggleProvider.ToggleState);
+		Assert.AreEqual(1, clickCount, "Automation Toggle should preserve ToggleButton click semantics.");
+	}
+
+	[TestMethod]
+	public async Task SelectionItemProvider_UpdatesMultipleSelection()
+	{
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.Multiple,
+			ItemsSource = new[] { "One", "Two" },
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var groupPeer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as ChipGroupAutomationPeer ??
+			throw new InvalidOperationException("ChipGroup does not expose its automation peer.");
+		var groupProvider = groupPeer.GetPattern(PatternInterface.Selection) as ISelectionProvider ??
+			throw new InvalidOperationException("ChipGroup does not expose Selection.");
+		var first = GetSelectionItemProvider(SUT, 0);
+		var second = GetSelectionItemProvider(SUT, 1);
+
+		first.AddToSelection();
+		Assert.IsTrue(first.IsSelected);
+		Assert.AreEqual(1, groupProvider.GetSelection().Length);
+
+		second.AddToSelection();
+		Assert.IsTrue(first.IsSelected);
+		Assert.IsTrue(second.IsSelected);
+		Assert.AreEqual(2, groupProvider.GetSelection().Length);
+
+		second.Select();
+		Assert.IsFalse(first.IsSelected);
+		Assert.IsTrue(second.IsSelected);
+		Assert.AreEqual(1, groupProvider.GetSelection().Length);
+
+		second.RemoveFromSelection();
+		Assert.IsFalse(second.IsSelected);
+		Assert.AreEqual(0, groupProvider.GetSelection().Length);
+	}
+
+	[TestMethod]
+	public async Task SelectionItemProvider_CannotRemoveRequiredSelection()
+	{
+		var SUT = new ChipGroup
+		{
+			SelectionMode = ChipSelectionMode.Single,
+			ItemsSource = new[] { "One", "Two" },
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var selectionItem = GetSelectionItemProvider(SUT, 0);
+		Assert.IsTrue(selectionItem.IsSelected);
+		Assert.ThrowsException<InvalidOperationException>(selectionItem.RemoveFromSelection);
+	}
+
+	[TestMethod]
+	public async Task RemoveButtonAutomationName_UsesRenderedChipName()
+	{
+		var SUT = new ChipControl
+		{
+			CanRemove = true,
+			Content = new object(),
+			ContentTemplate = XamlHelper.LoadXaml<DataTemplate>("""
+				<DataTemplate>
+					<TextBlock Text="Project" />
+				</DataTemplate>
+				"""),
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(SUT);
+
+		var chipPeer = FrameworkElementAutomationPeer.CreatePeerForElement(SUT) as ChipAutomationPeer;
+		Assert.IsNotNull(chipPeer);
+		Assert.AreEqual("Project", chipPeer!.GetName());
+
+		var removeButton = SUT.GetFirstDescendantOrThrow<Button>("PART_RemoveButton");
+		var removeButtonPeer = FrameworkElementAutomationPeer.CreatePeerForElement(removeButton);
+		Assert.IsNotNull(removeButtonPeer);
+		Assert.AreEqual("Remove Project", removeButtonPeer!.GetName());
+	}
+
+	private static ISelectionItemProvider GetSelectionItemProvider(ChipGroup chipGroup, int index)
+	{
+		var chip = (ChipControl)chipGroup.ContainerFromIndex(index);
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(chip) as ChipAutomationPeer;
+		return peer?.GetPattern(PatternInterface.SelectionItem) as ISelectionItemProvider ??
+			throw new InvalidOperationException($"Chip at index {index} does not expose SelectionItem.");
 	}
 
 	#endregion

--- a/src/Uno.Toolkit.RuntimeTests/Tests/DrawerTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/DrawerTests.cs
@@ -1,16 +1,28 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests;
 using Uno.Toolkit.RuntimeTests.Helpers;
 using Uno.Toolkit.UI;
 using Uno.UI.Extensions;
+using Windows.System;
 
 #if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Animation;
 #else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media.Animation;
 #endif
 
@@ -54,5 +66,239 @@ internal class DrawerTests
 		await UnitTestUIContentHelperEx.WaitFor(
 			() => lightDismissOverlay.Opacity == 0,
 			message: $"Expected lightDismissOverlay.Opacity to be 0, got {lightDismissOverlay.Opacity}");
+	}
+
+	[TestMethod]
+	public async Task AutomationPeers_Expose_Drawer_Semantics_And_Dismiss()
+	{
+		var drawer = new DrawerControl
+		{
+			DrawerDepth = 200,
+			IsOpen = true,
+			DrawerContent = new Button { Content = "Drawer action" },
+		};
+		AutomationProperties.SetName(drawer, "Navigation drawer");
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(drawer);
+
+		var drawerPeer = FrameworkElementAutomationPeer.CreatePeerForElement(drawer);
+		Assert.IsInstanceOfType(drawerPeer, typeof(DrawerControlAutomationPeer));
+		Assert.AreEqual(AutomationControlType.Group, drawerPeer!.GetAutomationControlType());
+
+		var pane = drawer.GetFirstDescendant<ContentControl>(x => x.Name == DrawerControl.TemplateParts.DrawerContentControlName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.DrawerContentControlName}");
+		var panePeer = FrameworkElementAutomationPeer.CreatePeerForElement(pane);
+		Assert.IsNotNull(panePeer);
+		Assert.AreEqual(AutomationControlType.Window, panePeer!.GetAutomationControlType());
+		Assert.AreEqual("Navigation drawer", panePeer.GetName());
+
+		var windowProvider = panePeer.GetPattern(PatternInterface.Window) as IWindowProvider;
+		Assert.IsNotNull(windowProvider);
+		Assert.IsTrue(windowProvider!.IsModal);
+		Assert.IsTrue(windowProvider.IsTopmost);
+
+		var lightDismiss = drawer.GetFirstDescendant<Border>(x => x.Name == DrawerControl.TemplateParts.LightDismissOverlayName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.LightDismissOverlayName}");
+
+		var openChildren = drawerPeer.GetChildren() ?? throw new Exception("Drawer peer should expose children");
+		Assert.IsTrue(openChildren.OfType<FrameworkElementAutomationPeer>().Any(x => ReferenceEquals(x.Owner, pane)));
+		var lightDismissPeer = openChildren
+			.OfType<FrameworkElementAutomationPeer>()
+			.Single(x => ReferenceEquals(x.Owner, lightDismiss));
+		Assert.AreEqual(AutomationControlType.Button, lightDismissPeer.GetAutomationControlType());
+		Assert.AreEqual("Close", lightDismissPeer.GetName());
+		Assert.AreEqual("LightDismiss", lightDismissPeer.GetAutomationId());
+
+		var invokeProvider = lightDismissPeer.GetPattern(PatternInterface.Invoke) as IInvokeProvider;
+		Assert.IsNotNull(invokeProvider);
+		invokeProvider!.Invoke();
+
+		Assert.IsFalse(drawer.IsOpen);
+		Assert.AreEqual(AccessibilityView.Raw, AutomationProperties.GetAccessibilityView(pane));
+		Assert.IsFalse(lightDismiss.IsHitTestVisible);
+		Assert.IsNull(panePeer.GetPattern(PatternInterface.Window));
+		Assert.AreEqual(0, panePeer.GetChildren()?.Count ?? 0);
+
+		var closedChildren = drawerPeer.GetChildren();
+		Assert.IsFalse(closedChildren?.OfType<FrameworkElementAutomationPeer>().Any(x =>
+			ReferenceEquals(x.Owner, pane) || ReferenceEquals(x.Owner, lightDismiss)) == true);
+	}
+
+	[TestMethod]
+	public async Task Opening_And_Closing_Manages_Focus_And_Accessibility()
+	{
+		var opener = new Button { Content = "Open" };
+		var drawerButton = new Button { Content = "Drawer action" };
+		var drawer = new DrawerControl
+		{
+			DrawerDepth = 200,
+			Content = opener,
+			DrawerContent = drawerButton,
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(drawer);
+		var pane = drawer.GetFirstDescendant<ContentControl>(x => x.Name == DrawerControl.TemplateParts.DrawerContentControlName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.DrawerContentControlName}");
+		Assert.AreEqual(Visibility.Collapsed, pane.Visibility);
+		Assert.IsFalse(pane.IsEnabled);
+
+		Assert.IsTrue(opener.Focus(FocusState.Programmatic));
+
+		drawer.IsOpen = true;
+		await UnitTestUIContentHelperEx.WaitFor(() => drawerButton.FocusState != FocusState.Unfocused);
+
+		Assert.AreEqual(AccessibilityView.Control, AutomationProperties.GetAccessibilityView(pane));
+		Assert.AreEqual(KeyboardNavigationMode.Cycle, pane.TabFocusNavigation);
+
+		drawer.IsOpen = false;
+		await UnitTestUIContentHelperEx.WaitFor(() => opener.FocusState != FocusState.Unfocused);
+
+		Assert.AreEqual(AccessibilityView.Raw, AutomationProperties.GetAccessibilityView(pane));
+		Assert.IsFalse(pane.IsEnabled);
+		Assert.IsFalse(pane.IsHitTestVisible);
+		Assert.IsFalse(drawerButton.Focus(FocusState.Programmatic));
+		await UnitTestUIContentHelperEx.WaitFor(() => drawer.AnimationStoryboard.GetCurrentState() == ClockState.Stopped);
+		Assert.AreEqual(Visibility.Collapsed, pane.Visibility);
+	}
+
+	[TestMethod]
+	public async Task LightDismiss_Peer_Is_Only_Exposed_When_Enabled()
+	{
+		var drawer = new DrawerControl
+		{
+			DrawerDepth = 200,
+			IsOpen = true,
+			IsLightDismissEnabled = false,
+			DrawerContent = new Button { Content = "Drawer action" },
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(drawer);
+
+		var lightDismiss = drawer.GetFirstDescendant<Border>(x => x.Name == DrawerControl.TemplateParts.LightDismissOverlayName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.LightDismissOverlayName}");
+		Assert.AreEqual(AccessibilityView.Raw, AutomationProperties.GetAccessibilityView(lightDismiss));
+
+		var drawerPeer = FrameworkElementAutomationPeer.CreatePeerForElement(drawer);
+		Assert.IsNotNull(drawerPeer);
+		Assert.IsFalse(drawerPeer!.GetChildren()?.OfType<FrameworkElementAutomationPeer>()
+			.Any(x => ReferenceEquals(x.Owner, lightDismiss)) == true);
+	}
+
+	[TestMethod]
+	public async Task Escape_Dismisses_Only_When_LightDismiss_Is_Enabled()
+	{
+		var drawer = new DrawerControl
+		{
+			DrawerDepth = 200,
+			IsOpen = true,
+			DrawerContent = new Button { Content = "Drawer action" },
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(drawer);
+
+		Assert.IsTrue(drawer.TryHandleDismissKey(VirtualKey.Escape));
+		Assert.IsFalse(drawer.IsOpen);
+
+		drawer.IsLightDismissEnabled = false;
+		drawer.IsOpen = true;
+
+		Assert.IsFalse(drawer.TryHandleDismissKey(VirtualKey.Escape));
+		Assert.IsTrue(drawer.IsOpen);
+	}
+
+	[TestMethod]
+	public async Task Custom_Template_Base_Parts_Get_Dedicated_Automation_Peers()
+	{
+		var drawer = new DrawerControl
+		{
+			DrawerDepth = 200,
+			IsOpen = true,
+			DrawerContent = new Button { Content = "Drawer action" },
+			Template = XamlHelper.LoadXaml<ControlTemplate>("""
+				<ControlTemplate TargetType="utu:DrawerControl">
+					<Grid>
+						<ContentPresenter x:Name="MainContentPresenter" />
+						<Border x:Name="LightDismissOverlay" />
+						<ContentControl x:Name="DrawerContentControl"
+										Content="{TemplateBinding DrawerContent}">
+							<ContentControl.RenderTransform>
+								<TranslateTransform />
+							</ContentControl.RenderTransform>
+						</ContentControl>
+						<Border x:Name="GestureInterceptor" />
+					</Grid>
+				</ControlTemplate>
+				"""),
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(drawer);
+
+		var pane = drawer.GetFirstDescendant<ContentControl>(x => x.Name == DrawerControl.TemplateParts.DrawerContentControlName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.DrawerContentControlName}");
+		var lightDismiss = drawer.GetFirstDescendant<Border>(x => x.Name == DrawerControl.TemplateParts.LightDismissOverlayName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.LightDismissOverlayName}");
+		var drawerPeer = FrameworkElementAutomationPeer.CreatePeerForElement(drawer) ??
+			throw new Exception("Drawer peer was not created");
+		var children = drawerPeer.GetChildren() ?? throw new Exception("Drawer peer should expose children");
+
+		var panePeer = children.OfType<FrameworkElementAutomationPeer>().Single(x => ReferenceEquals(x.Owner, pane));
+		var lightDismissPeer = children.OfType<FrameworkElementAutomationPeer>().Single(x => ReferenceEquals(x.Owner, lightDismiss));
+
+		Assert.AreEqual(AutomationControlType.Window, panePeer.GetAutomationControlType());
+		Assert.IsInstanceOfType(panePeer.GetPattern(PatternInterface.Window), typeof(IWindowProvider));
+		Assert.AreEqual(AutomationControlType.Button, lightDismissPeer.GetAutomationControlType());
+		Assert.IsInstanceOfType(lightDismissPeer.GetPattern(PatternInterface.Invoke), typeof(IInvokeProvider));
+	}
+
+	[TestMethod]
+	public async Task FitToContent_Drawer_Measures_After_Being_Collapsed()
+	{
+		var drawer = new DrawerControl
+		{
+			Width = 400,
+			Height = 400,
+			Content = new Grid(),
+			DrawerContent = new Button
+			{
+				Content = "Drawer action",
+				Width = 180,
+			},
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(drawer);
+
+		var pane = drawer.GetFirstDescendant<ContentControl>(x => x.Name == DrawerControl.TemplateParts.DrawerContentControlName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.DrawerContentControlName}");
+		Assert.AreEqual(Visibility.Collapsed, pane.Visibility);
+
+		drawer.IsOpen = true;
+
+		await UnitTestUIContentHelperEx.WaitFor(() => pane.Visibility == Visibility.Visible && pane.ActualWidth >= 180);
+		Assert.IsTrue(drawer.IsOpen);
+	}
+
+	[TestMethod]
+	public async Task Opening_Without_Focusable_Content_Focuses_The_Pane()
+	{
+		var opener = new Button { Content = "Open" };
+		var drawer = new DrawerControl
+		{
+			DrawerDepth = 200,
+			Content = opener,
+			DrawerContent = new TextBlock { Text = "Drawer content" },
+		};
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(drawer);
+
+		var pane = drawer.GetFirstDescendant<ContentControl>(x => x.Name == DrawerControl.TemplateParts.DrawerContentControlName) ??
+			throw new Exception($"Failed to find {DrawerControl.TemplateParts.DrawerContentControlName}");
+		Assert.IsTrue(opener.Focus(FocusState.Programmatic));
+
+		drawer.IsOpen = true;
+
+		await UnitTestUIContentHelperEx.WaitFor(() => pane.FocusState != FocusState.Unfocused);
+
+		drawer.IsOpen = false;
+		await UnitTestUIContentHelperEx.WaitFor(() => opener.FocusState != FocusState.Unfocused);
 	}
 }

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ZoomContentControlAutomationPeerTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ZoomContentControlAutomationPeerTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.UI.RuntimeTests;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.RuntimeTests.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class ZoomContentControlAutomationPeerTests
+{
+	[TestMethod]
+	public async Task When_Loaded_Then_ExposesPaneAndAutomationPatterns()
+	{
+		var sut = CreateZoomContentControl();
+		AutomationProperties.SetName(sut, "Zoom viewport");
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(sut);
+
+		var peer = GetPeer(sut);
+
+		Assert.AreEqual(AutomationControlType.Pane, peer.GetAutomationControlType());
+		Assert.AreEqual(nameof(ZoomContentControl), peer.GetClassName());
+		Assert.AreEqual("Zoom viewport", peer.GetName());
+		Assert.AreSame(peer, peer.GetPattern(PatternInterface.Scroll));
+		Assert.AreSame(peer, peer.GetPattern(PatternInterface.Transform));
+		Assert.AreSame(peer, peer.GetPattern(PatternInterface.Transform2));
+		Assert.IsTrue(sut.IsTabStop);
+	}
+
+	[TestMethod]
+	public async Task When_ScrollPatternInvoked_Then_ViewportPans()
+	{
+		var sut = CreateZoomContentControl();
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(sut);
+
+		var provider = GetPeer(sut).GetPattern(PatternInterface.Scroll) as IScrollProvider
+			?? throw new InvalidOperationException("ZoomContentControl should expose IScrollProvider.");
+
+		Assert.IsTrue(provider.HorizontallyScrollable);
+		Assert.IsTrue(provider.VerticallyScrollable);
+		Assert.IsTrue(provider.HorizontalViewSize < 100);
+		Assert.IsTrue(provider.VerticalViewSize < 100);
+
+		provider.SetScrollPercent(50, 25);
+
+		Assert.AreEqual(50, provider.HorizontalScrollPercent, 0.001);
+		Assert.AreEqual(25, provider.VerticalScrollPercent, 0.001);
+
+		var previousHorizontalOffset = sut.HorizontalScrollValue;
+		provider.Scroll(ScrollAmount.SmallIncrement, ScrollAmount.NoAmount);
+
+		Assert.IsTrue(sut.HorizontalScrollValue > previousHorizontalOffset);
+
+		sut.IsPanAllowed = false;
+
+		Assert.IsFalse(provider.HorizontallyScrollable);
+		Assert.IsFalse(provider.VerticallyScrollable);
+		Assert.AreEqual(ScrollPatternIdentifiers.NoScroll, provider.HorizontalScrollPercent);
+		Assert.AreEqual(ScrollPatternIdentifiers.NoScroll, provider.VerticalScrollPercent);
+	}
+
+	[TestMethod]
+	public async Task When_TransformPatternInvoked_Then_ZoomLevelChanges()
+	{
+		var sut = CreateZoomContentControl();
+		sut.MinZoomLevel = 0.5;
+		sut.MaxZoomLevel = 3;
+
+		await UnitTestUIContentHelperEx.SetContentAndWait(sut);
+
+		sut.ZoomLevel = 1.5;
+
+		var provider = GetPeer(sut).GetPattern(PatternInterface.Transform2) as ITransformProvider2
+			?? throw new InvalidOperationException("ZoomContentControl should expose ITransformProvider2.");
+
+		Assert.IsTrue(provider.CanZoom);
+		Assert.AreEqual(50, provider.MinZoom);
+		Assert.AreEqual(300, provider.MaxZoom);
+		Assert.AreEqual(150, provider.ZoomLevel);
+
+		provider.Zoom(200);
+
+		Assert.AreEqual(2, sut.ZoomLevel, 0.001);
+		Assert.AreEqual(200, provider.ZoomLevel, 0.001);
+
+		provider.ZoomByUnit(ZoomUnit.SmallIncrement);
+
+		Assert.IsTrue(sut.ZoomLevel > 2);
+
+		sut.IsZoomAllowed = false;
+
+		Assert.IsFalse(provider.CanZoom);
+	}
+
+	private static ZoomContentControl CreateZoomContentControl() =>
+		new()
+		{
+			Width = 200,
+			Height = 200,
+			AutoCenterContent = false,
+			AutoFitToCanvas = false,
+			Content = new Border
+			{
+				Width = 600,
+				Height = 600,
+			},
+		};
+
+	private static ZoomContentControlAutomationPeer GetPeer(ZoomContentControl owner) =>
+		FrameworkElementAutomationPeer.CreatePeerForElement(owner) as ZoomContentControlAutomationPeer
+		?? throw new InvalidOperationException("ZoomContentControl should create its dedicated automation peer.");
+}

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.Properties.cs
@@ -299,15 +299,23 @@ namespace Uno.Toolkit.UI
 			nameof(IsClickable),
 			typeof(bool),
 			typeof(Card),
-			new PropertyMetadata(true));
+			new PropertyMetadata(true, OnIsClickableChanged));
 
 		/// <summary>
-		/// Gets or sets a value indicating whether the control will respond to pointer and focus events.
+		/// Gets or sets a value indicating whether the control supports pointer, keyboard, and automation activation.
 		/// </summary>
 		public bool IsClickable
 		{
 			get => (bool)GetValue(IsClickableProperty);
 			set => SetValue(IsClickableProperty, value);
+		}
+
+		private static void OnIsClickableChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+		{
+			if (sender is Card card)
+			{
+				card.UpdateIsClickable((bool)args.NewValue);
+			}
 		}
 
 		#endregion

--- a/src/Uno.Toolkit.UI/Controls/Card/Card.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/Card.cs
@@ -1,24 +1,45 @@
-﻿using Windows.ApplicationModel.Store;
-using Windows.Foundation;
-
 #if IS_WINUI
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 #endif
 
 namespace Uno.Toolkit.UI
 {
 	public partial class Card : Control
 	{
+		private const string HeaderContentPresenterName = "HeaderContentPresenter";
+		private const string SubHeaderContentPresenterName = "SubHeaderContentPresenter";
+		private const string SupportingContentPresenterName = "SupportingContentPresenter";
+
+		private Windows.System.VirtualKey? _activationKey;
+
+		/// <summary>
+		/// Occurs when the clickable card is activated by pointer, keyboard, or automation.
+		/// </summary>
+		public
+#if __ANDROID__
+			new
+#endif
+			event RoutedEventHandler? Click;
+
 		public Card()
 		{
 			DefaultStyleKey = typeof(Card);
+			IsTabStop = IsClickable;
+			Tapped += OnTapped;
 		}
+
+		/// <inheritdoc />
+		protected override AutomationPeer OnCreateAutomationPeer() => new CardAutomationPeer(this);
 
 		protected override void OnApplyTemplate()
 		{
@@ -80,12 +101,100 @@ namespace Uno.Toolkit.UI
 
 		protected override void OnLostFocus(RoutedEventArgs e)
 		{
+			if (_activationKey is not null)
+			{
+				VisualStateManager.GoToState(this, IsEnabled ? CommonStates.Normal : CommonStates.Disabled, true);
+			}
+
+			_activationKey = null;
+
 			if (IsClickable)
 			{
 				VisualStateManager.GoToState(this, FocusStates.Unfocused, true);
-
-				base.OnLostFocus(e);
 			}
+
+			base.OnLostFocus(e);
+		}
+
+		protected override void OnKeyDown(KeyRoutedEventArgs e)
+		{
+			base.OnKeyDown(e);
+
+			if (!e.Handled &&
+				IsClickable &&
+				IsEnabled &&
+				FocusState != FocusState.Unfocused &&
+				IsActivationKey(e.OriginalKey))
+			{
+				e.Handled = true;
+
+				if (_activationKey is null)
+				{
+					_activationKey = e.OriginalKey;
+					VisualStateManager.GoToState(this, CommonStates.Pressed, true);
+				}
+			}
+		}
+
+		protected override void OnKeyUp(KeyRoutedEventArgs e)
+		{
+			base.OnKeyUp(e);
+
+			if (!e.Handled &&
+				_activationKey == e.OriginalKey &&
+				IsActivationKey(e.OriginalKey))
+			{
+				_activationKey = null;
+				e.Handled = true;
+				VisualStateManager.GoToState(this, IsEnabled ? CommonStates.Normal : CommonStates.Disabled, true);
+				InvokeClick();
+			}
+		}
+
+		internal UIElement? GetHeaderContentPresenter() => GetTemplateChild(HeaderContentPresenterName) as UIElement;
+
+		internal UIElement? GetSubHeaderContentPresenter() => GetTemplateChild(SubHeaderContentPresenterName) as UIElement;
+
+		internal UIElement? GetSupportingContentPresenter() => GetTemplateChild(SupportingContentPresenterName) as UIElement;
+
+		internal UIElement? GetTemplateVisualRoot() =>
+			VisualTreeHelper.GetChildrenCount(this) > 0
+				? VisualTreeHelper.GetChild(this, 0) as UIElement
+				: null;
+
+		internal void InvokeClick()
+		{
+			if (!IsClickable || !IsEnabled)
+			{
+				return;
+			}
+
+			if (AutomationPeer.ListenerExists(AutomationEvents.InvokePatternOnInvoked) &&
+				FrameworkElementAutomationPeer.CreatePeerForElement(this) is { } peer)
+			{
+				peer.RaiseAutomationEvent(AutomationEvents.InvokePatternOnInvoked);
+			}
+
+			Click?.Invoke(this, new RoutedEventArgs());
+		}
+
+		internal void UpdateIsClickable(bool isClickable)
+		{
+			IsTabStop = isClickable;
+
+			if (!isClickable)
+			{
+				_activationKey = null;
+				VisualStateManager.GoToState(this, IsEnabled ? CommonStates.Normal : CommonStates.Disabled, true);
+			}
+		}
+
+		private static bool IsActivationKey(Windows.System.VirtualKey key) =>
+			key is Windows.System.VirtualKey.Enter or Windows.System.VirtualKey.Space;
+
+		private void OnTapped(object sender, TappedRoutedEventArgs e)
+		{
+			InvokeClick();
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/Card/CardAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/CardAutomationPeer.cs
@@ -1,0 +1,76 @@
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+#else
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes <see cref="Card"/> to Microsoft UI Automation.
+	/// </summary>
+	public partial class CardAutomationPeer : FrameworkElementAutomationPeer, IInvokeProvider
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CardAutomationPeer"/> class.
+		/// </summary>
+		/// <param name="owner">The <see cref="Card"/> instance to create the peer for.</param>
+		public CardAutomationPeer(Card owner) : base(owner)
+		{
+		}
+
+		protected override string GetClassNameCore() => nameof(Card);
+
+		protected override AutomationControlType GetAutomationControlTypeCore() =>
+			Owner is Card { IsClickable: true }
+				? AutomationControlType.Button
+				: AutomationControlType.Group;
+
+		protected override string GetNameCore()
+		{
+			var name = base.GetNameCore();
+			if (Owner is not Card { IsClickable: true } card ||
+				!string.IsNullOrEmpty(AutomationProperties.GetName(card)) ||
+				AutomationProperties.GetLabeledBy(card) is not null)
+			{
+				return name;
+			}
+
+			var contentName = CardAutomationPeerHelper.GetContentName(card.GetHeaderContentPresenter());
+			if (string.IsNullOrEmpty(contentName))
+			{
+				contentName = CardAutomationPeerHelper.GetContentName(card.GetSubHeaderContentPresenter());
+			}
+
+			if (string.IsNullOrEmpty(contentName))
+			{
+				contentName = CardAutomationPeerHelper.GetContentName(card.GetSupportingContentPresenter());
+			}
+
+			if (string.IsNullOrEmpty(contentName))
+			{
+				contentName = CardAutomationPeerHelper.GetContentName(card.GetTemplateVisualRoot());
+			}
+
+			return string.IsNullOrEmpty(contentName) ? name : contentName;
+		}
+
+		protected override object? GetPatternCore(PatternInterface patternInterface) =>
+			patternInterface == PatternInterface.Invoke && Owner is Card { IsClickable: true }
+				? this
+				: base.GetPatternCore(patternInterface);
+
+		/// <inheritdoc />
+		public void Invoke()
+		{
+			if (Owner is Card { IsClickable: true, IsEnabled: true } card)
+			{
+				card.InvokeClick();
+			}
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/Card/CardAutomationPeerHelper.cs
+++ b/src/Uno.Toolkit.UI/Controls/Card/CardAutomationPeerHelper.cs
@@ -1,0 +1,46 @@
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Media;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Media;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	internal static class CardAutomationPeerHelper
+	{
+		public static string GetContentName(UIElement? element)
+		{
+			if (element is null)
+			{
+				return string.Empty;
+			}
+
+			if (FrameworkElementAutomationPeer.CreatePeerForElement(element) is { } peer)
+			{
+				var name = peer.GetName();
+				if (!string.IsNullOrEmpty(name))
+				{
+					return name;
+				}
+			}
+
+			for (var i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
+			{
+				if (VisualTreeHelper.GetChild(element, i) is UIElement child)
+				{
+					var name = GetContentName(child);
+					if (!string.IsNullOrEmpty(name))
+					{
+						return name;
+					}
+				}
+			}
+
+			return string.Empty;
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControl.cs
@@ -7,13 +7,17 @@ using System.Threading.Tasks;
 #if IS_WINUI
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 #else
 using Windows.UI;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 #endif
 
 namespace Uno.Toolkit.UI
@@ -43,6 +47,10 @@ namespace Uno.Toolkit.UI
 	/// </summary>
 	public partial class CardContentControl : ContentControl
 	{
+		private const string ContentPresenterName = "ContentPresenter";
+
+		private Windows.System.VirtualKey? _activationKey;
+
 		#region DependencyProperty: Elevation
 
 		public static DependencyProperty ElevationProperty { get; } = DependencyProperty.Register(
@@ -89,10 +97,10 @@ namespace Uno.Toolkit.UI
 			nameof(IsClickable),
 			typeof(bool),
 			typeof(CardContentControl),
-			new PropertyMetadata(true));
+			new PropertyMetadata(true, OnIsClickableChanged));
 
 		/// <summary>
-		/// Gets or sets a value indicating whether the control will respond to pointer and focus events.
+		/// Gets or sets a value indicating whether the control supports pointer, keyboard, and automation activation.
 		/// </summary>
 		public bool IsClickable
 		{
@@ -100,12 +108,34 @@ namespace Uno.Toolkit.UI
 			set => SetValue(IsClickableProperty, value);
 		}
 
+		private static void OnIsClickableChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+		{
+			if (sender is CardContentControl card)
+			{
+				card.UpdateIsClickable((bool)args.NewValue);
+			}
+		}
+
 		#endregion
+
+		/// <summary>
+		/// Occurs when the clickable card is activated by pointer, keyboard, or automation.
+		/// </summary>
+		public
+#if __ANDROID__
+			new
+#endif
+			event RoutedEventHandler? Click;
 
 		public CardContentControl()
 		{
 			DefaultStyleKey = typeof(CardContentControl);
+			IsTabStop = IsClickable;
+			Tapped += OnTapped;
 		}
+
+		/// <inheritdoc />
+		protected override AutomationPeer OnCreateAutomationPeer() => new CardContentControlAutomationPeer(this);
 
 		protected override void OnApplyTemplate()
 		{
@@ -167,12 +197,106 @@ namespace Uno.Toolkit.UI
 
 		protected override void OnLostFocus(RoutedEventArgs e)
 		{
+			if (_activationKey is not null)
+			{
+				VisualStateManager.GoToState(this, IsEnabled ? CommonStates.Normal : CommonStates.Disabled, true);
+			}
+
+			_activationKey = null;
+
 			if (IsClickable)
 			{
 				VisualStateManager.GoToState(this, FocusStates.Unfocused, true);
-
-				base.OnLostFocus(e);
 			}
+
+			base.OnLostFocus(e);
+		}
+
+		protected override void OnKeyDown(KeyRoutedEventArgs e)
+		{
+			base.OnKeyDown(e);
+
+			if (!e.Handled &&
+				IsClickable &&
+				IsEnabled &&
+				FocusState != FocusState.Unfocused &&
+				IsActivationKey(e.OriginalKey))
+			{
+				e.Handled = true;
+
+				if (_activationKey is null)
+				{
+					_activationKey = e.OriginalKey;
+					VisualStateManager.GoToState(this, CommonStates.Pressed, true);
+				}
+			}
+		}
+
+		protected override void OnKeyUp(KeyRoutedEventArgs e)
+		{
+			base.OnKeyUp(e);
+
+			if (!e.Handled &&
+				_activationKey == e.OriginalKey &&
+				IsActivationKey(e.OriginalKey))
+			{
+				_activationKey = null;
+				e.Handled = true;
+				VisualStateManager.GoToState(this, IsEnabled ? CommonStates.Normal : CommonStates.Disabled, true);
+				InvokeClick();
+			}
+		}
+
+		internal UIElement? GetContentTemplateRoot()
+		{
+			if (ContentTemplateRoot as UIElement is { } root)
+			{
+				return root;
+			}
+
+			if (GetTemplateChild(ContentPresenterName) is UIElement presenter)
+			{
+				return presenter;
+			}
+
+			return VisualTreeHelper.GetChildrenCount(this) > 0
+				? VisualTreeHelper.GetChild(this, 0) as UIElement
+				: null;
+		}
+
+		internal void InvokeClick()
+		{
+			if (!IsClickable || !IsEnabled)
+			{
+				return;
+			}
+
+			if (AutomationPeer.ListenerExists(AutomationEvents.InvokePatternOnInvoked) &&
+				FrameworkElementAutomationPeer.CreatePeerForElement(this) is { } peer)
+			{
+				peer.RaiseAutomationEvent(AutomationEvents.InvokePatternOnInvoked);
+			}
+
+			Click?.Invoke(this, new RoutedEventArgs());
+		}
+
+		private void UpdateIsClickable(bool isClickable)
+		{
+			IsTabStop = isClickable;
+
+			if (!isClickable)
+			{
+				_activationKey = null;
+				VisualStateManager.GoToState(this, IsEnabled ? CommonStates.Normal : CommonStates.Disabled, true);
+			}
+		}
+
+		private static bool IsActivationKey(Windows.System.VirtualKey key) =>
+			key is Windows.System.VirtualKey.Enter or Windows.System.VirtualKey.Space;
+
+		private void OnTapped(object sender, TappedRoutedEventArgs e)
+		{
+			InvokeClick();
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControlAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/CardContentControl/CardContentControlAutomationPeer.cs
@@ -1,0 +1,61 @@
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+#else
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes <see cref="CardContentControl"/> to Microsoft UI Automation.
+	/// </summary>
+	public partial class CardContentControlAutomationPeer : FrameworkElementAutomationPeer, IInvokeProvider
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CardContentControlAutomationPeer"/> class.
+		/// </summary>
+		/// <param name="owner">The <see cref="CardContentControl"/> instance to create the peer for.</param>
+		public CardContentControlAutomationPeer(CardContentControl owner) : base(owner)
+		{
+		}
+
+		protected override string GetClassNameCore() => nameof(CardContentControl);
+
+		protected override AutomationControlType GetAutomationControlTypeCore() =>
+			Owner is CardContentControl { IsClickable: true }
+				? AutomationControlType.Button
+				: AutomationControlType.Group;
+
+		protected override string GetNameCore()
+		{
+			var name = base.GetNameCore();
+			if (Owner is not CardContentControl { IsClickable: true } card ||
+				!string.IsNullOrEmpty(AutomationProperties.GetName(card)) ||
+				AutomationProperties.GetLabeledBy(card) is not null)
+			{
+				return name;
+			}
+
+			var contentName = CardAutomationPeerHelper.GetContentName(card.GetContentTemplateRoot());
+			return string.IsNullOrEmpty(contentName) ? name : contentName;
+		}
+
+		protected override object? GetPatternCore(PatternInterface patternInterface) =>
+			patternInterface == PatternInterface.Invoke && Owner is CardContentControl { IsClickable: true }
+				? this
+				: base.GetPatternCore(patternInterface);
+
+		/// <inheritdoc />
+		public void Invoke()
+		{
+			if (Owner is CardContentControl { IsClickable: true, IsEnabled: true } card)
+			{
+				card.InvokeClick();
+			}
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/Chips/Chip.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/Chip.cs
@@ -6,12 +6,18 @@ using System.Windows.Input;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Media;
 using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
 #endif
 
@@ -20,26 +26,72 @@ namespace Uno.Toolkit.UI
 	[TemplatePart(Name = RemoveButtonName, Type = typeof(Button))]
 	public partial class Chip : ToggleButton
 	{
+		private const string ContentPresenterName = "ContentPresenter";
 		private const string RemoveButtonName = "PART_RemoveButton";
+		private const string RemoveButtonAutomationName = "Remove";
 
+		private bool? _automationIsChecked;
+		private Button? _removeButton;
+		private bool _ownsRemoveButtonAutomationName;
 		private bool _shouldRaiseIsCheckedChanged;
 
-		private ChipGroup? ChipGroup => ItemsControl.ItemsControlFromItemContainer(this) as ChipGroup;
+		internal ChipGroup? OwningChipGroup => ItemsControl.ItemsControlFromItemContainer(this) as ChipGroup;
 
 		public Chip()
 		{
+			_automationIsChecked = IsChecked;
 			Checked += RaiseIsCheckedChanged;
 			Unchecked += RaiseIsCheckedChanged;
+			Loaded += OnLoaded;
+
+			RegisterPropertyChangedCallback(IsCheckedProperty, OnIsCheckedPropertyChanged);
+			RegisterPropertyChangedCallback(ContentProperty, OnAutomationNameSourceChanged);
+			RegisterPropertyChangedCallback(ContentTemplateProperty, OnAutomationNameSourceChanged);
+			RegisterPropertyChangedCallback(ContentTemplateSelectorProperty, OnAutomationNameSourceChanged);
+			RegisterPropertyChangedCallback(AutomationProperties.NameProperty, OnAutomationNameSourceChanged);
+			RegisterPropertyChangedCallback(AutomationProperties.LabeledByProperty, OnAutomationNameSourceChanged);
 		}
+
+		/// <inheritdoc />
+		protected override AutomationPeer OnCreateAutomationPeer() => new ChipAutomationPeer(this);
 
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
 
+			if (_removeButton is not null)
+			{
+				_removeButton.Click -= RaiseRemoveButtonClicked;
+				_removeButton.Loaded -= OnRemoveButtonLoaded;
+			}
+
+			_removeButton = null;
+			_ownsRemoveButtonAutomationName = false;
+
 			if (GetTemplateChild(RemoveButtonName) is Button removeButton)
 			{
+				_removeButton = removeButton;
+				_ownsRemoveButtonAutomationName = string.IsNullOrEmpty(AutomationProperties.GetName(removeButton));
 				removeButton.Click += RaiseRemoveButtonClicked;
+				removeButton.Loaded += OnRemoveButtonLoaded;
+				UpdateRemoveButtonAutomationName();
 			}
+		}
+
+		internal UIElement? GetContentTemplateRoot()
+		{
+			if (ContentTemplateRoot as UIElement is { } root)
+			{
+				return root;
+			}
+
+			if (GetTemplateChild(ContentPresenterName) is ContentPresenter presenter &&
+				VisualTreeHelper.GetChildrenCount(presenter) > 0)
+			{
+				return VisualTreeHelper.GetChild(presenter, 0) as UIElement;
+			}
+
+			return null;
 		}
 
 		internal void OnChipSelectionModeChanged(DependencyPropertyChangedEventArgs e)
@@ -47,6 +99,69 @@ namespace Uno.Toolkit.UI
 			if (e.NewValue is ChipSelectionMode.None)
 			{
 				IsChecked = false;
+			}
+		}
+
+		private void OnLoaded(object sender, RoutedEventArgs e) => UpdateRemoveButtonAutomationName();
+
+		private void OnRemoveButtonLoaded(object sender, RoutedEventArgs e) => UpdateRemoveButtonAutomationName();
+
+		private void OnAutomationNameSourceChanged(DependencyObject sender, DependencyProperty property) =>
+			UpdateRemoveButtonAutomationName();
+
+		private void UpdateRemoveButtonAutomationName()
+		{
+			if (!_ownsRemoveButtonAutomationName || _removeButton is null)
+			{
+				return;
+			}
+
+			var chipName = FrameworkElementAutomationPeer.CreatePeerForElement(this)?.GetName();
+			AutomationProperties.SetName(
+				_removeButton,
+				string.IsNullOrWhiteSpace(chipName)
+					? RemoveButtonAutomationName
+					: $"{RemoveButtonAutomationName} {chipName}");
+		}
+
+		private void OnIsCheckedPropertyChanged(DependencyObject sender, DependencyProperty property)
+		{
+			var oldValue = _automationIsChecked;
+			var newValue = IsChecked;
+			_automationIsChecked = newValue;
+
+			if (oldValue == newValue)
+			{
+				return;
+			}
+
+			if (OwningChipGroup is { SelectionMode: not ChipSelectionMode.None } chipGroup)
+			{
+				var oldSelection = oldValue == true;
+				var newSelection = newValue == true;
+				if (oldSelection == newSelection)
+				{
+					return;
+				}
+
+				var selectionEvent = newSelection
+					? chipGroup.SelectionMode == ChipSelectionMode.Multiple
+						? AutomationEvents.SelectionItemPatternOnElementAddedToSelection
+						: AutomationEvents.SelectionItemPatternOnElementSelected
+					: AutomationEvents.SelectionItemPatternOnElementRemovedFromSelection;
+
+				if ((AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged) ||
+					AutomationPeer.ListenerExists(selectionEvent)) &&
+					FrameworkElementAutomationPeer.CreatePeerForElement(this) is ChipAutomationPeer peer)
+				{
+					peer.RaiseSelectionChanged(oldSelection, newSelection, chipGroup.SelectionMode);
+				}
+			}
+			else if (OwningChipGroup is null &&
+				AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged) &&
+				FrameworkElementAutomationPeer.CreatePeerForElement(this) is ChipAutomationPeer peer)
+			{
+				peer.RaiseToggleStateChanged(oldValue, newValue);
 			}
 		}
 
@@ -96,7 +211,7 @@ namespace Uno.Toolkit.UI
 
 		protected override void OnToggle()
 		{
-			var mode = ChipGroup?.SelectionMode;
+			var mode = OwningChipGroup?.SelectionMode;
 			if (mode is ChipSelectionMode.None)
 			{
 				SetIsCheckedSilently(false);

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipAutomationPeer.cs
@@ -1,0 +1,274 @@
+using System;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Media;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+using Windows.UI.Xaml.Media;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes <see cref="Chip"/> to Microsoft UI Automation.
+	/// </summary>
+	public partial class ChipAutomationPeer : ButtonBaseAutomationPeer, IToggleProvider, ISelectionItemProvider, IInvokeProvider
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ChipAutomationPeer"/> class.
+		/// </summary>
+		/// <param name="owner">The <see cref="Chip"/> instance to create the peer for.</param>
+		public ChipAutomationPeer(Chip owner) : base(owner)
+		{
+		}
+
+		protected override string GetClassNameCore() => nameof(Chip);
+
+		protected override AutomationControlType GetAutomationControlTypeCore() =>
+			GetSelectionGroup() is null ? AutomationControlType.Button : AutomationControlType.ListItem;
+
+		protected override string GetNameCore()
+		{
+			var name = base.GetNameCore();
+			if (Owner is not Chip chip ||
+				!string.IsNullOrEmpty(AutomationProperties.GetName(chip)) ||
+				AutomationProperties.GetLabeledBy(chip) is not null ||
+				chip.GetContentTemplateRoot() is not { } contentTemplateRoot)
+			{
+				return name;
+			}
+
+			var contentName = GetContentName(contentTemplateRoot);
+			return string.IsNullOrEmpty(contentName) ? name : contentName;
+		}
+
+		protected override object? GetPatternCore(PatternInterface patternInterface)
+		{
+			if (Owner is not Chip chip)
+			{
+				return base.GetPatternCore(patternInterface);
+			}
+
+			if (chip.OwningChipGroup is { } chipGroup)
+			{
+				if (patternInterface == PatternInterface.SelectionItem &&
+					chipGroup.SelectionMode != ChipSelectionMode.None)
+				{
+					return this;
+				}
+
+				if (patternInterface == PatternInterface.Invoke &&
+					chipGroup.SelectionMode == ChipSelectionMode.None)
+				{
+					return this;
+				}
+
+				return base.GetPatternCore(patternInterface);
+			}
+
+			return patternInterface == PatternInterface.Toggle
+				? this
+				: base.GetPatternCore(patternInterface);
+		}
+
+		/// <inheritdoc />
+		public ToggleState ToggleState => (Owner as Chip)?.IsChecked switch
+		{
+			true => ToggleState.On,
+			false => ToggleState.Off,
+			_ => ToggleState.Indeterminate,
+		};
+
+		/// <inheritdoc />
+		public void Toggle()
+		{
+			if (Owner is Chip { IsEnabled: true, OwningChipGroup: null } chip)
+			{
+				new ToggleButtonAutomationPeer(chip).Toggle();
+			}
+		}
+
+		/// <inheritdoc />
+		public void Invoke()
+		{
+			if (Owner is Chip
+				{
+					IsEnabled: true,
+					OwningChipGroup: { SelectionMode: ChipSelectionMode.None },
+				} chip)
+			{
+				new ToggleButtonAutomationPeer(chip).Toggle();
+			}
+		}
+
+		/// <inheritdoc />
+		public bool IsSelected => GetSelectionGroup() is not null && (Owner as Chip)?.IsChecked == true;
+
+		/// <inheritdoc />
+		public IRawElementProviderSimple? SelectionContainer
+		{
+			get
+			{
+				if (GetSelectionGroup() is not { } chipGroup ||
+					FrameworkElementAutomationPeer.CreatePeerForElement(chipGroup) is not { } peer)
+				{
+					return null;
+				}
+
+				return ProviderFromPeer(peer);
+			}
+		}
+
+		/// <inheritdoc />
+		public void Select()
+		{
+			var (chip, chipGroup) = GetSelectionContext();
+			if (!chip.IsEnabled)
+			{
+				return;
+			}
+
+			if (chipGroup.SelectionMode == ChipSelectionMode.Multiple)
+			{
+				foreach (var container in chipGroup.GetItemContainers<Chip>())
+				{
+					if (!ReferenceEquals(container, chip) && container.IsChecked == true)
+					{
+						container.IsChecked = false;
+					}
+				}
+			}
+
+			chip.IsChecked = true;
+		}
+
+		/// <inheritdoc />
+		public void AddToSelection()
+		{
+			var (chip, chipGroup) = GetSelectionContext();
+			if (!chip.IsEnabled || chip.IsChecked == true)
+			{
+				return;
+			}
+
+			if (chipGroup.SelectionMode != ChipSelectionMode.Multiple)
+			{
+				foreach (var container in chipGroup.GetItemContainers<Chip>())
+				{
+					if (container.IsChecked == true)
+					{
+						throw new InvalidOperationException("ChipGroup does not support multiple selection.");
+					}
+				}
+			}
+
+			chip.IsChecked = true;
+		}
+
+		/// <inheritdoc />
+		public void RemoveFromSelection()
+		{
+			var (chip, chipGroup) = GetSelectionContext();
+			if (!chip.IsEnabled || chip.IsChecked != true)
+			{
+				return;
+			}
+
+			if (chipGroup.SelectionMode == ChipSelectionMode.Single)
+			{
+				throw new InvalidOperationException("ChipGroup requires a selection.");
+			}
+
+			chip.IsChecked = false;
+		}
+
+		internal void RaiseSelectionChanged(bool oldValue, bool newValue, ChipSelectionMode selectionMode)
+		{
+			if (oldValue == newValue)
+			{
+				return;
+			}
+
+			if (AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged))
+			{
+				RaisePropertyChangedEvent(SelectionItemPatternIdentifiers.IsSelectedProperty, oldValue, newValue);
+			}
+
+			var selectionEvent = newValue
+				? selectionMode == ChipSelectionMode.Multiple
+					? AutomationEvents.SelectionItemPatternOnElementAddedToSelection
+					: AutomationEvents.SelectionItemPatternOnElementSelected
+				: AutomationEvents.SelectionItemPatternOnElementRemovedFromSelection;
+
+			if (AutomationPeer.ListenerExists(selectionEvent))
+			{
+				RaiseAutomationEvent(selectionEvent);
+			}
+		}
+
+		internal void RaiseToggleStateChanged(bool? oldValue, bool? newValue)
+		{
+			var oldState = ConvertToToggleState(oldValue);
+			var newState = ConvertToToggleState(newValue);
+			if (oldState != newState)
+			{
+				RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, oldState, newState);
+			}
+		}
+
+		private ChipGroup? GetSelectionGroup() =>
+			Owner is Chip { OwningChipGroup: { SelectionMode: not ChipSelectionMode.None } chipGroup }
+				? chipGroup
+				: null;
+
+		private (Chip Chip, ChipGroup ChipGroup) GetSelectionContext()
+		{
+			if (Owner is Chip { OwningChipGroup: { SelectionMode: not ChipSelectionMode.None } chipGroup } chip)
+			{
+				return (chip, chipGroup);
+			}
+
+			throw new InvalidOperationException("The Chip is not in a selectable ChipGroup.");
+		}
+
+		private static ToggleState ConvertToToggleState(bool? value) => value switch
+		{
+			true => ToggleState.On,
+			false => ToggleState.Off,
+			_ => ToggleState.Indeterminate,
+		};
+
+		private static string GetContentName(UIElement element)
+		{
+			if (FrameworkElementAutomationPeer.CreatePeerForElement(element) is { } peer)
+			{
+				var name = peer.GetName();
+				if (!string.IsNullOrEmpty(name))
+				{
+					return name;
+				}
+			}
+
+			for (var i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
+			{
+				if (VisualTreeHelper.GetChild(element, i) is UIElement child)
+				{
+					var name = GetContentName(child);
+					if (!string.IsNullOrEmpty(name))
+					{
+						return name;
+					}
+				}
+			}
+
+			return string.Empty;
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipGroup.cs
@@ -8,13 +8,20 @@ using Uno.UI.Extensions;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using XamlFlowDirection = Microsoft.UI.Xaml.FlowDirection;
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using XamlFlowDirection = Windows.UI.Xaml.FlowDirection;
 #endif
+using Windows.System;
 
 namespace Uno.Toolkit.UI
 {
@@ -29,6 +36,9 @@ namespace Uno.Toolkit.UI
 			this.Loaded += OnLoaded;
 		}
 
+		/// <inheritdoc />
+		protected override AutomationPeer OnCreateAutomationPeer() => new ChipGroupAutomationPeer(this);
+
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
@@ -41,6 +51,51 @@ namespace Uno.Toolkit.UI
 			{
 				presenter.Loaded += OnItemsPresenterLoaded;
 			}
+		}
+
+		protected override void OnKeyDown(KeyRoutedEventArgs e)
+		{
+			if (!e.Handled &&
+				e.OriginalSource is DependencyObject source &&
+				source.FindFirstParent<Chip>() is { } currentChip &&
+				ReferenceEquals(currentChip.OwningChipGroup, this) &&
+				GetNavigationOffset(e.Key) is int offset &&
+				TryMoveFocus(currentChip, offset))
+			{
+				e.Handled = true;
+				return;
+			}
+
+			base.OnKeyDown(e);
+		}
+
+		private int? GetNavigationOffset(VirtualKey key) => key switch
+		{
+			VirtualKey.Up => -1,
+			VirtualKey.Down => 1,
+			VirtualKey.Left => FlowDirection == XamlFlowDirection.RightToLeft ? 1 : -1,
+			VirtualKey.Right => FlowDirection == XamlFlowDirection.RightToLeft ? -1 : 1,
+			_ => null,
+		};
+
+		private bool TryMoveFocus(Chip currentChip, int offset)
+		{
+			var containers = this.GetItemContainers<Chip>().ToArray();
+			var currentIndex = Array.IndexOf(containers, currentChip);
+			if (currentIndex < 0)
+			{
+				return false;
+			}
+
+			for (var index = currentIndex + offset; index >= 0 && index < containers.Length; index += offset)
+			{
+				if (containers[index].Focus(FocusState.Keyboard))
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		private void OnLoaded(object sender, RoutedEventArgs e)

--- a/src/Uno.Toolkit.UI/Controls/Chips/ChipGroupAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/Chips/ChipGroupAutomationPeer.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+#else
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes <see cref="ChipGroup"/> to Microsoft UI Automation.
+	/// </summary>
+	public partial class ChipGroupAutomationPeer : FrameworkElementAutomationPeer, ISelectionProvider
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ChipGroupAutomationPeer"/> class.
+		/// </summary>
+		/// <param name="owner">The <see cref="ChipGroup"/> instance to create the peer for.</param>
+		public ChipGroupAutomationPeer(ChipGroup owner) : base(owner)
+		{
+		}
+
+		protected override string GetClassNameCore() => nameof(ChipGroup);
+
+		protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.List;
+
+		protected override object? GetPatternCore(PatternInterface patternInterface) =>
+			patternInterface == PatternInterface.Selection &&
+			Owner is ChipGroup { SelectionMode: not ChipSelectionMode.None }
+				? this
+				: base.GetPatternCore(patternInterface);
+
+		/// <inheritdoc />
+		public bool CanSelectMultiple => Owner is ChipGroup { SelectionMode: ChipSelectionMode.Multiple };
+
+		/// <inheritdoc />
+		public bool IsSelectionRequired => Owner is ChipGroup { SelectionMode: ChipSelectionMode.Single };
+
+		/// <inheritdoc />
+		public IRawElementProviderSimple[] GetSelection()
+		{
+			if (Owner is not ChipGroup { SelectionMode: not ChipSelectionMode.None } chipGroup)
+			{
+				return Array.Empty<IRawElementProviderSimple>();
+			}
+
+			var selection = new List<IRawElementProviderSimple>();
+			foreach (var chip in chipGroup.GetItemContainers<Chip>())
+			{
+				if (chip.IsChecked == true &&
+					FrameworkElementAutomationPeer.CreatePeerForElement(chip) is { } peer &&
+					ProviderFromPeer(peer) is { } provider)
+				{
+					selection.Add(provider);
+				}
+			}
+
+			return selection.ToArray();
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.Properties.cs
@@ -220,7 +220,7 @@ namespace Uno.Toolkit.UI
 			nameof(IsLightDismissEnabled),
 			typeof(bool),
 			typeof(DrawerControl),
-			new PropertyMetadata(DefaultValues.IsLightDismissEnabled));
+			new PropertyMetadata(DefaultValues.IsLightDismissEnabled, OnIsLightDismissEnabledChanged));
 
 		/// <summary>
 		/// Gets or sets a value that indicates whether the drawer can be light-dismissed.
@@ -238,6 +238,7 @@ namespace Uno.Toolkit.UI
 		private static void OnIsOpenChanged(DependencyObject control, DependencyPropertyChangedEventArgs e) => ((DrawerControl)control).OnIsOpenChanged(e);
 		private static void OnFitToDrawerContentChanged(DependencyObject control, DependencyPropertyChangedEventArgs e) => ((DrawerControl)control).OnFitToDrawerContentChanged(e);
 		private static void OnIsGestureEnabledChanged(DependencyObject control, DependencyPropertyChangedEventArgs e) => ((DrawerControl)control).OnIsGestureEnabledChanged(e);
+		private static void OnIsLightDismissEnabledChanged(DependencyObject control, DependencyPropertyChangedEventArgs e) => ((DrawerControl)control).OnIsLightDismissEnabledChanged(e);
 		private static void OnEdgeSwipeDetectionLengthChanged(DependencyObject control, DependencyPropertyChangedEventArgs e) => ((DrawerControl)control).OnEdgeSwipeDetectionLengthChanged(e);
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.cs
@@ -51,6 +51,7 @@ namespace Uno.Toolkit.UI
 
 		private const double DragToggleThresholdRatio = 1.0 / 3; // only accept gesture open/close if 1/3 of distance is completed
 		private const double AnimateSnappingThresholdRatio = 0.05; // skip animation at if 5% of distance from done
+		private const double OpennessTolerance = 0.0001;
 		private static readonly TimeSpan AnimationDuration = TimeSpan.FromMilliseconds(150);
 
 		// template parts
@@ -438,15 +439,16 @@ namespace Uno.Toolkit.UI
 		private void UpdateOpenness(double ratio)
 		{
 			TranslateOffset = ratio * GetVectoredLength();
+			var isClosed = Math.Abs(ratio - 1) < OpennessTolerance;
 			if (_lightDismissOverlay != null)
 			{
 				_lightDismissOverlay.Opacity = 1 - ratio;
-				_lightDismissOverlay.IsHitTestVisible = ratio != 1;
-				_lightDismissOverlay.Visibility = ratio == 1 ? Visibility.Collapsed : Visibility.Visible;
+				_lightDismissOverlay.IsHitTestVisible = !isClosed;
+				_lightDismissOverlay.Visibility = isClosed ? Visibility.Collapsed : Visibility.Visible;
 			}
 			if (_gestureInterceptor != null)
 			{
-				_gestureInterceptor.IsHitTestVisible = IsGestureEnabled && ratio == 1;
+				_gestureInterceptor.IsHitTestVisible = IsGestureEnabled && isClosed;
 			}
 		}
 

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.cs
@@ -12,17 +12,22 @@ using Windows.Foundation;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 #endif
+using Windows.System;
 
 namespace Uno.Toolkit.UI
 {
@@ -65,9 +70,34 @@ namespace Uno.Toolkit.UI
 		private bool _isGestureCaptured;
 		private double _startingTranslateOffset;
 		private bool _suppressIsOpenHandler;
+		private WeakReference<Control>? _previouslyFocusedElement;
+		private FocusState _previousFocusState;
 
 		// test backdoor
 		internal Storyboard AnimationStoryboard => _storyboard;
+		internal ContentControl? DrawerContentPart => _drawerContentControl;
+		internal Border? LightDismissPart => _lightDismissOverlay;
+
+		/// <summary>
+		/// Walks up the visual tree to find the owning <see cref="DrawerControl"/>.
+		/// </summary>
+		/// <remarks>
+		/// FrameworkElement.TemplatedParent is not public API on WinUI, so it
+		/// cannot be used to climb out of a template on every target platform.
+		/// </remarks>
+		internal static DrawerControl? FindOwner(DependencyObject? element)
+		{
+			for (var current = element; current is not null;
+				 current = VisualTreeHelper.GetParent(current))
+			{
+				if (current is DrawerControl drawer)
+				{
+					return drawer;
+				}
+			}
+
+			return null;
+		}
 
 		public DrawerControl()
 		{
@@ -75,6 +105,9 @@ namespace Uno.Toolkit.UI
 
 			_dispatcher = this.GetDispatcherCompat();
 		}
+
+		/// <inheritdoc />
+		protected override AutomationPeer OnCreateAutomationPeer() => new DrawerControlAutomationPeer(this);
 
 		protected override void OnApplyTemplate()
 		{
@@ -90,6 +123,11 @@ namespace Uno.Toolkit.UI
 
 			if (_drawerContentControl != null)
 			{
+				if (_drawerContentControl is DrawerPane drawerPane)
+				{
+					drawerPane.DrawerOwner = this;
+				}
+
 				UpdateSwipeContentPresenterSize();
 				UpdateSwipeContentPresenterLayout();
 				_drawerContentControl.RenderTransform = _drawerContentPresenterTransform = new TranslateTransform();
@@ -125,6 +163,14 @@ namespace Uno.Toolkit.UI
 				_lightDismissOverlay.Tapped += OnLightDismissOverlayTapped;
 			}
 
+			_storyboard.Completed += (_, _) =>
+			{
+				if (!IsOpen)
+				{
+					UpdateAccessibilityState(isOpen: false);
+				}
+			};
+
 			if (_gestureInterceptor != null)
 			{
 				UpdateGestureInterceptorSize();
@@ -134,6 +180,10 @@ namespace Uno.Toolkit.UI
 			if (DrawerDepth != 0)
 			{
 				UpdateIsOpen(IsOpen, shouldAnimate: false);
+			}
+			else
+			{
+				UpdateInteractionState(IsOpen);
 			}
 			_isReady = _drawerContentControl != null;
 
@@ -154,13 +204,48 @@ namespace Uno.Toolkit.UI
 			}
 		}
 
+		protected override void OnKeyDown(KeyRoutedEventArgs e)
+		{
+			base.OnKeyDown(e);
+
+			if (!e.Handled && TryHandleDismissKey(e.Key))
+			{
+				e.Handled = true;
+			}
+		}
+
+		internal bool TryHandleDismissKey(VirtualKey key)
+		{
+			if (key != VirtualKey.Escape || !IsOpen || !IsLightDismissEnabled)
+			{
+				return false;
+			}
+
+			Dismiss();
+			return true;
+		}
+
 		private void OnIsOpenChanged(DependencyPropertyChangedEventArgs e)
 		{
 			if (!_isReady) return;
 			if (_suppressIsOpenHandler) return;
 
+			var isOpen = (bool)e.NewValue;
+			if (!_dispatcher.HasThreadAccess)
+			{
+				_dispatcher.Invoke(() =>
+				{
+					if (_isReady && IsOpen == isOpen)
+					{
+						StopRunningAnimation();
+						UpdateIsOpen(isOpen, shouldAnimate: true);
+					}
+				});
+				return;
+			}
+
 			StopRunningAnimation();
-			UpdateIsOpen((bool)e.NewValue, shouldAnimate: true);
+			UpdateIsOpen(isOpen, shouldAnimate: true);
 		}
 
 		private void OnDrawerDepthChanged(DependencyPropertyChangedEventArgs e)
@@ -213,6 +298,11 @@ namespace Uno.Toolkit.UI
 			}
 		}
 
+		private void OnIsLightDismissEnabledChanged(DependencyPropertyChangedEventArgs e)
+		{
+			UpdateLightDismissAccessibilityState();
+		}
+
 		private void OnManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)
 		{
 			if (!ShouldHandleManipulationFrom(e.OriginalSource)) return;
@@ -229,6 +319,11 @@ namespace Uno.Toolkit.UI
 			if (_isGestureCaptured)
 			{
 				StopRunningAnimation();
+				if (!IsOpen && PrepareDrawerForOpening())
+				{
+					TranslateOffset = GetVectoredLength();
+				}
+
 				_startingTranslateOffset = TranslateOffset;
 
 				e.Handled = true;
@@ -278,7 +373,15 @@ namespace Uno.Toolkit.UI
 
 		private void OnLightDismissOverlayTapped(object sender, TappedRoutedEventArgs e)
 		{
-			if (!IsLightDismissEnabled) return;
+			Dismiss();
+		}
+
+		internal void Dismiss()
+		{
+			if (!IsOpen || !IsLightDismissEnabled)
+			{
+				return;
+			}
 
 			StopRunningAnimation();
 			UpdateIsOpen(false, shouldAnimate: true);
@@ -286,16 +389,26 @@ namespace Uno.Toolkit.UI
 
 		private void UpdateIsOpen(bool willBeOpen, bool shouldAnimate = true)
 		{
+			var wasHidden = willBeOpen && PrepareDrawerForOpening();
+
 			var length = GetActualDrawerDepth();
+			if (wasHidden)
+			{
+				TranslateOffset = UseNegativeTranslation() ? -length : length;
+			}
+
 			var currentOffset = TranslateOffset;
 			var targetOffset = GetSnappingOffsetFor(willBeOpen);
 			var relativeDistanceRatio = Math.Abs(Math.Abs(currentOffset) - Math.Abs(targetOffset)) / length;
 
-			if (shouldAnimate &&
+			var willAnimate =
+				shouldAnimate &&
 				IsLoaded &&
 				_dispatcher.HasThreadAccess &&
 				length > 0 && // skip animation if we have nothing to animate (either from not being ready, or no valid content)
-				relativeDistanceRatio >= AnimateSnappingThresholdRatio) // skip animation if we are less than 5% from done
+				relativeDistanceRatio >= AnimateSnappingThresholdRatio; // skip animation if we are less than 5% from done
+
+			if (willAnimate)
 			{
 				UpdateIsOpenWithSuppress(willBeOpen);
 				PlayAnimation(willBeOpen);
@@ -305,6 +418,8 @@ namespace Uno.Toolkit.UI
 				UpdateOpenness(willBeOpen ? 0 : 1);
 				UpdateIsOpenWithSuppress(willBeOpen);
 			}
+
+			UpdateInteractionState(willBeOpen, keepPaneVisible: willAnimate && !willBeOpen);
 
 			void UpdateIsOpenWithSuppress(bool value)
 			{
@@ -327,6 +442,7 @@ namespace Uno.Toolkit.UI
 			{
 				_lightDismissOverlay.Opacity = 1 - ratio;
 				_lightDismissOverlay.IsHitTestVisible = ratio != 1;
+				_lightDismissOverlay.Visibility = ratio == 1 ? Visibility.Collapsed : Visibility.Visible;
 			}
 			if (_gestureInterceptor != null)
 			{
@@ -360,6 +476,7 @@ namespace Uno.Toolkit.UI
 			if (_lightDismissOverlay != null)
 			{
 				_lightDismissOverlay.IsHitTestVisible = willBeOpen;
+				_lightDismissOverlay.Visibility = Visibility.Visible;
 			}
 			if (_gestureInterceptor != null)
 			{
@@ -625,6 +742,145 @@ namespace Uno.Toolkit.UI
 		private static double Clamp(double min, double value, double max)
 		{
 			return Math.Max(Math.Min(value, max), min);
+		}
+
+		private void MoveFocusIntoDrawer()
+		{
+			if (_drawerContentControl is null)
+			{
+				return;
+			}
+
+			var focusedControl = XamlRoot is { } xamlRoot
+				? FocusManager.GetFocusedElement(xamlRoot) as Control
+				: null;
+			if (focusedControl is not null && IsAncestorOf(_drawerContentControl, focusedControl))
+			{
+				return;
+			}
+
+			if (focusedControl is not null && _previouslyFocusedElement is null)
+			{
+				_previouslyFocusedElement = new WeakReference<Control>(focusedControl);
+				_previousFocusState = focusedControl.FocusState == FocusState.Unfocused
+					? FocusState.Programmatic
+					: focusedControl.FocusState;
+			}
+
+			if (FocusManager.FindFirstFocusableElement(_drawerContentControl) is Control firstFocusable)
+			{
+				firstFocusable.Focus(FocusState.Programmatic);
+			}
+			else
+			{
+				_drawerContentControl.Focus(FocusState.Programmatic);
+			}
+		}
+
+		private void RestoreFocus()
+		{
+			if (_previouslyFocusedElement?.TryGetTarget(out var previouslyFocusedElement) == true)
+			{
+				previouslyFocusedElement.Focus(
+					_previousFocusState == FocusState.Unfocused ? FocusState.Programmatic : _previousFocusState);
+			}
+
+			_previouslyFocusedElement = null;
+			_previousFocusState = FocusState.Unfocused;
+		}
+
+		private static bool IsAncestorOf(DependencyObject ancestor, DependencyObject descendant)
+		{
+			for (var current = descendant; current is not null; current = VisualTreeHelper.GetParent(current))
+			{
+				if (ReferenceEquals(current, ancestor))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private void UpdateAccessibilityState(bool isOpen, bool keepPaneVisible = false)
+		{
+			if (!_dispatcher.HasThreadAccess)
+			{
+				_dispatcher.Invoke(() => UpdateAccessibilityState(isOpen, keepPaneVisible));
+				return;
+			}
+
+			if (_lightDismissOverlay is not null)
+			{
+				_lightDismissOverlay.Visibility = isOpen || keepPaneVisible
+					? Visibility.Visible
+					: Visibility.Collapsed;
+				AutomationProperties.SetAccessibilityView(
+					_lightDismissOverlay,
+					isOpen && IsLightDismissEnabled ? AccessibilityView.Control : AccessibilityView.Raw);
+			}
+
+			if (_drawerContentControl is not null)
+			{
+				_drawerContentControl.Visibility = isOpen || keepPaneVisible
+					? Visibility.Visible
+					: Visibility.Collapsed;
+				_drawerContentControl.IsEnabled = isOpen;
+				_drawerContentControl.IsHitTestVisible = isOpen;
+				_drawerContentControl.TabFocusNavigation = isOpen
+					? KeyboardNavigationMode.Cycle
+					: KeyboardNavigationMode.Local;
+				AutomationProperties.SetAccessibilityView(
+					_drawerContentControl,
+					isOpen ? AccessibilityView.Control : AccessibilityView.Raw);
+			}
+		}
+
+		private void UpdateInteractionState(bool isOpen, bool keepPaneVisible = false)
+		{
+			if (!_dispatcher.HasThreadAccess)
+			{
+				_dispatcher.Invoke(() => UpdateInteractionState(isOpen, keepPaneVisible));
+				return;
+			}
+
+			UpdateAccessibilityState(isOpen, keepPaneVisible);
+			if (isOpen)
+			{
+				MoveFocusIntoDrawer();
+			}
+			else
+			{
+				RestoreFocus();
+			}
+		}
+
+		private void UpdateLightDismissAccessibilityState()
+		{
+			if (!_dispatcher.HasThreadAccess)
+			{
+				_dispatcher.Invoke(UpdateLightDismissAccessibilityState);
+				return;
+			}
+
+			if (_lightDismissOverlay is not null)
+			{
+				AutomationProperties.SetAccessibilityView(
+					_lightDismissOverlay,
+					IsOpen && IsLightDismissEnabled ? AccessibilityView.Control : AccessibilityView.Raw);
+			}
+		}
+
+		private bool PrepareDrawerForOpening()
+		{
+			if (_drawerContentControl is null || _drawerContentControl.Visibility == Visibility.Visible)
+			{
+				return false;
+			}
+
+			_drawerContentControl.Visibility = Visibility.Visible;
+			_drawerContentControl.UpdateLayout();
+			return true;
 		}
 	}
 }

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControl.xaml
@@ -33,22 +33,22 @@
 										  not_win:Content="{TemplateBinding Content}" />
 						<Border x:Name="LightDismissOverlay"
 								Background="{TemplateBinding LightDismissOverlayBackground}" />
-						<ContentControl x:Name="DrawerContentControl"
+						<utu:DrawerPane x:Name="DrawerContentControl"
 										Content="{TemplateBinding DrawerContent}"
 										Background="{TemplateBinding DrawerBackground}"
 										HorizontalContentAlignment="{TemplateBinding HorizontalAlignment}"
 										VerticalContentAlignment="{TemplateBinding VerticalAlignment}">
-							<ContentControl.Template>
+							<utu:DrawerPane.Template>
 								<ControlTemplate TargetType="ContentControl">
 									<Border Background="{TemplateBinding Background}">
 										<ContentPresenter not_win:Content="{TemplateBinding Content}" />
 									</Border>
 								</ControlTemplate>
-							</ContentControl.Template>
-							<ContentControl.RenderTransform>
+							</utu:DrawerPane.Template>
+							<utu:DrawerPane.RenderTransform>
 								<TranslateTransform />
-							</ContentControl.RenderTransform>
-						</ContentControl>
+							</utu:DrawerPane.RenderTransform>
+						</utu:DrawerPane>
 
 						<!-- workaround for edge swipe to work on top of other control (eg: SwipeControl) -->
 						<!-- see: https://github.com/unoplatform/nventive-private/issues/271 -->

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControlAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerControlAutomationPeer.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Media;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Media;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes <see cref="DrawerControl"/> to Microsoft UI Automation.
+	/// </summary>
+	public partial class DrawerControlAutomationPeer : FrameworkElementAutomationPeer
+	{
+		private FrameworkElement? _panePeerOwner;
+		private DrawerPaneAutomationPeer? _panePeer;
+		private FrameworkElement? _lightDismissPeerOwner;
+		private DrawerLightDismissAutomationPeer? _lightDismissPeer;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DrawerControlAutomationPeer"/> class.
+		/// </summary>
+		/// <param name="owner">The <see cref="DrawerControl"/> instance to create the peer for.</param>
+		public DrawerControlAutomationPeer(DrawerControl owner) : base(owner)
+		{
+		}
+
+		protected override string GetClassNameCore() => nameof(DrawerControl);
+
+		protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Group;
+
+		protected override IList<AutomationPeer> GetChildrenCore()
+		{
+			var children = new List<AutomationPeer>();
+			if (Owner is not DrawerControl drawer)
+			{
+				return children;
+			}
+
+			var pane = drawer.DrawerContentPart;
+			var lightDismiss = drawer.LightDismissPart;
+
+			if (base.GetChildrenCore() is { } baseChildren)
+			{
+				foreach (var child in baseChildren)
+				{
+					if (child is FrameworkElementAutomationPeer frameworkElementPeer &&
+						(IsPartOrDescendant(frameworkElementPeer.Owner, pane) ||
+							IsPartOrDescendant(frameworkElementPeer.Owner, lightDismiss)))
+					{
+						continue;
+					}
+
+					children.Add(child);
+				}
+			}
+
+			if (drawer.IsOpen && pane is not null)
+			{
+				children.Add(GetPanePeer(pane, drawer));
+			}
+
+			if (drawer.IsOpen && drawer.IsLightDismissEnabled && lightDismiss is not null)
+			{
+				children.Add(GetLightDismissPeer(lightDismiss, drawer));
+			}
+
+			return children;
+		}
+
+		private AutomationPeer GetPanePeer(FrameworkElement pane, DrawerControl drawer)
+		{
+			if (FrameworkElementAutomationPeer.CreatePeerForElement(pane) is DrawerPaneAutomationPeer peer)
+			{
+				return peer;
+			}
+
+			if (!ReferenceEquals(_panePeerOwner, pane) || _panePeer is null)
+			{
+				_panePeerOwner = pane;
+				_panePeer = new DrawerPaneAutomationPeer(pane, drawer);
+			}
+
+			return _panePeer;
+		}
+
+		private AutomationPeer GetLightDismissPeer(FrameworkElement lightDismiss, DrawerControl drawer)
+		{
+			// Border is sealed on WinUI, so expose its peer as a logical child of the drawer.
+			if (!ReferenceEquals(_lightDismissPeerOwner, lightDismiss) || _lightDismissPeer is null)
+			{
+				_lightDismissPeerOwner = lightDismiss;
+				_lightDismissPeer = new DrawerLightDismissAutomationPeer(lightDismiss, drawer);
+			}
+
+			return _lightDismissPeer;
+		}
+
+		private static bool IsPartOrDescendant(DependencyObject element, DependencyObject? part)
+		{
+			if (part is null)
+			{
+				return false;
+			}
+
+			for (var current = element; current is not null; current = VisualTreeHelper.GetParent(current))
+			{
+				if (ReferenceEquals(current, part))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerLightDismissAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerLightDismissAutomationPeer.cs
@@ -1,0 +1,61 @@
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes the light-dismiss surface of a <see cref="DrawerControl"/> to Microsoft UI Automation.
+	/// </summary>
+	internal partial class DrawerLightDismissAutomationPeer : FrameworkElementAutomationPeer, IInvokeProvider
+	{
+		private readonly DrawerControl? _drawerOwner;
+
+		public DrawerLightDismissAutomationPeer(FrameworkElement owner, DrawerControl? drawerOwner = null) : base(owner)
+		{
+			_drawerOwner = drawerOwner;
+		}
+
+		protected override string GetClassNameCore() => "DrawerLightDismiss";
+
+		protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Button;
+
+		protected override string GetNameCore()
+		{
+			var name = base.GetNameCore();
+			return string.IsNullOrEmpty(name) ? "Close" : name;
+		}
+
+		protected override string GetAutomationIdCore() => "LightDismiss";
+
+		protected override object? GetPatternCore(PatternInterface patternInterface) =>
+			patternInterface == PatternInterface.Invoke && IsLightDismissEnabled()
+				? this
+				: base.GetPatternCore(patternInterface);
+
+		public void Invoke()
+		{
+			if (GetDrawer() is { } drawer)
+			{
+				drawer.Dismiss();
+			}
+		}
+
+		private bool IsLightDismissEnabled() =>
+			GetDrawer() is
+			{
+				IsOpen: true,
+				IsLightDismissEnabled: true,
+			};
+
+		private DrawerControl? GetDrawer() =>
+			_drawerOwner ??
+			DrawerControl.FindOwner(Owner);
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerPane.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerPane.cs
@@ -1,0 +1,17 @@
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+#else
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	internal partial class DrawerPane : ContentControl
+	{
+		internal DrawerControl? DrawerOwner { get; set; }
+
+		protected override AutomationPeer OnCreateAutomationPeer() => new DrawerPaneAutomationPeer(this, DrawerOwner);
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerPaneAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/DrawerControl/DrawerPaneAutomationPeer.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+#endif
+
+namespace Uno.Toolkit.UI
+{
+	/// <summary>
+	/// Exposes the pane of a <see cref="DrawerControl"/> to Microsoft UI Automation.
+	/// </summary>
+	internal partial class DrawerPaneAutomationPeer : FrameworkElementAutomationPeer, IWindowProvider
+	{
+		private readonly DrawerControl? _drawerOwner;
+
+		public DrawerPaneAutomationPeer(FrameworkElement owner, DrawerControl? drawerOwner = null) : base(owner)
+		{
+			_drawerOwner = drawerOwner;
+		}
+
+		protected override string GetClassNameCore() => "DrawerPane";
+
+		protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Window;
+
+		protected override string GetNameCore()
+		{
+			var paneName = AutomationProperties.GetName(Owner);
+			if (!string.IsNullOrEmpty(paneName))
+			{
+				return paneName;
+			}
+
+			if (GetDrawer() is { } drawer)
+			{
+				var drawerName = AutomationProperties.GetName(drawer);
+				if (!string.IsNullOrEmpty(drawerName))
+				{
+					return drawerName;
+				}
+			}
+
+			return base.GetNameCore();
+		}
+
+		protected override object? GetPatternCore(PatternInterface patternInterface) =>
+			patternInterface == PatternInterface.Window && IsOpen()
+				? this
+				: base.GetPatternCore(patternInterface);
+
+		protected override IList<AutomationPeer> GetChildrenCore() =>
+			IsOpen() ? base.GetChildrenCore() : Array.Empty<AutomationPeer>();
+
+		public bool IsModal => true;
+
+		public bool IsTopmost => true;
+
+		public bool Maximizable => false;
+
+		public bool Minimizable => false;
+
+		public WindowInteractionState InteractionState => WindowInteractionState.Running;
+
+		public WindowVisualState VisualState => WindowVisualState.Normal;
+
+		public void Close()
+		{
+			if (GetDrawer() is { } drawer)
+			{
+				drawer.Dismiss();
+			}
+		}
+
+		public void SetVisualState(WindowVisualState state)
+		{
+		}
+
+		public bool WaitForInputIdle(int milliseconds) => false;
+
+		private DrawerControl? GetDrawer() =>
+			_drawerOwner ??
+			(Owner as DrawerPane)?.DrawerOwner ??
+			DrawerControl.FindOwner(Owner);
+
+		private bool IsOpen() => GetDrawer()?.IsOpen == true;
+	}
+}

--- a/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.Properties.cs
+++ b/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.Properties.cs
@@ -226,7 +226,7 @@ partial class ZoomContentControl // dependency properties
 		nameof(IsZoomAllowed),
 		typeof(bool),
 		typeof(ZoomContentControl),
-		new PropertyMetadata(DefaultValues.IsZoomAllowed));
+		new PropertyMetadata(DefaultValues.IsZoomAllowed, OnIsZoomAllowedChanged));
 
 	/// <summary>
 	/// Gets or sets a value indicating whether zooming is allowed.
@@ -291,7 +291,7 @@ partial class ZoomContentControl // dependency properties
 		nameof(IsPanAllowed),
 		typeof(bool),
 		typeof(ZoomContentControl),
-		new PropertyMetadata(DefaultValues.IsPanAllowed));
+		new PropertyMetadata(DefaultValues.IsPanAllowed, OnIsPanAllowedChanged));
 
 	/// <summary>
 	/// Gets or sets a value indicating whether panning is allowed.
@@ -458,6 +458,8 @@ partial class ZoomContentControl // dependency properties
 	private static void OnZoomLevelChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => ((ZoomContentControl)sender).OnZoomLevelChanged();
 	private static void OnMinZoomLevelChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => ((ZoomContentControl)sender).OnMinZoomLevelChanged();
 	private static void OnMaxZoomLevelChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => ((ZoomContentControl)sender).OnMaxZoomLevelChanged();
+	private static void OnIsZoomAllowedChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => ((ZoomContentControl)sender).OnIsZoomAllowedChanged();
+	private static void OnIsPanAllowedChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => ((ZoomContentControl)sender).OnIsPanAllowedChanged();
 	private static void OnIsActiveChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => ((ZoomContentControl)sender).OnIsActiveChanged();
 	private static void OnAllowFreePanningChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => ((ZoomContentControl)sender).OnAllowFreePanningChanged();
 	private static void OnAdditionalMarginChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) => ((ZoomContentControl)sender).OnAdditionalMarginChanged();

--- a/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Uno.Disposables;
+using Uno.Extensions;
+using Uno.Logging;
 using Uno.UI.Extensions;
 
 #if IS_WINUI
@@ -425,7 +427,7 @@ partial class ZoomContentControl
 		ViewportSizeChanged?.Invoke(this, EventArgs.Empty);
 	}
 
-	private async void OnZoomLevelChanged()
+	private void OnZoomLevelChanged()
 	{
 		if (_viewport is null || _translation is null)
 		{
@@ -469,7 +471,7 @@ partial class ZoomContentControl
 		UpdateTransformAutomationProperties();
 		ZoomLevelChanged?.Invoke(this, new(previousZoom ?? double.NaN, ZoomLevel, fromMouseWheelPanning: _isHandlingMouseWheelZooming));
 		NotifyStateChanged();
-		await RaiseRenderedContentUpdated();
+		_ = RaiseRenderedContentUpdated();
 	}
 
 	private void OnMinZoomLevelChanged()
@@ -663,7 +665,7 @@ partial class ZoomContentControl // helpers
 		return false;
 	}
 
-	private async void UpdateScrollDetails()
+	private void UpdateScrollDetails()
 	{
 		if ((_localFocusTarget ?? Content) is FrameworkElement { IsLoaded: true } fe)
 		{
@@ -673,7 +675,7 @@ partial class ZoomContentControl // helpers
 			if (AutoCenterContent) CenterContent();
 			UpdateScrollBars();
 
-			await RaiseRenderedContentUpdated();
+			_ = RaiseRenderedContentUpdated();
 		}
 	}
 
@@ -792,9 +794,15 @@ partial class ZoomContentControl // helpers
 
 	private async Task RaiseRenderedContentUpdated()
 	{
-		await Task.Yield();
-
-		RenderedContentUpdated?.Invoke(this, EventArgs.Empty);
+		try
+		{
+			await Task.Yield();
+			RenderedContentUpdated?.Invoke(this, EventArgs.Empty);
+		}
+		catch (Exception error)
+		{
+			this.Log().Error("Failed to raise RenderedContentUpdated.", error);
+		}
 	}
 
 	private void UpdateScrollBarMirrorSpacing()

--- a/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.cs
+++ b/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.cs
@@ -9,6 +9,7 @@ using Uno.UI.Extensions;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
@@ -16,6 +17,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Input;
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
@@ -78,6 +80,9 @@ partial class ZoomContentControl
 [TemplatePart(Name = TemplateParts.HorizontalScrollBar, Type = typeof(ScrollBar))]
 partial class ZoomContentControl
 {
+	private const double KeyboardScrollRatio = 0.1d;
+	private const double KeyboardZoomChange = 0.1d;
+
 	private static class TemplateParts
 	{
 		public const string RootGrid = "PART_RootGrid";
@@ -128,6 +133,9 @@ partial class ZoomContentControl
 		DefaultStyleKey = typeof(ZoomContentControl);
 		SizeChanged += OnSizeChanged;
 	}
+
+	/// <inheritdoc />
+	protected override AutomationPeer OnCreateAutomationPeer() => new ZoomContentControlAutomationPeer(this);
 
 	protected override void OnApplyTemplate()
 	{
@@ -207,6 +215,7 @@ partial class ZoomContentControl
 	private void OnViewportSizeChanged(object sender, SizeChangedEventArgs args)
 	{
 		UpdateScrollDetails();
+		UpdateScrollAutomationProperties();
 
 		ViewportSizeChanged?.Invoke(this, EventArgs.Empty);
 	}
@@ -330,17 +339,77 @@ partial class ZoomContentControl
 		}
 	}
 
+	protected override void OnKeyDown(KeyRoutedEventArgs e)
+	{
+		base.OnKeyDown(e);
+
+		if (e.Handled || !IsAllowedToWork)
+		{
+			return;
+		}
+
+		if (e.OriginalKey is Windows.System.VirtualKey.Add or Windows.System.VirtualKey.Subtract)
+		{
+			if (!IsZoomAllowed)
+			{
+				return;
+			}
+
+			var oldZoomLevel = ZoomLevel;
+			var change = e.OriginalKey == Windows.System.VirtualKey.Add
+				? KeyboardZoomChange
+				: -KeyboardZoomChange;
+			ZoomLevel = Math.Clamp(ZoomLevel + change, MinZoomLevel, MaxZoomLevel);
+			e.Handled = ZoomLevel != oldZoomLevel;
+			return;
+		}
+
+		if (!IsPanAllowed)
+		{
+			return;
+		}
+
+		var viewport = ClippedViewportSize;
+		var horizontalSmallChange = GetKeyboardScrollChange(viewport.Width);
+		var verticalSmallChange = GetKeyboardScrollChange(viewport.Height);
+		var horizontalLargeChange = Math.Max(horizontalSmallChange, GetFinitePositiveValue(viewport.Width));
+		var verticalLargeChange = Math.Max(verticalSmallChange, GetFinitePositiveValue(viewport.Height));
+		var delta = e.OriginalKey switch
+		{
+			Windows.System.VirtualKey.Left => new Point(-horizontalSmallChange, 0),
+			Windows.System.VirtualKey.Right => new Point(horizontalSmallChange, 0),
+			Windows.System.VirtualKey.Up => new Point(0, -verticalSmallChange),
+			Windows.System.VirtualKey.Down => new Point(0, verticalSmallChange),
+			Windows.System.VirtualKey.PageUp => new Point(0, -verticalLargeChange),
+			Windows.System.VirtualKey.PageDown => new Point(0, verticalLargeChange),
+			_ => default,
+		};
+
+		if (delta == default)
+		{
+			return;
+		}
+
+		var oldScrollValue = ScrollValue;
+		SetScrollValue(oldScrollValue.Add(delta));
+		e.Handled =
+			HorizontalScrollValue != oldScrollValue.X ||
+			VerticalScrollValue != oldScrollValue.Y;
+	}
+
 	// dp changed handlers
 	private void OnHorizontalScrollValueChanged()
 	{
 		if (_preventTranslationUpdate) return;
 		UpdateTranslation();
+		UpdateScrollAutomationProperties();
 	}
 
 	private void OnVerticalScrollValueChanged()
 	{
 		if (_preventTranslationUpdate) return;
 		UpdateTranslation();
+		UpdateScrollAutomationProperties();
 	}
 
 	private void OnAdditionalMarginChanged()
@@ -351,13 +420,18 @@ partial class ZoomContentControl
 		// AutoCenterContent inside UpdateScrollDetails); otherwise the content stays fitted/centered
 		// against the previous margin until an unrelated size/zoom change happens to re-fit.
 		UpdateScrollDetails();
+		UpdateScrollAutomationProperties();
 
 		ViewportSizeChanged?.Invoke(this, EventArgs.Empty);
 	}
 
 	private async void OnZoomLevelChanged()
 	{
-		if (_viewport is null || _translation is null) return;
+		if (_viewport is null || _translation is null)
+		{
+			UpdateTransformAutomationProperties();
+			return;
+		}
 
 		if (CoerceZoomLevel())
 		{
@@ -392,6 +466,7 @@ partial class ZoomContentControl
 		}
 		_previousZoomLevel = ZoomLevel;
 
+		UpdateTransformAutomationProperties();
 		ZoomLevelChanged?.Invoke(this, new(previousZoom ?? double.NaN, ZoomLevel, fromMouseWheelPanning: _isHandlingMouseWheelZooming));
 		NotifyStateChanged();
 		await RaiseRenderedContentUpdated();
@@ -400,11 +475,23 @@ partial class ZoomContentControl
 	private void OnMinZoomLevelChanged()
 	{
 		CoerceZoomLevel();
+		UpdateTransformAutomationProperties();
 	}
 
 	private void OnMaxZoomLevelChanged()
 	{
 		CoerceZoomLevel();
+		UpdateTransformAutomationProperties();
+	}
+
+	private void OnIsZoomAllowedChanged()
+	{
+		UpdateTransformAutomationProperties();
+	}
+
+	private void OnIsPanAllowedChanged()
+	{
+		UpdateScrollAutomationProperties();
 	}
 
 	private void OnIsActiveChanged()
@@ -423,6 +510,8 @@ partial class ZoomContentControl
 			_scrollV.Visibility = IsActive ? Visibility.Visible : Visibility.Collapsed;
 		}
 
+		UpdateScrollAutomationProperties();
+		UpdateTransformAutomationProperties();
 		IsActiveChanged?.Invoke(this, EventArgs.Empty);
 	}
 
@@ -663,6 +752,8 @@ partial class ZoomContentControl // helpers
 			sb.IsEnabled = shown;
 			sb.Opacity = shown ? 1 : 0;
 		}
+
+		UpdateScrollAutomationProperties();
 	}
 
 	internal void SetScrollValue(Point value, bool shouldClamp = true)
@@ -681,6 +772,7 @@ partial class ZoomContentControl // helpers
 		_preventTranslationUpdate = false;
 
 		UpdateTranslation();
+		UpdateScrollAutomationProperties();
 		NotifyStateChanged();
 	}
 
@@ -764,6 +856,28 @@ partial class ZoomContentControl // helpers
 #else
 			.PointerDevice.PointerDeviceType == PointerDeviceType.Mouse;
 #endif
+	}
+
+	private static double GetKeyboardScrollChange(double viewport) =>
+		Math.Max(1d, GetFinitePositiveValue(viewport) * KeyboardScrollRatio);
+
+	private static double GetFinitePositiveValue(double value) =>
+		double.IsFinite(value) && value > 0 ? value : 0;
+
+	private void UpdateScrollAutomationProperties()
+	{
+		if (FrameworkElementAutomationPeer.FromElement(this) is ZoomContentControlAutomationPeer peer)
+		{
+			peer.UpdateScrollPatternProperties();
+		}
+	}
+
+	private void UpdateTransformAutomationProperties()
+	{
+		if (FrameworkElementAutomationPeer.FromElement(this) is ZoomContentControlAutomationPeer peer)
+		{
+			peer.UpdateTransformPatternProperties();
+		}
 	}
 
 	public Size ViewportSize => _viewport is { } ? new Size(_viewport.ActualWidth, _viewport.ActualHeight) : new Size(double.NaN, double.NaN);

--- a/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.xaml
+++ b/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControl.xaml
@@ -5,6 +5,8 @@
 	<Style x:Key="DefaultZoomContentControlStyle" TargetType="utu:ZoomContentControl">
 		<Setter Property="Background" Value="Transparent" />
 		<Setter Property="HorizontalContentAlignment" Value="Left" />
+		<Setter Property="IsTabStop" Value="True" />
+		<Setter Property="UseSystemFocusVisuals" Value="True" />
 		<Setter Property="VerticalContentAlignment" Value="Top" />
 
 		<Setter Property="Template">
@@ -13,7 +15,8 @@
 					<Grid x:Name="PART_RootGrid"
 						  Background="{TemplateBinding Background}"
 						  BorderBrush="{TemplateBinding BorderBrush}"
-						  BorderThickness="{TemplateBinding BorderThickness}">
+						  BorderThickness="{TemplateBinding BorderThickness}"
+						  Control.IsTemplateFocusTarget="True">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="ScrollBarLayoutStates">
 								<VisualState x:Name="BottomRight">

--- a/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControlAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControlAutomationPeer.cs
@@ -20,6 +20,7 @@ public partial class ZoomContentControlAutomationPeer : FrameworkElementAutomati
 {
 	private const double MinimumPercent = 0d;
 	private const double MaximumPercent = 100d;
+	private const double PercentTolerance = 0.0001d;
 	private const double SmallScrollRatio = 0.1d;
 	private const double SmallZoomChange = 10d;
 	private const double LargeZoomChange = 50d;
@@ -124,8 +125,8 @@ public partial class ZoomContentControlAutomationPeer : FrameworkElementAutomati
 	{
 		EnsureEnabled();
 
-		var scrollHorizontally = horizontalPercent != ScrollPatternIdentifiers.NoScroll;
-		var scrollVertically = verticalPercent != ScrollPatternIdentifiers.NoScroll;
+		var scrollHorizontally = !IsNoScroll(horizontalPercent);
+		var scrollVertically = !IsNoScroll(verticalPercent);
 		if (!scrollHorizontally && !scrollVertically)
 		{
 			return;
@@ -266,6 +267,9 @@ public partial class ZoomContentControlAutomationPeer : FrameworkElementAutomati
 		var range = maximum - minimum;
 		return double.IsFinite(range) && range > 0 ? range : 0;
 	}
+
+	private static bool IsNoScroll(double percent) =>
+		Math.Abs(percent - ScrollPatternIdentifiers.NoScroll) < PercentTolerance;
 
 	private static double GetScrollPercent(bool scrollable, double value, double minimum, double range)
 	{

--- a/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControlAutomationPeer.cs
+++ b/src/Uno.Toolkit.UI/Controls/ZoomContentControl/ZoomContentControlAutomationPeer.cs
@@ -1,0 +1,379 @@
+using System;
+using Windows.Foundation;
+
+#if IS_WINUI
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+#else
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+#endif
+
+namespace Uno.Toolkit.UI;
+
+/// <summary>
+/// Exposes <see cref="ZoomContentControl"/> to Microsoft UI Automation.
+/// </summary>
+public partial class ZoomContentControlAutomationPeer : FrameworkElementAutomationPeer, IScrollProvider, ITransformProvider2
+{
+	private const double MinimumPercent = 0d;
+	private const double MaximumPercent = 100d;
+	private const double SmallScrollRatio = 0.1d;
+	private const double SmallZoomChange = 10d;
+	private const double LargeZoomChange = 50d;
+
+	private readonly ZoomContentControl _owner;
+
+	private bool _horizontallyScrollable;
+	private bool _verticallyScrollable;
+	private double _horizontalScrollPercent;
+	private double _verticalScrollPercent;
+	private double _horizontalViewSize;
+	private double _verticalViewSize;
+	private bool _canZoom;
+	private double _zoomLevel;
+	private double _minZoom;
+	private double _maxZoom;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ZoomContentControlAutomationPeer"/> class.
+	/// </summary>
+	/// <param name="owner">The <see cref="ZoomContentControl"/> instance to create the peer for.</param>
+	public ZoomContentControlAutomationPeer(ZoomContentControl owner) : base(owner)
+	{
+		_owner = owner;
+
+		_horizontallyScrollable = HorizontallyScrollable;
+		_verticallyScrollable = VerticallyScrollable;
+		_horizontalScrollPercent = HorizontalScrollPercent;
+		_verticalScrollPercent = VerticalScrollPercent;
+		_horizontalViewSize = HorizontalViewSize;
+		_verticalViewSize = VerticalViewSize;
+		_canZoom = CanZoom;
+		_zoomLevel = ZoomLevel;
+		_minZoom = MinZoom;
+		_maxZoom = MaxZoom;
+	}
+
+	protected override string GetClassNameCore() => nameof(ZoomContentControl);
+
+	protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Pane;
+
+	protected override object? GetPatternCore(PatternInterface patternInterface) =>
+		patternInterface is PatternInterface.Scroll or PatternInterface.Transform or PatternInterface.Transform2
+			? this
+			: base.GetPatternCore(patternInterface);
+
+	/// <inheritdoc />
+	public bool HorizontallyScrollable => _owner.IsActive && _owner.IsPanAllowed && GetHorizontalRange() > 0;
+
+	/// <inheritdoc />
+	public bool VerticallyScrollable => _owner.IsActive && _owner.IsPanAllowed && GetVerticalRange() > 0;
+
+	/// <inheritdoc />
+	public double HorizontalScrollPercent =>
+		GetScrollPercent(HorizontallyScrollable, _owner.HorizontalScrollValue, _owner.HorizontalMinScroll, GetHorizontalRange());
+
+	/// <inheritdoc />
+	public double VerticalScrollPercent =>
+		GetScrollPercent(VerticallyScrollable, _owner.VerticalScrollValue, _owner.VerticalMinScroll, GetVerticalRange());
+
+	/// <inheritdoc />
+	public double HorizontalViewSize => GetViewSize(GetHorizontalRange(), _owner.ClippedViewportSize.Width);
+
+	/// <inheritdoc />
+	public double VerticalViewSize => GetViewSize(GetVerticalRange(), _owner.ClippedViewportSize.Height);
+
+	/// <inheritdoc />
+	public void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount)
+	{
+		EnsureEnabled();
+		ValidateScrollAmount(horizontalAmount, nameof(horizontalAmount));
+		ValidateScrollAmount(verticalAmount, nameof(verticalAmount));
+
+		var scrollHorizontally = horizontalAmount != ScrollAmount.NoAmount;
+		var scrollVertically = verticalAmount != ScrollAmount.NoAmount;
+		if (!scrollHorizontally && !scrollVertically)
+		{
+			return;
+		}
+
+		if ((scrollHorizontally && !HorizontallyScrollable) ||
+			(scrollVertically && !VerticallyScrollable))
+		{
+			throw new InvalidOperationException("The requested direction cannot be scrolled.");
+		}
+
+		var value = _owner.ScrollValue;
+		if (scrollHorizontally)
+		{
+			value.X += GetScrollDelta(horizontalAmount, _owner.ClippedViewportSize.Width);
+		}
+		if (scrollVertically)
+		{
+			value.Y += GetScrollDelta(verticalAmount, _owner.ClippedViewportSize.Height);
+		}
+
+		_owner.SetScrollValue(value);
+	}
+
+	/// <inheritdoc />
+	public void SetScrollPercent(double horizontalPercent, double verticalPercent)
+	{
+		EnsureEnabled();
+
+		var scrollHorizontally = horizontalPercent != ScrollPatternIdentifiers.NoScroll;
+		var scrollVertically = verticalPercent != ScrollPatternIdentifiers.NoScroll;
+		if (!scrollHorizontally && !scrollVertically)
+		{
+			return;
+		}
+
+		if ((scrollHorizontally && !HorizontallyScrollable) ||
+			(scrollVertically && !VerticallyScrollable))
+		{
+			throw new InvalidOperationException("The requested direction cannot be scrolled.");
+		}
+
+		ValidateScrollPercent(horizontalPercent, scrollHorizontally, nameof(horizontalPercent));
+		ValidateScrollPercent(verticalPercent, scrollVertically, nameof(verticalPercent));
+
+		var value = _owner.ScrollValue;
+		if (scrollHorizontally)
+		{
+			value.X = _owner.HorizontalMinScroll + (GetHorizontalRange() * horizontalPercent / MaximumPercent);
+		}
+		if (scrollVertically)
+		{
+			value.Y = _owner.VerticalMinScroll + (GetVerticalRange() * verticalPercent / MaximumPercent);
+		}
+
+		_owner.SetScrollValue(value);
+	}
+
+	/// <inheritdoc />
+	public bool CanMove => false;
+
+	/// <inheritdoc />
+	public bool CanResize => false;
+
+	/// <inheritdoc />
+	public bool CanRotate => false;
+
+	/// <inheritdoc />
+	public void Move(double x, double y) => ThrowUnsupportedTransformOperation();
+
+	/// <inheritdoc />
+	public void Resize(double width, double height) => ThrowUnsupportedTransformOperation();
+
+	/// <inheritdoc />
+	public void Rotate(double degrees) => ThrowUnsupportedTransformOperation();
+
+	/// <inheritdoc />
+	public bool CanZoom => _owner.IsActive && _owner.IsZoomAllowed;
+
+	/// <inheritdoc />
+	public double MaxZoom => _owner.MaxZoomLevel * MaximumPercent;
+
+	/// <inheritdoc />
+	public double MinZoom => _owner.MinZoomLevel * MaximumPercent;
+
+	/// <inheritdoc />
+	public double ZoomLevel => _owner.ZoomLevel * MaximumPercent;
+
+	/// <inheritdoc />
+	public void Zoom(double zoom)
+	{
+		EnsureEnabled();
+		EnsureCanZoom();
+
+		if (!double.IsFinite(zoom))
+		{
+			throw new ArgumentOutOfRangeException(nameof(zoom));
+		}
+
+		_owner.ZoomLevel = Math.Clamp(zoom, MinZoom, MaxZoom) / MaximumPercent;
+	}
+
+	/// <inheritdoc />
+	public void ZoomByUnit(ZoomUnit zoomUnit)
+	{
+		EnsureEnabled();
+
+		var change = zoomUnit switch
+		{
+			ZoomUnit.NoAmount => 0d,
+			ZoomUnit.SmallDecrement => -SmallZoomChange,
+			ZoomUnit.LargeDecrement => -LargeZoomChange,
+			ZoomUnit.SmallIncrement => SmallZoomChange,
+			ZoomUnit.LargeIncrement => LargeZoomChange,
+			_ => throw new ArgumentOutOfRangeException(nameof(zoomUnit)),
+		};
+
+		if (change == 0)
+		{
+			return;
+		}
+
+		EnsureCanZoom();
+		Zoom(ZoomLevel + change);
+	}
+
+	internal void UpdateScrollPatternProperties()
+	{
+		UpdateProperty(
+			ScrollPatternIdentifiers.HorizontallyScrollableProperty,
+			ref _horizontallyScrollable,
+			HorizontallyScrollable);
+		UpdateProperty(
+			ScrollPatternIdentifiers.VerticallyScrollableProperty,
+			ref _verticallyScrollable,
+			VerticallyScrollable);
+		UpdateProperty(
+			ScrollPatternIdentifiers.HorizontalViewSizeProperty,
+			ref _horizontalViewSize,
+			HorizontalViewSize);
+		UpdateProperty(
+			ScrollPatternIdentifiers.VerticalViewSizeProperty,
+			ref _verticalViewSize,
+			VerticalViewSize);
+		UpdateProperty(
+			ScrollPatternIdentifiers.HorizontalScrollPercentProperty,
+			ref _horizontalScrollPercent,
+			HorizontalScrollPercent);
+		UpdateProperty(
+			ScrollPatternIdentifiers.VerticalScrollPercentProperty,
+			ref _verticalScrollPercent,
+			VerticalScrollPercent);
+	}
+
+	internal void UpdateTransformPatternProperties()
+	{
+		UpdateProperty(TransformPattern2Identifiers.CanZoomProperty, ref _canZoom, CanZoom);
+		UpdateProperty(TransformPattern2Identifiers.MinZoomProperty, ref _minZoom, MinZoom);
+		UpdateProperty(TransformPattern2Identifiers.MaxZoomProperty, ref _maxZoom, MaxZoom);
+		UpdateProperty(TransformPattern2Identifiers.ZoomLevelProperty, ref _zoomLevel, ZoomLevel);
+	}
+
+	private double GetHorizontalRange() => GetRange(_owner.HorizontalMinScroll, _owner.HorizontalMaxScroll);
+
+	private double GetVerticalRange() => GetRange(_owner.VerticalMinScroll, _owner.VerticalMaxScroll);
+
+	private static double GetRange(double minimum, double maximum)
+	{
+		var range = maximum - minimum;
+		return double.IsFinite(range) && range > 0 ? range : 0;
+	}
+
+	private static double GetScrollPercent(bool scrollable, double value, double minimum, double range)
+	{
+		if (!scrollable || range == 0)
+		{
+			return ScrollPatternIdentifiers.NoScroll;
+		}
+
+		var percent = (value - minimum) * MaximumPercent / range;
+		return double.IsFinite(percent)
+			? Math.Clamp(percent, MinimumPercent, MaximumPercent)
+			: MinimumPercent;
+	}
+
+	private static double GetViewSize(double range, double viewport)
+	{
+		if (range == 0)
+		{
+			return MaximumPercent;
+		}
+
+		viewport = double.IsFinite(viewport) && viewport > 0 ? viewport : 0;
+		var extent = viewport + range;
+		return extent > 0
+			? Math.Clamp(viewport * MaximumPercent / extent, MinimumPercent, MaximumPercent)
+			: MaximumPercent;
+	}
+
+	private static double GetScrollDelta(ScrollAmount amount, double viewport)
+	{
+		viewport = double.IsFinite(viewport) && viewport > 0 ? viewport : 0;
+		var smallChange = Math.Max(1d, viewport * SmallScrollRatio);
+		var largeChange = Math.Max(smallChange, viewport);
+
+		return amount switch
+		{
+			ScrollAmount.LargeDecrement => -largeChange,
+			ScrollAmount.SmallDecrement => -smallChange,
+			ScrollAmount.SmallIncrement => smallChange,
+			ScrollAmount.LargeIncrement => largeChange,
+			_ => 0,
+		};
+	}
+
+	private static void ValidateScrollAmount(ScrollAmount amount, string parameterName)
+	{
+		if (amount is not ScrollAmount.NoAmount and
+			not ScrollAmount.SmallDecrement and
+			not ScrollAmount.LargeDecrement and
+			not ScrollAmount.SmallIncrement and
+			not ScrollAmount.LargeIncrement)
+		{
+			throw new ArgumentOutOfRangeException(parameterName);
+		}
+	}
+
+	private static void ValidateScrollPercent(double percent, bool requested, string parameterName)
+	{
+		if (requested &&
+			(!double.IsFinite(percent) || percent < MinimumPercent || percent > MaximumPercent))
+		{
+			throw new ArgumentOutOfRangeException(parameterName);
+		}
+	}
+
+	private void EnsureEnabled()
+	{
+		if (!IsEnabled())
+		{
+			throw new ElementNotEnabledException();
+		}
+	}
+
+	private void EnsureCanZoom()
+	{
+		if (!CanZoom)
+		{
+			throw new InvalidOperationException("Zooming is not available.");
+		}
+	}
+
+	private void ThrowUnsupportedTransformOperation()
+	{
+		EnsureEnabled();
+		throw new InvalidOperationException("Moving, resizing, and rotating are not supported.");
+	}
+
+	private void UpdateProperty(AutomationProperty property, ref bool currentValue, bool newValue)
+	{
+		if (currentValue == newValue)
+		{
+			return;
+		}
+
+		var oldValue = currentValue;
+		currentValue = newValue;
+		RaisePropertyChangedEvent(property, oldValue, newValue);
+	}
+
+	private void UpdateProperty(AutomationProperty property, ref double currentValue, double newValue)
+	{
+		if (currentValue == newValue)
+		{
+			return;
+		}
+
+		var oldValue = currentValue;
+		currentValue = newValue;
+		RaisePropertyChangedEvent(property, oldValue, newValue);
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): related to unoplatform/kahua-private#507

## PR Type

- Bugfix

## What is the current behavior?

Following the TabBar accessibility work in #1618, an audit of the remaining Toolkit controls found that none of them override `OnCreateAutomationPeer()`. WinUI only creates a peer for a plain `FrameworkElement` when `AutomationProperties.Name` or `LabeledBy` is explicitly set, and even then the result is a generic peer reporting `AutomationControlType.Group`.

Per control:

- **ZoomContentControl** — the two ScrollBars expose separate RangeValue controls, but assistive technology cannot pan or zoom the viewport itself.
- **DrawerControl** — the pane is translated offscreen rather than removed, so closed content stays reachable. The light-dismiss surface is pointer-only, and there is no Escape handling or focus management.
- **Card / CardContentControl** — `IsClickable` only drives visual states. There is no keyboard activation, no tab stop, and no Invoke semantics, so a clickable card is not operable without a pointer.
- **ChipGroup / Chip** — `ChipGroup` exposes no `ISelectionProvider`. Chips advertise Toggle even in selection modes where SelectionItem is the correct pattern, and in `None` mode where toggling is suppressed. The remove buttons have no accessible name.

## What is the new behavior?

Each control gains dedicated automation peers and an `OnCreateAutomationPeer()` override. One commit per control.

**ZoomContentControl** reports `Pane` and implements `IScrollProvider` and `ITransformProvider2`, raising property-change events for scroll offset and zoom, plus keyboard navigation and focus visuals.

**DrawerControl** gains a `Window`/`IWindowProvider` pane peer and a `Button`/`IInvokeProvider` light-dismiss peer, Escape handling, focus entry and restoration, tab containment, and a genuinely collapsed closed state.

**Card / CardContentControl** expose `Button` with `IInvokeProvider` when `IsClickable` is set, and stay structural otherwise. Adds Enter/Space activation, tab stop behaviour, a minimal public `Click` event, and a name fallback from rendered content.

**ChipGroup / Chip** gains `ISelectionProvider` on the group with `CanSelectMultiple` and `IsSelectionRequired` reflecting the selection mode, mode-aware `SelectionItem`/`Toggle`/`Invoke` semantics on chips, selection events, RTL-aware arrow-key navigation, and named remove buttons.

Note: the library has no localisation infrastructure, so the remove-button fallback name is an English string. An explicit `AutomationProperties.Name` in a template still takes precedence. Happy to change this if there is a preferred mechanism.

## Verification

Built on macOS from the combined branch, so the four changes are verified together and not only in isolation:

- `dotnet build src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj -c Release -p:TargetFrameworkOverride=desktop` — 0 warnings, 0 errors (Release treats warnings as errors)
- `dotnet build src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.csproj -c Debug -p:TargetFrameworkOverride=desktop` — 0 warnings, 0 errors
- `dotnet build src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj -c Debug -f net9.0-ios` — 0 errors
- `dotnet build src/Uno.Toolkit.UI/Uno.Toolkit.WinUI.csproj -c Debug -f net9.0-android` — 0 errors

Runtime tests were added for every control, covering control types, the implemented patterns, selection state, keyboard activation and name resolution.

## Not verified

- Announcement text and event routing with a real screen reader (Narrator, VoiceOver, TalkBack).
- The Windows target could not be compiled locally; CI covers it.

## PR Checklist

- [x] Tested code with current supported SDKs
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed
- [x] Runtime Tests and/or UI Tests for the changes have been added
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
