### PR TITLE
docs: correct 9.0 migration guide, seed palette generation is opt-in

### DIFF
--- a/doc/uno-toolkit-migration.md
+++ b/doc/uno-toolkit-migration.md
@@ -48,9 +48,9 @@ Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-base
     </MaterialToolkitTheme>
     ```
 
-5. Default Material palette is now seed-generated
+5. Seed-based palette generation is opt-in
 
-    `MaterialToolkitTheme` now uses a default primary seed color (`#5946D2`) to algorithmically generate the Material Design 3 tonal palette. This produces a different visual result than 8.x's static palette. To preserve the previous look, set `Colors.PrimarySeed` to your desired anchor color or use `Colors.OverrideDictionary` to override individual color resources. `SimpleToolkitTheme` still defaults to the standard neutral Simple palette; if you do not specify any `Colors` seeds or overrides, apps keep the default neutral appearance. In current documentation this default Simple palette may be described as being produced from the built-in neutral gray seed (`#808080`), rather than from an app-specified seed.
+    Uno Themes 7.0 ships with seed-based palette generation, but it is opt-in: `MaterialToolkitTheme` keeps the same default Material Design 3 palette as 8.x unless you set `Colors.PrimarySeed` (or the other seed properties). `SimpleToolkitTheme` likewise keeps its default neutral palette unless a seed is set.
 
 6. `ColorOverrideDictionary` precedence changed
 


### PR DESCRIPTION
GitHub Issue (If applicable): related to #1689

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

Item 5 of the "Upgrading to Uno Toolkit 9.0" section in `doc/uno-toolkit-migration.md` states that `MaterialToolkitTheme` generates its default palette from a built-in seed color (`#5946D2`). This is stale: Uno Themes 7.0 made seed-based palette generation opt-in (unoplatform/Uno.Themes#1684), so the default palettes are unchanged from 8.x.

## What is the new behavior?

The item is retitled to "Seed-based palette generation is opt-in" and now states that `MaterialToolkitTheme` and `SimpleToolkitTheme` keep their default palettes unless `Colors.PrimarySeed` (or another seed property) is set.

## Other information

Documentation-only change; no code affected. Companion to the Uno Themes v7 migration guide added for unoplatform/Uno.Themes#1689.

Internal Issue (If applicable):
