### PR TITLE
docs: complete 9.0 migration guide breaking changes

### DIFF
--- a/doc/uno-toolkit-migration.md
+++ b/doc/uno-toolkit-migration.md
@@ -8,11 +8,11 @@ uid: Toolkit.Migration
 
 ## Upgrading to Uno Toolkit 9.0
 
-Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-based color generation and a unified design-token system. It also drops UWP support and reshapes the public surface of the theme classes. Most apps that consume `<MaterialToolkitTheme/>` or `<SimpleToolkitTheme/>` via XAML will not need code changes, but several behaviors and defaults have shifted.
+Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-based color generation and a unified design-token system. It also drops UWP support and reshapes the public surface of the theme classes. Most apps that consume `<MaterialToolkitTheme/>` or `<SimpleToolkitTheme/>` via XAML will not need code changes, but several behaviors and defaults have shifted. Uno Toolkit 9.0 requires Uno.WinUI 6.5 or later; apps using the Uno SDK get compatible versions automatically, while apps pinning package versions manually should update their `Uno.WinUI` reference.
 
 1. UWP target dropped
 
-    The Uno Toolkit packages no longer target UWP and migrate to the `Uno.Sdk` single-project model. Apps must be on .NET 6+ / WinUI to upgrade. UWP-only consumers should remain on the 8.x line.
+    The Uno Toolkit packages no longer target UWP and migrate to the `Uno.Sdk` single-project model. Apps must be on .NET 6+ / WinUI to upgrade. UWP-only consumers should remain on the 8.x line (the last UWP-flavored release is 8.4.2). The packages also no longer ship `net9.0-macos` / `net9.0-maccatalyst` assets — move these heads to the Skia Desktop target (`net9.0-desktop`) instead.
 
 2. Generated resource paths renamed
 
@@ -23,7 +23,7 @@ Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-base
     | `ms-appx:///Uno.Toolkit.WinUI/Generated/mergedpages.WinUI.xaml`               | `ms-appx:///Uno.Toolkit.WinUI/Generated/mergedpages.xaml`             |
     | `ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.WinUI.v2.xaml`   | `ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.v2.xaml` |
 
-    This only affects code that merged these dictionaries directly by URI. Apps using `<MaterialToolkitTheme/>` or `<SimpleToolkitTheme/>` are unaffected.
+    This breaks code that merged these dictionaries directly by URI, as well as the deprecated `MaterialToolkitResourcesV1` / `MaterialToolkitResourcesV2` dictionaries, which reference the old URIs internally and now fail at startup with `Cannot locate resource from 'ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.WinUI.v2.xaml'`. Replace them with `<MaterialToolkitTheme />`. Apps already using `<MaterialToolkitTheme/>` or `<SimpleToolkitTheme/>` are unaffected.
 
 3. `MaterialToolkitTheme` and new `SimpleToolkitTheme` inherit from their underlying theme
 

--- a/doc/uno-toolkit-migration.md
+++ b/doc/uno-toolkit-migration.md
@@ -12,7 +12,7 @@ Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-base
 
 1. UWP target dropped
 
-    The Uno Toolkit packages no longer target UWP and migrate to the `Uno.Sdk` single-project model. Apps must be on .NET 6+ / WinUI to upgrade. UWP-only consumers should remain on the 8.x line (the last UWP-flavored release is 8.4.2). The packages also no longer ship `net9.0-macos` / `net9.0-maccatalyst` assets — move these heads to the Skia Desktop target (`net9.0-desktop`) instead.
+    The Uno Toolkit packages no longer target UWP and migrate to the `Uno.Sdk` single-project model. Apps must be on .NET 6+ / WinUI to upgrade. UWP-only consumers should remain on the 8.x line (the last UWP-flavored release is 8.4.2). The packages also no longer ship `net9.0-macos` / `net9.0-maccatalyst` assets — move these heads to the Skia Desktop target (for example `net10.0-desktop`) instead.
 
 2. Generated resource paths renamed
 
@@ -23,7 +23,7 @@ Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-base
     | `ms-appx:///Uno.Toolkit.WinUI/Generated/mergedpages.WinUI.xaml`               | `ms-appx:///Uno.Toolkit.WinUI/Generated/mergedpages.xaml`             |
     | `ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.WinUI.v2.xaml`   | `ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.v2.xaml` |
 
-    This breaks code that merged these dictionaries directly by URI, as well as the deprecated `MaterialToolkitResourcesV1` / `MaterialToolkitResourcesV2` dictionaries, which reference the old URIs internally and now fail at startup with `Cannot locate resource from 'ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.WinUI.v2.xaml'`. Replace them with `<MaterialToolkitTheme />`. Apps already using `<MaterialToolkitTheme/>` or `<SimpleToolkitTheme/>` are unaffected.
+    This breaks code that merged these dictionaries directly by URI, as well as the deprecated `MaterialToolkitResourcesV1` / `MaterialToolkitResourcesV2` dictionaries, which reference the old URIs internally and now fail at startup with `Cannot locate resource from 'ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.WinUI.v2.xaml'`. Replace them with `<MaterialToolkitTheme/>`. Apps already using `<MaterialToolkitTheme/>` or `<SimpleToolkitTheme/>` are unaffected.
 
 3. `MaterialToolkitTheme` and new `SimpleToolkitTheme` inherit from their underlying theme
 


### PR DESCRIPTION
GitHub Issue (If applicable): related to unoplatform/uno#23925

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The "Upgrading to Uno Toolkit 9.0" section in `doc/uno-toolkit-migration.md` is missing three breaking changes, identified while validating the 6.6 migration notes in unoplatform/uno#23925:

- The deprecated `MaterialToolkitResourcesV1` / `MaterialToolkitResourcesV2` dictionaries reference the old `mergedpages.WinUI.*.xaml` URIs internally and fail at startup on 9.0 with `Cannot locate resource`. Item 2 currently claims the URI rename "only affects code that merged these dictionaries directly by URI", which understates the break.
- The `net9.0-macos` / `net9.0-maccatalyst` assets were dropped from the 9.0 packages (verified against the published 8.4.2 and 9.0.3 packages).
- The Uno.WinUI dependency floor was raised to 6.5 (the 9.0.3 nuspec declares `Uno.WinUI 6.5.153`), which is not stated anywhere in the section.

## What is the new behavior?

- Item 2 now covers the `MaterialToolkitResourcesV1` / `MaterialToolkitResourcesV2` startup failure, including the error message (so it is searchable) and the `<MaterialToolkitTheme />` replacement.
- Item 1 now notes the last UWP-flavored release (8.4.2) and the removal of the macOS / Mac Catalyst assets, with `net9.0-desktop` as the migration target.
- The section intro now states the Uno.WinUI 6.5 minimum and that Uno SDK apps get compatible versions automatically.

## Other information

Documentation-only change; no code affected. Follow-up to #1621. The `MaterialToolkitResourcesV1`/`V2` startup failure was verified against the source (`src/library/Uno.Toolkit.Material/MaterialToolkitResourcesV2.cs` hard-codes the removed `mergedpages.WinUI.v2.xaml` URI) and reproduced at runtime during the validation of unoplatform/uno#23925.
