### PR TITLE
ci: Publish from servicing/* branches and bump main to 10.0-dev

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - servicing/*
       - release/*
       - feature/*
 

--- a/build/workflow/pipeline.yml
+++ b/build/workflow/pipeline.yml
@@ -91,6 +91,10 @@ stages:
 ## Publishing
 ##
 
+# A servicing/* branch continues a previous version line after main has moved on
+# to a newer one, so it publishes dev packages the same way main does. The same
+# pattern is added to the CI triggers, IsReleaseBranch, the dev-feed push step and
+# version.json's publicReleaseRefSpec.
 - stage: Publish_Dev
   displayName: 'Publish - Dev NuGet.org'
   condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))

--- a/build/workflow/pipeline.yml
+++ b/build/workflow/pipeline.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
       - main
+      - servicing/*
       - beta
       - release/beta/*
       - stable
@@ -18,6 +19,7 @@ pr:
   branches:
     include:
       - main
+      - servicing/*
       - beta
       - release/beta/*
       - stable
@@ -35,7 +37,7 @@ variables:
   PackageOutputPath: $(Build.ArtifactStagingDirectory)\nuget
 
   IsCanaryBranch: $[startsWith(variables['Build.SourceBranch'], 'refs/heads/canaries/')]
-  IsReleaseBranch: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
+  IsReleaseBranch: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
   XCODE_ROOT: '/Applications/Xcode_26.1.1.app'
 
 stages:
@@ -91,7 +93,7 @@ stages:
 
 - stage: Publish_Dev
   displayName: 'Publish - Dev NuGet.org'
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))
   dependsOn: Packages
   jobs:
   - template: publish/publish-nuget-dev.yml

--- a/build/workflow/templates/nuget-publish-dev.yml
+++ b/build/workflow/templates/nuget-publish-dev.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
     inputs:
       command: 'push'
       packagesToPush: '$(Pipeline.Workspace)/NuGet_Packages/**/*.nupkg'

--- a/build/workflow/templates/nuget-publish-dev.yml
+++ b/build/workflow/templates/nuget-publish-dev.yml
@@ -1,4 +1,6 @@
 steps:
+  # A servicing/* branch continues a previous version line after main has moved on
+  # to a newer one, so its packages reach the dev feed the same way main's do.
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
     condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))

--- a/version.json
+++ b/version.json
@@ -6,6 +6,7 @@
   },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
+    "^refs/heads/servicing/.*$",
     "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "9.2-dev.{height}",
+  "version": "10.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Release-process change, tracked internally as part of the Uno 7.0 release preparation. -->

## PR Type

- Build or CI related changes

## What is the current behavior?

`main` publishes `9.2.0-dev.*` to nuget.org, and it is the **only** branch that publishes a Toolkit dev channel. Once `main` retargets to Uno 7.0 (native targets dropped, Mac Catalyst removed, net9 dropped, SkiaSharp 3 to 4), those dev packages stop being consumable by apps still on Uno 6.x — which is what our clients validate fixes against before we backport them to a 6.7 service release.

`servicing/*` is also not wired into this repo's pipeline, so cutting such a branch today would produce a branch that builds nothing.

## What is the new behavior?

Two commits, and they have to land together.

**1. `ci: Build and publish from servicing/* branches`** — mirrors what [`unoplatform/uno`](https://github.com/unoplatform/uno) already carries on its own `servicing/6.8` branch:

| Change | Why |
|---|---|
| `servicing/*` in `trigger.branches` and `pr.branches` | CI runs at all on the branch and on PRs into it |
| `servicing/` in `IsReleaseBranch` | signed/release-configured build rather than a canary build |
| `servicing/` in the `Publish_Dev` stage condition | the nuget.org dev publish stage runs |
| `servicing/` in the dev-feed push step | packages also reach the internal dev feed, matching `main` |
| `^refs/heads/servicing/.*$` in `publicReleaseRefSpec` | NBGV emits `9.2.0-dev.N` rather than a height-plus-commit-hash version |
| `servicing/*` in `.github/workflows/conventional-commits.yml` | `Validate for conventional commits` is a required status check on `main`. It must also report for PRs into a servicing branch, otherwise applying `main`'s branch protection to `servicing/*` leaves those PRs stuck on a check that never runs |

**2. `chore: Bump version to 10.0-dev for the Uno 7.0 line`** — `main` moves to `10.0-dev`, and `servicing/9.2` (cut from this PR's merge-base, so it predates the bump) keeps publishing `9.2.0-dev.*` for Uno 6.x.

### Why the bump is not optional

`main`'s latest published version is `9.2.0-dev.19`. A `servicing/9.2` branch sits one commit above the same base, so **both branches would compute NBGV height 20 and publish `9.2.0-dev.20`** from different code. The dev-feed push runs with `allowPackageConflicts: true`, so the second push is skipped **silently, with a green pipeline** — one branch's packages just never appear, and nobody finds out until a client reports a fix missing from a version that claims to contain it.

Bumping `main` to `10.0-dev` separates the two version spaces: `main` owns `10.0.0-dev.*`, `servicing/9.2` owns `9.2.0-dev.*`.

`unoplatform/uno` avoided this only by accident of ordering — `master` was already `7.0-dev` before `servicing/6.8` went live, so the two never contended. It has since published `6.8.0-dev.142` from `servicing/6.8`, continuing unbroken from `master`'s last `6.8.0-dev.141`.

### Note on `10.0-dev` before the Uno 7.0 retarget

`main` will keep building against Uno 6.8 until the 7.0 retarget lands, so early `10.0.0-dev.*` packages are still 6.x-compatible. That is the same sequence `unoplatform/uno` used, and it is intentional: the bump is about reserving the version space, not about the retarget being finished.

## PR Checklist

- [x] Tested code with current supported SDKs — no product code changed
- [ ] Tested the changes where applicable — n/a, no product code
- [ ] Updated the documentation as needed — n/a
- [ ] Runtime Tests and/or UI Tests — n/a, pipeline and version metadata only
- [x] Contains **NO** breaking changes — no API change; the version bump is what *signals* the upcoming Uno 7.0 breaking changes
- [x] Associated with an issue (internal — Uno 7.0 release preparation)
- [x] Commits follow Conventional Commits

## Other information

**`servicing/9.2` is deliberately not pushed yet.** It is cut at this PR's merge-base and stays local until this merges — pushing it first would open exactly the `9.2.0-dev.20` collision window described above. Sequence: merge this, confirm `main` publishes `10.0.0-dev.1`, then push `servicing/9.2` and confirm `9.2.0-dev.20`.

Same change is needed in `uno.extensions` (`7.4-dev` to `8.0-dev`) and `uno.csharpmarkup` (`6.8-dev` to `7.0-dev`). `Uno.Themes` needs a decision first: its `main` is already `8.0-dev` with `release/stable/7.1` as the newest stable, so whether the 6.x channel comes off `servicing/8.0` or `servicing/7.1` depends on whether 8.0 is intended to ship for Uno 6.x or 7.0.



---

> [!NOTE]
> **Correction (2026-09-08): 10.0 is the Uno 6.x line, not the 7.0 line.**
>
> This PR's description says the bump frees version space "for the Uno 7.0 line". That turned out to be wrong, and #1637 supersedes it.
>
> Aligning the Toolkit to **Uno.Themes 8.0** (#1636) moves `UnoThemesVersion` from `7.1.0-dev.1` to `8.0.0-dev.15`. The Toolkit's own surface is unchanged, but the dependency floor crosses a major, so consumers upgrading the Toolkit are pulled onto Themes 8.0 and its breaking resource changes — that needs a major of its own, and it has to ship on the **6.x** line because Uno 6.7 SR3 will pin Themes 8.0.
>
> So **10.0 stays on the Uno 6.x line** as `servicing/10.0`, and `main` moves to **11.0** for the Uno Platform 7.0 retarget (#1637). This mirrors Uno.Themes, where 8.0 stayed on the 6.x line as `servicing/8.0` and `master` moved to 9.0 (unoplatform/Uno.Themes#1723).
>
> `servicing/9.2`, created by this PR, is retired in favour of `servicing/10.0`. Everything else in this PR — the `servicing/*` pipeline plumbing, the `publicReleaseRefSpec` entry, the conventional-commit validation — is unchanged and still in effect.
>
> The commit message on `d88a0c12` keeps its original wording: it is the base of two in-flight branches, so rewriting history there would orphan them. This note is the record instead.
