### PR TITLE
fix(TabBar): make SimpleVerticalTabBarStyle a real vertical rail

### DIFF
--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/TabBar.xaml
@@ -350,6 +350,15 @@
 				</ItemsPanelTemplate>
 			</Setter.Value>
 		</Setter>
+		<Setter Property="SelectionIndicatorContentTemplate">
+			<Setter.Value>
+				<DataTemplate>
+					<Border Width="2"
+							HorizontalAlignment="Left"
+							Background="{ThemeResource TabBarIndicatorBrush}" />
+				</DataTemplate>
+			</Setter.Value>
+		</Setter>
 	</Style>
 
 	<Style
@@ -373,10 +382,14 @@
 		BasedOn="{StaticResource SimpleTopTabBarItemStyle}"
 		TargetType="utu:TabBarItem" />
 
+	<!--  The inherited bottom underline is a horizontal-tab affordance; in a vertical stack it
+		 reads as a stray divider, and selection is carried by the bar-level edge indicator.  -->
 	<Style
 		x:Key="SimpleVerticalTabBarItemStyle"
 		BasedOn="{StaticResource SimpleTopTabBarItemStyle}"
-		TargetType="utu:TabBarItem" />
+		TargetType="utu:TabBarItem">
+		<Setter Property="BorderThickness" Value="0" />
+	</Style>
 
 	<Style
 		x:Key="SimpleBottomTabBarItemStyle"

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/TabBar.xaml
@@ -17,6 +17,7 @@
 			<StaticResource x:Key="TopTabBarBottomBorderBrush" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="BottomTabBarBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="VerticalTabBarBackground" ResourceKey="SurfaceBrush" />
+			<x:Double x:Key="VerticalTabBarWidth">80</x:Double>
 			<StaticResource x:Key="TabBarItemForeground" ResourceKey="OnSurfaceMediumBrush" />
 			<StaticResource x:Key="TabBarItemForegroundSelected" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="TabBarItemForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
@@ -36,6 +37,7 @@
 			<StaticResource x:Key="TopTabBarBottomBorderBrush" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="BottomTabBarBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="VerticalTabBarBackground" ResourceKey="SurfaceBrush" />
+			<x:Double x:Key="VerticalTabBarWidth">80</x:Double>
 			<StaticResource x:Key="TabBarItemForeground" ResourceKey="OnSurfaceMediumBrush" />
 			<StaticResource x:Key="TabBarItemForegroundSelected" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="TabBarItemForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
@@ -335,8 +337,20 @@
 
 	<Style
 		x:Key="SimpleVerticalTabBarStyle"
-		BasedOn="{StaticResource SimpleTopTabBarStyle}"
-		TargetType="utu:TabBar" />
+		BasedOn="{StaticResource BaseSimpleTabBarStyle}"
+		TargetType="utu:TabBar">
+		<Setter Property="Background" Value="{ThemeResource VerticalTabBarBackground}" />
+		<Setter Property="MinWidth" Value="{ThemeResource VerticalTabBarWidth}" />
+		<Setter Property="Orientation" Value="Vertical" />
+		<Setter Property="ItemContainerStyle" Value="{StaticResource SimpleVerticalTabBarItemStyle}" />
+		<Setter Property="ItemsPanel">
+			<Setter.Value>
+				<ItemsPanelTemplate>
+					<utu:TabBarListPanel Orientation="Vertical" />
+				</ItemsPanelTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
 
 	<Style
 		x:Key="SimpleBottomTabBarStyle"

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/TabBar.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/TabBar.xaml
@@ -17,7 +17,7 @@
 			<StaticResource x:Key="TopTabBarBottomBorderBrush" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="BottomTabBarBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="VerticalTabBarBackground" ResourceKey="SurfaceBrush" />
-			<x:Double x:Key="VerticalTabBarWidth">80</x:Double>
+			<x:Double x:Key="NavigationTabBarWidthOrHeight">80</x:Double>
 			<StaticResource x:Key="TabBarItemForeground" ResourceKey="OnSurfaceMediumBrush" />
 			<StaticResource x:Key="TabBarItemForegroundSelected" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="TabBarItemForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
@@ -37,7 +37,7 @@
 			<StaticResource x:Key="TopTabBarBottomBorderBrush" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="BottomTabBarBackground" ResourceKey="SurfaceBrush" />
 			<StaticResource x:Key="VerticalTabBarBackground" ResourceKey="SurfaceBrush" />
-			<x:Double x:Key="VerticalTabBarWidth">80</x:Double>
+			<x:Double x:Key="NavigationTabBarWidthOrHeight">80</x:Double>
 			<StaticResource x:Key="TabBarItemForeground" ResourceKey="OnSurfaceMediumBrush" />
 			<StaticResource x:Key="TabBarItemForegroundSelected" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="TabBarItemForegroundDisabled" ResourceKey="OnSurfaceDisabledBrush" />
@@ -340,7 +340,7 @@
 		BasedOn="{StaticResource BaseSimpleTabBarStyle}"
 		TargetType="utu:TabBar">
 		<Setter Property="Background" Value="{ThemeResource VerticalTabBarBackground}" />
-		<Setter Property="MinWidth" Value="{ThemeResource VerticalTabBarWidth}" />
+		<Setter Property="MinWidth" Value="{ThemeResource NavigationTabBarWidthOrHeight}" />
 		<Setter Property="Orientation" Value="Vertical" />
 		<Setter Property="ItemContainerStyle" Value="{StaticResource SimpleVerticalTabBarItemStyle}" />
 		<Setter Property="ItemsPanel">


### PR DESCRIPTION
GitHub Issue (If applicable): N/A — gap found while building a responsive dual-`TabBar` navigation shell (bottom `TabBar` when narrow, vertical side-rail `TabBar` when wide) on the Simple theme.

## PR Type

- Bugfix

## What is the current behavior?

`SimpleVerticalTabBarStyle` is a bare alias of `SimpleTopTabBarStyle` (a first-pass mapping from the SDS bring-up), so `Style="{StaticResource VerticalTabBarStyle}"` on the Simple theme silently renders a **horizontal top bar**: default horizontal items panel, no rail width, squished icons and truncated labels when hosted in a narrow side column. The theme dictionaries already define a `VerticalTabBarBackground` resource that nothing consumes — the vertical style was clearly intended but never fleshed out. The same markup works on Material because `MaterialVerticalTabBarStyle` is a real rail style.

## What is the new behavior?

`SimpleVerticalTabBarStyle` is a real vertical rail, mirroring the Material vertical setters on top of `BaseSimpleTabBarStyle`:

- `Orientation="Vertical"` with a vertical `utu:TabBarListPanel` items panel (same panel `MaterialVerticalTabBarStyle` uses)
- `Background="{ThemeResource VerticalTabBarBackground}"` — the previously unused resource
- `MinWidth="{ThemeResource NavigationTabBarWidthOrHeight}"` — the shared toolkit key (80), now defined in the Simple theme dictionaries too, so the existing C# Markup helper (`ToolkitTheme.TabBar.Resources.Navigation.WidthOrHeight`) resolves on Simple
- `ItemContainerStyle` stays `SimpleVerticalTabBarItemStyle` (the existing icon-over-label item template works vertically as-is)

A dual-TabBar responsive shell now renders correctly under the Simple theme with the same markup as Material.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [x] WinUI (desktop/Skia via the Simple samples app)
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [ ] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [ ] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

- Note for maintainers: running the **Debug** samples app from source currently trips an unrelated `Debug.Assert` on startup (`CreateWeakHandler: onEvent must be a static/non-capturing delegate`) in `SafeArea`/`WeakEventHelper` — `Target is null` is false even for `static` lambdas because the compiler emits them as instance methods on the cached field-less `<>c` singleton. Deterministic on any Debug source run that touches SafeArea; Release/NuGet consumers are unaffected. Worth a follow-up issue; boot verification for this PR was done with that assert locally patched.

Internal Issue (If applicable): N/A