### PR TITLE
docs(zoomcontentcontrol): replace non-existent ZoomTo/ZoomToRect with real API

### DIFF
--- a/doc/controls/walkthroughs/ZoomContentControl.howto.md
+++ b/doc/controls/walkthroughs/ZoomContentControl.howto.md
@@ -9,7 +9,7 @@ tags: [zoom, pan, pinch-zoom, zoom-control, image-zoom, map-zoom]
 
 ## Pan & zoom large content
 
-Place any visual inside `ZoomContentControl` to enable pinch‑zoom and panning.
+Place any visual inside `ZoomContentControl` to enable zooming and panning (Ctrl + mouse wheel zooms, the wheel scrolls, middle-click-drag pans).
 
 ```xml
 <Page
@@ -21,12 +21,13 @@ Place any visual inside `ZoomContentControl` to enable pinch‑zoom and panning.
 </Page>
 ```
 
-## Reset zoom programmatically
+## Drive the zoom from code
 
-Call methods from code‑behind/view‑model.
+`ZoomLevel` is a plain `double` dependency property — set it (or bind it) directly, and use the built-in helpers for the common actions:
 
 ```csharp
 // x:Name="Zoomer"
-Zoomer.ZoomTo(1.0f);          // 100%
-Zoomer.ZoomToRect(new Rect(0,0,500,300));
+Zoomer.ZoomLevel = 2.0;   // zoom to 200%; also bindable from a view-model
+Zoomer.FitToCanvas();     // pick the ZoomLevel that fits the content to the viewport
+Zoomer.ResetViewport();   // back to 100%, re-centered (ResetZoom + CenterContent)
 ```


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1632

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The `ZoomContentControl` how-to walkthrough (`doc/controls/walkthroughs/ZoomContentControl.howto.md`) shows a "Reset zoom programmatically" snippet calling `Zoomer.ZoomTo(1.0f)` and `Zoomer.ZoomToRect(new Rect(...))` — neither method exists on the control, so following the walkthrough ends in compile errors. The page also says placing content inside the control "enable[s] pinch-zoom and panning", which oversells the shipped interactions (pinch lands separately with #1630).

## What is the new behavior?

The programmatic section is rewritten around the actual API surface — the `ZoomLevel` dependency property (settable/bindable) plus `FitToCanvas()` and `ResetViewport()` — and the intro describes the interactions the shipped control actually has (Ctrl + wheel zoom, wheel scrolling, middle-click-drag panning). Once #1630 merges, that intro can gain the touch gestures.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Tested the changes where applicable:
	- [ ] UWP
	- [ ] WinUI
	- [ ] iOS
	- [ ] Android
	- [ ] WASM
	- [ ] MacOS
- [x] Updated the documentation as needed:
	- [ ] [General Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc)
	- [x] [Controls Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/controls)
	- [ ] [Extensions Doc Update](https://github.com/unoplatform/uno.toolkit.ui/tree/main/doc/helpers)
	- [ ] [controls-styles.md](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/controls-styles.md)
	- [ ] [lightweight-styling.md (LightWeight Styling Resource Keys)](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/lightweight-styling.md)
- [ ] [Runtime Tests and/or UI Tests](https://platform.uno/docs/articles/contributing/guidelines/creating-tests.html) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

Docs-only change, based on `main` (independent of #1628/#1630). Fell out of the Toolkit Tuesdays post on `ZoomContentControl`, whose "A Note on the Docs" section calls this exact snippet out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5UfgXRC7eSoqVSjpeL5ST