### PR TITLE
chore: update Uno.Sdk.Private to version 6.7.0-dev.938

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
 	"msbuild-sdks": {
 		"Uno.Sdk": "6.5.31",
-		"Uno.Sdk.Private": "6.6.166"
+		"Uno.Sdk.Private": "6.7.0-dev.938"
 	},
   "sdk":{
     "allowPrerelease": false


### PR DESCRIPTION
This pull request updates the `Uno.Sdk.Private` package version in the `global.json` file. The new version moves from `6.6.166` to `6.7.0-dev.938`, which likely includes bug fixes, new features, or other improvements from the Uno Platform team.

Dependency update:

* Updated the `Uno.Sdk.Private` dependency version from `6.6.166` to `6.7.0-dev.938` in `global.json` to bring in the latest changes from the Uno Platform.