### PR TITLE
Version bump after 9.1 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "9.1-dev.{height}",
+  "version": "9.2-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "9.1-dev.{height}",
+  "version": "9.1",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): related to unoplatform/uno#23925

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The "Upgrading to Uno Toolkit 9.0" section in `doc/uno-toolkit-migration.md` is missing three breaking changes, identified while validating the 6.6 migration notes in unoplatform/uno#23925:

- The deprecated `MaterialToolkitResourcesV1` / `MaterialToolkitResourcesV2` dictionaries reference the old `mergedpages.WinUI.*.xaml` URIs internally and fail at startup on 9.0 with `Cannot locate resource`. Item 2 currently claims the URI rename "only affects code that merged these dictionaries directly by URI", which understates the break.
- The `net9.0-macos` / `net9.0-maccatalyst` assets were dropped from the 9.0 packages (verified against the published 8.4.2 and 9.0.3 packages).
- The Uno.WinUI dependency floor was raised to 6.5 (the 9.0.3 nuspec declares `Uno.WinUI 6.5.153`), which is not stated anywhere in the section.

## What is the new behavior?

- Item 2 now covers the `MaterialToolkitResourcesV1` / `MaterialToolkitResourcesV2` startup failure, including the error message (so it is searchable) and the `<MaterialToolkitTheme />` replacement.
- Item 1 now notes the last UWP-flavored release (8.4.2) and the removal of the macOS / Mac Catalyst assets, with `net9.0-desktop` as the migration target.
- The section intro now states the Uno.WinUI 6.5 minimum and that Uno SDK apps get compatible versions automatically.

## Other information

Documentation-only change; no code affected. Follow-up to #1621. The `MaterialToolkitResourcesV1`/`V2` startup failure was verified against the source (`src/library/Uno.Toolkit.Material/MaterialToolkitResourcesV2.cs` hard-codes the removed `mergedpages.WinUI.v2.xaml` URI) and reproduced at runtime during the validation of unoplatform/uno#23925.

This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/9.1, based on #1622