### PR TITLE
fix(themes): adapt to upstream typography and spacing changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,8 @@ The PR template (`.github/pull_request_template.md`) requires updating documenta
 
 ✅ Prefer updating an existing page over adding a new one.
 ✅ Cross-link relevant pages (e.g. between a control's doc and `controls-styles.md`).
+✅ Keep public documentation independent of exact prerelease NuGet build versions; record package provenance in PR or validation notes instead.
+✅ Document Toolkit-specific setup, migration impact, and behavior here. For inherited Uno Themes / `BaseTheme` APIs, link to the authoritative Uno Themes documentation rather than duplicating usage, defaults, formulas, or runtime semantics.
 ✅ Sample pages: add a page under `samples/Uno.Toolkit.Samples/Content/` (the shared project) so all sample heads pick it up.
 
 </coding_directives>

--- a/build/workflow/cspell.json
+++ b/build/workflow/cspell.json
@@ -105,7 +105,8 @@
 		"UWP's",
 		"VSIX",
 		"walkthrough",
-		"WEBASSEMBLY"
+		"WEBASSEMBLY",
+		"worktree"
 	],
 	"ignoreWords": [
 		"ADAL",

--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -33,7 +33,9 @@ Initialization of the Material Toolkit resources is handled by the specialized `
 |-----------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `ColorOverrideSource` | `string`  | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a ResourceDictionary containing overrides for the default Uno.Material Color resources      |
 | `FontOverrideSource`  | `string`  | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a ResourceDictionary containing overrides for the default Uno.Material FontFamily resources |
-| `DefaultDensity`      | `Density` | (Optional) Gets or sets the density preset that drives the base spacing unit used by all `Space*` tokens. Default is `Regular`. Accepted values are `Compact` (3 px), `Regular` (4 px), and `Comfy` (5 px). |
+| `DefaultFontFamily` | `FontFamily` | (Optional) Sets the root typeface and derived type-scale font families. When unset, the theme uses Roboto. |
+| `DefaultSpacing` | `double` | (Optional) Sets the base spacing unit in pixels (default `4`), scaled by `DefaultDensity` to generate `Space*` tokens. |
+| `DefaultDensity`      | `Density` | (Optional) Scales `DefaultSpacing`: `Compact` ×0.75, `Regular` ×1 (default), or `Comfy` ×1.25. Control heights and icon sizes remain unchanged. |
 | `DefaultCornerRadius` | `double`  | (Optional) Gets or sets the base corner radius unit (in pixels) used to compute all shape scale tokens (`Radius100`, `Radius200`, …) as multiples of this value. Default is `4`. |
 
 ## Installation
@@ -151,7 +153,7 @@ Depending on the type of project template that the Uno Platform application was 
 
 ## Customization
 
-With `MaterialToolkitTheme`, you do not need to explicitly initialize `ToolkitResources`, `MaterialTheme`, `MaterialColors`, or `MaterialFonts`. This means that all resource overrides should go through `MaterialToolkitTheme` itself. There are two properties on `MaterialToolkitTheme` that you can set within your `App.xaml`.
+With `MaterialToolkitTheme`, you do not need to explicitly initialize `ToolkitResources`, `MaterialTheme`, `MaterialColors`, or `MaterialFonts`. This means that all resource overrides should go through `MaterialToolkitTheme` itself.
 
 ### Customize Colors
 
@@ -166,6 +168,19 @@ In `App.xaml`, use the `ColorOverrideSource` property on `MaterialToolkitTheme`:
 
 ### Customize Fonts
 
+Set `DefaultFontFamily` to customize the root typeface and its derived type-scale font families:
+
+```xml
+<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
+                      DefaultFontFamily="ms-appx:///Fonts/MyFont.ttf#MyFont" />
+```
+
+Use a font that supports the required weights, through a variable font or font manifest. The `*FontWeight` tokens continue to select each type scale's weight. The former `TypefacePlain` / `TypefaceBrand` keys and Simple's `SimpleFontFamily` / per-weight font-family keys have been removed; use `DefaultFontFamily` instead.
+
+For individual resource overrides, use `FontOverrideSource` or `FontOverrideDictionary`. Explicit keys in a font override take precedence over the corresponding generated keys. Toolkit control-specific aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; the root property does not regenerate these aliases. See [NavigationBar styling](controls/NavigationBar.md) and [Divider styling](controls/Divider.md).
+
+Changing the property at runtime regenerates the root and type-scale resources. Existing text that reads them through `ThemeResource` re-resolves after a theme-change pass (toggle the root's `RequestedTheme` away from its `ActualTheme` and back) or when root content is recreated. Unstyled text uses the framework's font default independently. See [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
+
 Follow the [Uno Material Customization guide](xref:Uno.Themes.Material.GetStarted#customization) to create a `FontOverride.xaml` file and add it to your application project.
 
 In `App.xaml`, use the `FontOverrideSource` property on `MaterialToolkitTheme`:
@@ -174,6 +189,18 @@ In `App.xaml`, use the `FontOverrideSource` property on `MaterialToolkitTheme`:
 <MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
                       FontOverrideSource="ms-appx:///Style/Application/FontOverride.xaml" />
 ```
+
+### Customize Spacing and Density
+
+`DefaultSpacing` sets the base unit (default `4` pixels), and `DefaultDensity` scales it by ×0.75 (`Compact`), ×1 (`Regular`), or ×1.25 (`Comfy`). For example, a base of `6` with `Comfy` generates `Space100=7.5` and `Space200=15`:
+
+```xml
+<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
+                      DefaultSpacing="6"
+                      DefaultDensity="Comfy" />
+```
+
+Only styles consuming `Space*` tokens follow this scale; fixed Toolkit padding and margins remain unchanged. Runtime changes regenerate the resources; existing controls reading them through `ThemeResource` re-resolve after a theme-change pass or root-content recreation. See [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
 
 ### Seed Color Customization
 

--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -29,7 +29,7 @@ Initialization of the Material Toolkit resources is handled by the specialized `
 
 #### Properties
 
-`MaterialToolkitTheme` inherits its theme properties from Uno Themes' `MaterialTheme` and `BaseTheme`, including `Colors`, font/color overrides, `DefaultFontFamily`, `DefaultSpacing`, `DefaultDensity`, and `DefaultCornerRadius`. See the [Uno Themes property reference](xref:Uno.Themes.DesignTokens#properties-reference) and [Uno Material customization guide](xref:Uno.Themes.Material.GetStarted#customization) for their behavior and usage.
+`MaterialToolkitTheme` inherits its configuration from Uno Themes. Refer to [Uno Material customization](xref:Uno.Themes.Material.GetStarted#customization) and the [shared theme property reference](xref:Uno.Themes.DesignTokens#properties-reference).
 
 ## Installation
 
@@ -154,17 +154,17 @@ Follow the [Uno Material color override guide](xref:Uno.Themes.Material.GetStart
 
 ### Customize Fonts
 
-See [Uno Themes typography customization](xref:Uno.Themes.DesignTokens#typography-font-swap) for `DefaultFontFamily`, override precedence, and runtime refresh behavior, and the [Uno Material font guide](xref:Uno.Themes.Material.GetStarted#change-default-font) for font resources.
+Follow the [Uno Themes typography guide](xref:Uno.Themes.DesignTokens#typography-font-swap) and [Uno Material font guide](xref:Uno.Themes.Material.GetStarted#change-default-font).
 
 Toolkit control-specific aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; `DefaultFontFamily` does not regenerate these aliases. See [NavigationBar styling](controls/NavigationBar.md) and [Divider styling](controls/Divider.md).
 
 ### Customize Spacing and Density
 
-See [Uno Themes spacing and shape customization](xref:Uno.Themes.DesignTokens#via-scalar-properties) and [density modes](xref:Uno.Themes.DesignTokens#density-modes) for `DefaultSpacing` and `DefaultDensity`. Toolkit padding and margins defined as fixed values do not follow these generated scales.
+Follow the Uno Themes guides for [spacing](xref:Uno.Themes.DesignTokens#via-scalar-properties) and [density](xref:Uno.Themes.DesignTokens#density-modes). Fixed Toolkit padding and margins remain independent of the generated spacing scale.
 
 ### Seed Color Customization
 
-Follow the [Uno Themes seed color guide](xref:Uno.Themes.SeedColors) for color generation and runtime customization, applying its examples to the Toolkit theme.
+Follow the [Uno Themes seed color guide](xref:Uno.Themes.SeedColors), using the Toolkit theme in its examples.
 
 ## Using C# Markup
 

--- a/doc/material-getting-started.md
+++ b/doc/material-getting-started.md
@@ -29,14 +29,7 @@ Initialization of the Material Toolkit resources is handled by the specialized `
 
 #### Properties
 
-| Property              | Type      | Description                                                                                                                                                                            |
-|-----------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ColorOverrideSource` | `string`  | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a ResourceDictionary containing overrides for the default Uno.Material Color resources      |
-| `FontOverrideSource`  | `string`  | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a ResourceDictionary containing overrides for the default Uno.Material FontFamily resources |
-| `DefaultFontFamily` | `FontFamily` | (Optional) Sets the root typeface and derived type-scale font families. When unset, the theme uses Roboto. |
-| `DefaultSpacing` | `double` | (Optional) Sets the base spacing unit in pixels (default `4`), scaled by `DefaultDensity` to generate `Space*` tokens. |
-| `DefaultDensity`      | `Density` | (Optional) Scales `DefaultSpacing`: `Compact` ×0.75, `Regular` ×1 (default), or `Comfy` ×1.25. Control heights and icon sizes remain unchanged. |
-| `DefaultCornerRadius` | `double`  | (Optional) Gets or sets the base corner radius unit (in pixels) used to compute all shape scale tokens (`Radius100`, `Radius200`, …) as multiples of this value. Default is `4`. |
+`MaterialToolkitTheme` inherits its theme properties from Uno Themes' `MaterialTheme` and `BaseTheme`, including `Colors`, font/color overrides, `DefaultFontFamily`, `DefaultSpacing`, `DefaultDensity`, and `DefaultCornerRadius`. See the [Uno Themes property reference](xref:Uno.Themes.DesignTokens#properties-reference) and [Uno Material customization guide](xref:Uno.Themes.Material.GetStarted#customization) for their behavior and usage.
 
 ## Installation
 
@@ -153,84 +146,25 @@ Depending on the type of project template that the Uno Platform application was 
 
 ## Customization
 
-With `MaterialToolkitTheme`, you do not need to explicitly initialize `ToolkitResources`, `MaterialTheme`, `MaterialColors`, or `MaterialFonts`. This means that all resource overrides should go through `MaterialToolkitTheme` itself.
+Apply the properties shown in Uno Themes examples directly to `MaterialToolkitTheme`. It initializes the underlying theme and Toolkit resources, so do not add a separate `MaterialTheme`.
 
 ### Customize Colors
 
-Follow the [Uno Material Customization guide](xref:Uno.Themes.Material.GetStarted#customization) to create a `ColorPaletteOverride.xaml` file and add it to your application project.
-
-In `App.xaml`, use the `ColorOverrideSource` property on `MaterialToolkitTheme`:
-
-```xml
-<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
-                      ColorOverrideSource="ms-appx:///Style/Application/ColorPaletteOverride.xaml" />
-```
+Follow the [Uno Material color override guide](xref:Uno.Themes.Material.GetStarted#manual-color-overrides), using `MaterialToolkitTheme` as the theme dictionary.
 
 ### Customize Fonts
 
-Set `DefaultFontFamily` to customize the root typeface and its derived type-scale font families:
+See [Uno Themes typography customization](xref:Uno.Themes.DesignTokens#typography-font-swap) for `DefaultFontFamily`, override precedence, and runtime refresh behavior, and the [Uno Material font guide](xref:Uno.Themes.Material.GetStarted#change-default-font) for font resources.
 
-```xml
-<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
-                      DefaultFontFamily="ms-appx:///Fonts/MyFont.ttf#MyFont" />
-```
-
-Use a font that supports the required weights, through a variable font or font manifest. The `*FontWeight` tokens continue to select each type scale's weight. The former `TypefacePlain` / `TypefaceBrand` keys and Simple's `SimpleFontFamily` / per-weight font-family keys have been removed; use `DefaultFontFamily` instead.
-
-For individual resource overrides, use `FontOverrideSource` or `FontOverrideDictionary`. Explicit keys in a font override take precedence over the corresponding generated keys. Toolkit control-specific aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; the root property does not regenerate these aliases. See [NavigationBar styling](controls/NavigationBar.md) and [Divider styling](controls/Divider.md).
-
-Changing the property at runtime regenerates the root and type-scale resources. Existing text that reads them through `ThemeResource` re-resolves after a theme-change pass (toggle the root's `RequestedTheme` away from its `ActualTheme` and back) or when root content is recreated. Unstyled text uses the framework's font default independently. See [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
-
-Follow the [Uno Material Customization guide](xref:Uno.Themes.Material.GetStarted#customization) to create a `FontOverride.xaml` file and add it to your application project.
-
-In `App.xaml`, use the `FontOverrideSource` property on `MaterialToolkitTheme`:
-
-```xml
-<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
-                      FontOverrideSource="ms-appx:///Style/Application/FontOverride.xaml" />
-```
+Toolkit control-specific aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; `DefaultFontFamily` does not regenerate these aliases. See [NavigationBar styling](controls/NavigationBar.md) and [Divider styling](controls/Divider.md).
 
 ### Customize Spacing and Density
 
-`DefaultSpacing` sets the base unit (default `4` pixels), and `DefaultDensity` scales it by ×0.75 (`Compact`), ×1 (`Regular`), or ×1.25 (`Comfy`). For example, a base of `6` with `Comfy` generates `Space100=7.5` and `Space200=15`:
-
-```xml
-<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
-                      DefaultSpacing="6"
-                      DefaultDensity="Comfy" />
-```
-
-Only styles consuming `Space*` tokens follow this scale; fixed Toolkit padding and margins remain unchanged. Runtime changes regenerate the resources; existing controls reading them through `ThemeResource` re-resolve after a theme-change pass or root-content recreation. See [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
+See [Uno Themes spacing and shape customization](xref:Uno.Themes.DesignTokens#via-scalar-properties) and [density modes](xref:Uno.Themes.DesignTokens#density-modes) for `DefaultSpacing` and `DefaultDensity`. Toolkit padding and margins defined as fixed values do not follow these generated scales.
 
 ### Seed Color Customization
 
-`MaterialToolkitTheme` supports seed-based color generation using the Material Design 3 HCT color space. A single seed color is used to derive the full tonal palette (Primary, Secondary, Tertiary, Neutral, and Error), for both Light and Dark themes.
-
-By default, no seed is set and `MaterialToolkitTheme` uses the Material color palette. To opt into seed-based generation, set a seed via the `Colors` property:
-
-```xml
-<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
-                      xmlns:ut="using:Uno.Themes">
-    <MaterialToolkitTheme.Colors>
-        <ut:ThemeColors PrimarySeed="#FF6B35" />
-    </MaterialToolkitTheme.Colors>
-</MaterialToolkitTheme>
-```
-
-You can also change the seed color at runtime from C#:
-
-```csharp
-using Uno.Themes;
-using Windows.UI;
-
-// Change the primary seed color at runtime
-SemanticThemeHelper.PrimarySeed = Color.FromArgb(0xFF, 0xFF, 0x6B, 0x35);
-
-// Clear the seed to revert to the default palette
-SemanticThemeHelper.PrimarySeed = null;
-```
-
-For more details, see the [Seed Color Palette documentation](xref:Uno.Themes.SeedColors).
+Follow the [Uno Themes seed color guide](xref:Uno.Themes.SeedColors) for color generation and runtime customization, applying its examples to the Toolkit theme.
 
 ## Using C# Markup
 

--- a/doc/simple-getting-started.md
+++ b/doc/simple-getting-started.md
@@ -25,14 +25,7 @@ Initialization of the Simple Toolkit resources is handled by the specialized `Si
 
 #### Properties
 
-| Property              | Type                 | Description                                                                                                                                                                       |
-|-----------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ColorOverrideSource` | `string`             | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a ResourceDictionary containing overrides for the default Simple Color resources       |
-| `FontOverrideSource`  | `string`             | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a ResourceDictionary containing overrides for the default Simple FontFamily resources  |
-| `DefaultFontFamily` | `FontFamily` | (Optional) Sets the root typeface and derived type-scale font families. When unset, the theme uses Inter. |
-| `DefaultSpacing` | `double` | (Optional) Sets the base spacing unit in pixels (default `4`), scaled by `DefaultDensity` to generate `Space*` tokens. |
-| `DefaultDensity`      | `Density`            | (Optional) Scales `DefaultSpacing`: `Compact` ×0.75, `Regular` ×1 (default), or `Comfy` ×1.25. Control heights and icon sizes remain unchanged. |
-| `DefaultCornerRadius` | `double`             | (Optional) Gets or sets the base corner radius unit (in pixels) used to compute all shape scale tokens (`Radius100`, `Radius200`, …) as multiples of this value. Default is `4`. |
+`SimpleToolkitTheme` inherits its theme properties from Uno Themes' `SimpleTheme` and `BaseTheme`, including `Colors`, font/color overrides, `DefaultFontFamily`, `DefaultSpacing`, `DefaultDensity`, and `DefaultCornerRadius`. See the [Uno Themes property reference](xref:Uno.Themes.DesignTokens#properties-reference) and [Uno Simple customization guide](xref:Uno.Themes.Simple.GetStarted#customization) for their behavior and usage.
 
 ## Installation
 
@@ -144,94 +137,26 @@ Depending on the type of project template that the Uno Platform application was 
 
 ## Customization
 
-With `SimpleToolkitTheme`, you do not need to explicitly initialize `ToolkitResources`, `SimpleTheme`, or `SimpleColors`. This means that all resource overrides should go through `SimpleToolkitTheme` itself.
+Apply the properties shown in Uno Themes examples directly to `SimpleToolkitTheme`. It initializes the underlying theme and Toolkit resources, so do not add a separate `SimpleTheme`.
 
 ### Customize Colors
 
-Follow the [Uno Simple Customization guide](xref:Uno.Themes.Simple.GetStarted#customization) to create a `ColorPaletteOverride.xaml` file and add it to your application project.
-
-In `App.xaml`, use the `ColorOverrideSource` property on `SimpleToolkitTheme`:
-
-```xml
-<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
-                    ColorOverrideSource="ms-appx:///Style/Application/ColorPaletteOverride.xaml" />
-```
+Follow the [Uno Simple color override guide](xref:Uno.Themes.Simple.GetStarted#customize-color-palette), using `SimpleToolkitTheme` as the theme dictionary.
 
 ### Customize Fonts
 
-Set `DefaultFontFamily` to customize the root typeface and its derived type-scale font families:
+See [Uno Themes typography customization](xref:Uno.Themes.DesignTokens#typography-font-swap) for `DefaultFontFamily`, override precedence, and runtime refresh behavior, and the [Uno Simple font guide](xref:Uno.Themes.Simple.GetStarted#customize-fonts) for font resources.
 
-```xml
-<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
-                    DefaultFontFamily="ms-appx:///Fonts/MyFont.ttf#MyFont" />
-```
-
-Use a font that supports the required weights, through a variable font or font manifest. The `*FontWeight` tokens continue to select each type scale's weight. The former `TypefacePlain` / `TypefaceBrand` keys and Simple's `SimpleFontFamily` / per-weight font-family keys have been removed; use `DefaultFontFamily` instead.
-
-For individual resource overrides, use `FontOverrideSource` or `FontOverrideDictionary`. Explicit keys in a font override take precedence over the corresponding generated keys. Toolkit control-specific aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; the root property does not regenerate these aliases. See [NavigationBar styling](controls/NavigationBar.md) and [Divider styling](controls/Divider.md).
-
-Changing the property at runtime regenerates the root and type-scale resources. Existing text that reads them through `ThemeResource` re-resolves after a theme-change pass (toggle the root's `RequestedTheme` away from its `ActualTheme` and back) or when root content is recreated. Unstyled text uses the framework's font default independently. See [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
-
-Follow the [Uno Simple Customization guide](xref:Uno.Themes.Simple.GetStarted#customization) to create a `FontOverride.xaml` file and add it to your application project.
-
-In `App.xaml`, use the `FontOverrideSource` property on `SimpleToolkitTheme`:
-
-```xml
-<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
-                    FontOverrideSource="ms-appx:///Style/Application/FontOverride.xaml" />
-```
+Toolkit control-specific aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; `DefaultFontFamily` does not regenerate these aliases. See [NavigationBar styling](controls/NavigationBar.md) and [Divider styling](controls/Divider.md).
 
 ### Customize Default Density
 
-`DefaultSpacing` sets the base unit (default `4` pixels), and `DefaultDensity` scales it:
-
-| Density | Factor | Effective base when `DefaultSpacing="4"` |
-|---------|--------|-----------------------------------------|
-| `Compact` | ×0.75 | 3 px |
-| `Regular` (default) | ×1 | 4 px |
-| `Comfy` | ×1.25 | 5 px |
-
-For example, a base of `6` with `Comfy` generates `Space100=7.5` and `Space200=15`:
-
-```xml
-<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
-                    DefaultSpacing="6"
-                    DefaultDensity="Comfy" />
-```
-
-Only styles consuming `Space*` tokens follow this scale; fixed Toolkit padding and margins remain unchanged. Control heights and icon sizes are independent of density. Runtime changes regenerate the resources; existing controls reading them through `ThemeResource` re-resolve after a theme-change pass or root-content recreation. See [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
+See [Uno Themes spacing and shape customization](xref:Uno.Themes.DesignTokens#via-scalar-properties) and [density modes](xref:Uno.Themes.DesignTokens#density-modes) for `DefaultSpacing` and `DefaultDensity`. Toolkit padding and margins defined as fixed values do not follow these generated scales.
 
 ### Customize Default Corner Radius
 
-The `SimpleToolkitTheme` exposes the base corner radius unit (in pixels) through the `DefaultCornerRadius` property. All shape scale tokens (`Radius100`, `Radius200`, …) are computed as multiples of this value — e.g. `DefaultCornerRadius="6"` makes `Radius100=6`, `Radius200=12`, `Radius400=24`, etc. `RadiusFull` always remains `9999` (pill shape). Default is `4`.
-
-```xml
-<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
-                    DefaultCornerRadius="6" />
-```
+See [Uno Themes shape customization](xref:Uno.Themes.DesignTokens#via-scalar-properties) for `DefaultCornerRadius`. Toolkit styles follow it where they consume the generated shape tokens.
 
 ### Seed Color Customization
 
-`SimpleToolkitTheme` supports seed-based color generation. A single seed color is used to derive tonal palettes for both Light and Dark themes.
-
-By default, no seed is set and `SimpleToolkitTheme` uses its grayscale palette. To opt into seed-based generation, set a seed via the `Colors` property:
-
-```xml
-<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
-                    xmlns:ut="using:Uno.Themes">
-    <SimpleToolkitTheme.Colors>
-        <ut:ThemeColors PrimarySeed="#2196F3" />
-    </SimpleToolkitTheme.Colors>
-</SimpleToolkitTheme>
-```
-
-You can also change the seed color at runtime:
-
-```csharp
-using Uno.Themes;
-using Windows.UI;
-
-SemanticThemeHelper.PrimarySeed = Color.FromArgb(0xFF, 0x21, 0x96, 0xF3);
-```
-
-For more details, see the [Seed Color Palette documentation](xref:Uno.Themes.SeedColors).
+Follow the [Uno Themes seed color guide](xref:Uno.Themes.SeedColors) for color generation and runtime customization, applying its examples to the Toolkit theme.

--- a/doc/simple-getting-started.md
+++ b/doc/simple-getting-started.md
@@ -29,7 +29,9 @@ Initialization of the Simple Toolkit resources is handled by the specialized `Si
 |-----------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `ColorOverrideSource` | `string`             | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a ResourceDictionary containing overrides for the default Simple Color resources       |
 | `FontOverrideSource`  | `string`             | (Optional) Gets or sets a Uniform Resource Identifier that provides the source location of a ResourceDictionary containing overrides for the default Simple FontFamily resources  |
-| `DefaultDensity`      | `Density`            | (Optional) Gets or sets the density preset that drives the base spacing unit used by all `Space*` tokens. Default is `Regular`. Accepted values are `Compact` (3 px), `Regular` (4 px), and `Comfy` (5 px). |
+| `DefaultFontFamily` | `FontFamily` | (Optional) Sets the root typeface and derived type-scale font families. When unset, the theme uses Inter. |
+| `DefaultSpacing` | `double` | (Optional) Sets the base spacing unit in pixels (default `4`), scaled by `DefaultDensity` to generate `Space*` tokens. |
+| `DefaultDensity`      | `Density`            | (Optional) Scales `DefaultSpacing`: `Compact` ×0.75, `Regular` ×1 (default), or `Comfy` ×1.25. Control heights and icon sizes remain unchanged. |
 | `DefaultCornerRadius` | `double`             | (Optional) Gets or sets the base corner radius unit (in pixels) used to compute all shape scale tokens (`Radius100`, `Radius200`, …) as multiples of this value. Default is `4`. |
 
 ## Installation
@@ -157,6 +159,19 @@ In `App.xaml`, use the `ColorOverrideSource` property on `SimpleToolkitTheme`:
 
 ### Customize Fonts
 
+Set `DefaultFontFamily` to customize the root typeface and its derived type-scale font families:
+
+```xml
+<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
+                    DefaultFontFamily="ms-appx:///Fonts/MyFont.ttf#MyFont" />
+```
+
+Use a font that supports the required weights, through a variable font or font manifest. The `*FontWeight` tokens continue to select each type scale's weight. The former `TypefacePlain` / `TypefaceBrand` keys and Simple's `SimpleFontFamily` / per-weight font-family keys have been removed; use `DefaultFontFamily` instead.
+
+For individual resource overrides, use `FontOverrideSource` or `FontOverrideDictionary`. Explicit keys in a font override take precedence over the corresponding generated keys. Toolkit control-specific aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; the root property does not regenerate these aliases. See [NavigationBar styling](controls/NavigationBar.md) and [Divider styling](controls/Divider.md).
+
+Changing the property at runtime regenerates the root and type-scale resources. Existing text that reads them through `ThemeResource` re-resolves after a theme-change pass (toggle the root's `RequestedTheme` away from its `ActualTheme` and back) or when root content is recreated. Unstyled text uses the framework's font default independently. See [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
+
 Follow the [Uno Simple Customization guide](xref:Uno.Themes.Simple.GetStarted#customization) to create a `FontOverride.xaml` file and add it to your application project.
 
 In `App.xaml`, use the `FontOverrideSource` property on `SimpleToolkitTheme`:
@@ -168,18 +183,23 @@ In `App.xaml`, use the `FontOverrideSource` property on `SimpleToolkitTheme`:
 
 ### Customize Default Density
 
-The `SimpleToolkitTheme` exposes a density preset through the `DefaultDensity` property, which drives the base spacing unit used by all `Space*` tokens (control heights and icon sizes remain constant across densities):
+`DefaultSpacing` sets the base unit (default `4` pixels), and `DefaultDensity` scales it:
 
-- `Compact` - Tighter padding for data-dense UIs (base spacing unit = 3 px)
-- `Regular` (default) - Balanced spacing (base spacing unit = 4 px)
-- `Comfy` - More generous padding (base spacing unit = 5 px)
+| Density | Factor | Effective base when `DefaultSpacing="4"` |
+|---------|--------|-----------------------------------------|
+| `Compact` | ×0.75 | 3 px |
+| `Regular` (default) | ×1 | 4 px |
+| `Comfy` | ×1.25 | 5 px |
 
-In `App.xaml`, use the `DefaultDensity` property on `SimpleToolkitTheme`:
+For example, a base of `6` with `Comfy` generates `Space100=7.5` and `Space200=15`:
 
 ```xml
 <SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
+                    DefaultSpacing="6"
                     DefaultDensity="Comfy" />
 ```
+
+Only styles consuming `Space*` tokens follow this scale; fixed Toolkit padding and margins remain unchanged. Control heights and icon sizes are independent of density. Runtime changes regenerate the resources; existing controls reading them through `ThemeResource` re-resolve after a theme-change pass or root-content recreation. See [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
 
 ### Customize Default Corner Radius
 

--- a/doc/simple-getting-started.md
+++ b/doc/simple-getting-started.md
@@ -25,7 +25,7 @@ Initialization of the Simple Toolkit resources is handled by the specialized `Si
 
 #### Properties
 
-`SimpleToolkitTheme` inherits its theme properties from Uno Themes' `SimpleTheme` and `BaseTheme`, including `Colors`, font/color overrides, `DefaultFontFamily`, `DefaultSpacing`, `DefaultDensity`, and `DefaultCornerRadius`. See the [Uno Themes property reference](xref:Uno.Themes.DesignTokens#properties-reference) and [Uno Simple customization guide](xref:Uno.Themes.Simple.GetStarted#customization) for their behavior and usage.
+`SimpleToolkitTheme` inherits its configuration from Uno Themes. Refer to [Uno Simple customization](xref:Uno.Themes.Simple.GetStarted#customization) and the [shared theme property reference](xref:Uno.Themes.DesignTokens#properties-reference).
 
 ## Installation
 
@@ -145,18 +145,18 @@ Follow the [Uno Simple color override guide](xref:Uno.Themes.Simple.GetStarted#c
 
 ### Customize Fonts
 
-See [Uno Themes typography customization](xref:Uno.Themes.DesignTokens#typography-font-swap) for `DefaultFontFamily`, override precedence, and runtime refresh behavior, and the [Uno Simple font guide](xref:Uno.Themes.Simple.GetStarted#customize-fonts) for font resources.
+Follow the [Uno Themes typography guide](xref:Uno.Themes.DesignTokens#typography-font-swap) and [Uno Simple font guide](xref:Uno.Themes.Simple.GetStarted#customize-fonts).
 
 Toolkit control-specific aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; `DefaultFontFamily` does not regenerate these aliases. See [NavigationBar styling](controls/NavigationBar.md) and [Divider styling](controls/Divider.md).
 
 ### Customize Default Density
 
-See [Uno Themes spacing and shape customization](xref:Uno.Themes.DesignTokens#via-scalar-properties) and [density modes](xref:Uno.Themes.DesignTokens#density-modes) for `DefaultSpacing` and `DefaultDensity`. Toolkit padding and margins defined as fixed values do not follow these generated scales.
+Follow the Uno Themes guides for [spacing](xref:Uno.Themes.DesignTokens#via-scalar-properties) and [density](xref:Uno.Themes.DesignTokens#density-modes). Fixed Toolkit padding and margins remain independent of the generated spacing scale.
 
 ### Customize Default Corner Radius
 
-See [Uno Themes shape customization](xref:Uno.Themes.DesignTokens#via-scalar-properties) for `DefaultCornerRadius`. Toolkit styles follow it where they consume the generated shape tokens.
+Follow the [Uno Themes shape customization guide](xref:Uno.Themes.DesignTokens#via-scalar-properties).
 
 ### Seed Color Customization
 
-Follow the [Uno Themes seed color guide](xref:Uno.Themes.SeedColors) for color generation and runtime customization, applying its examples to the Toolkit theme.
+Follow the [Uno Themes seed color guide](xref:Uno.Themes.SeedColors), using the Toolkit theme in its examples.

--- a/doc/uno-toolkit-migration.md
+++ b/doc/uno-toolkit-migration.md
@@ -6,6 +6,41 @@ uid: Toolkit.Migration
 
 **UnoFeatures:** `Toolkit` (add to `<UnoFeatures>` in your `.csproj`)
 
+## Upgrading to Uno Toolkit 10.0
+
+Uno Toolkit 10.0 adopts the Uno Themes typography and spacing changes in `8.0.0-dev.15`. Apps that override font resource keys or persist density values should make the following changes.
+
+### Replace removed font resources
+
+The `TypefacePlain` and `TypefaceBrand` root tokens have been replaced by `DefaultFontFamily`. Simple also removes `SimpleFontFamily`, `SimpleRegularFontFamily`, `SimpleMediumFontFamily`, `SimpleSemiBoldFontFamily`, and `SimpleBoldFontFamily`. Replace these keys in app resource overrides with `DefaultFontFamily`; per-scale weights are controlled by the existing `*FontWeight` tokens.
+
+Both toolkit themes inherit a `DefaultFontFamily` property that generates the root and derived type-scale font families:
+
+```xml
+<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
+                    DefaultFontFamily="ms-appx:///Fonts/MyFont.ttf#MyFont" />
+```
+
+Use a variable font or a font manifest to resolve the required weights from a single family. `FontOverrideSource` and `FontOverrideDictionary` still support individual overrides, and their explicit keys take precedence over corresponding generated keys. Toolkit aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; the root property does not regenerate them. Material's legacy `MaterialLightFontFamily`, `MaterialMediumFontFamily`, and `MaterialRegularFontFamily` keys remain available.
+
+Changing `DefaultFontFamily` at runtime regenerates its resources. Existing text reading those resources through `ThemeResource` re-resolves after a theme-change pass or root-content recreation. Unstyled text keeps the framework's font default. See [font customization](simple-getting-started.md#customize-fonts) for details.
+
+### Separate spacing from density
+
+`DefaultSpacing` is the base spacing unit in pixels (default `4`). `DefaultDensity` now scales that unit: `Compact` ×0.75, `Regular` ×1, or `Comfy` ×1.25. Defaults still produce the previous 3 / 4 / 5 pixel spacing bases.
+
+```xml
+<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
+                      DefaultSpacing="6"
+                      DefaultDensity="Comfy" />
+```
+
+This produces an effective base of 7.5 pixels (`Space100=7.5`, `Space200=15`). Only styles that consume the spacing tokens follow this scale; fixed Toolkit padding, control heights, and icon sizes are unchanged.
+
+The numeric values of `Density.Compact`, `Density.Regular`, and `Density.Comfy` changed from `3`, `4`, and `5` to `0`, `1`, and `2`. Replace casts from spacing values with named enum members, and migrate any persisted numeric density values. XAML using the names needs no change.
+
+For runtime resource refresh behavior and precedence, see [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
+
 ## Upgrading to Uno Toolkit 9.0
 
 Uno Toolkit 9.0 takes a dependency on Uno Themes 7.0, which introduces seed-based color generation and a unified design-token system. It also drops UWP support and reshapes the public surface of the theme classes. Most apps that consume `<MaterialToolkitTheme/>` or `<SimpleToolkitTheme/>` via XAML will not need code changes, but several behaviors and defaults have shifted. Uno Toolkit 9.0 requires Uno.WinUI 6.5 or later; apps using the Uno SDK get compatible versions automatically, while apps pinning package versions manually should update their `Uno.WinUI` reference.

--- a/doc/uno-toolkit-migration.md
+++ b/doc/uno-toolkit-migration.md
@@ -8,38 +8,14 @@ uid: Toolkit.Migration
 
 ## Upgrading to Uno Toolkit 10.0
 
-Uno Toolkit 10.0 adopts the Uno Themes typography and spacing changes in `8.0.0-dev.15`. Apps that override font resource keys or persist density values should make the following changes.
+Uno Toolkit 10.0 adopts the Uno Themes typography and spacing changes. Applications that override removed font resources or persist numeric density values need to update those usages:
 
-### Replace removed font resources
+- Replace `TypefacePlain`, `TypefaceBrand`, `SimpleFontFamily`, and Simple's per-weight font-family keys with `DefaultFontFamily`. See [Uno Themes typography](xref:Uno.Themes.DesignTokens#typography) for the resource changes.
+- Use named `Density` members and migrate persisted numeric values: `Compact`, `Regular`, and `Comfy` changed from `3`, `4`, and `5` to `0`, `1`, and `2`. XAML using the names needs no change. See [Uno Themes density modes](xref:Uno.Themes.DesignTokens#density-modes).
 
-The `TypefacePlain` and `TypefaceBrand` root tokens have been replaced by `DefaultFontFamily`. Simple also removes `SimpleFontFamily`, `SimpleRegularFontFamily`, `SimpleMediumFontFamily`, `SimpleSemiBoldFontFamily`, and `SimpleBoldFontFamily`. Replace these keys in app resource overrides with `DefaultFontFamily`; per-scale weights are controlled by the existing `*FontWeight` tokens.
+`MaterialToolkitTheme` and `SimpleToolkitTheme` inherit the shared `BaseTheme` APIs. Apply the [Uno Themes customization examples](xref:Uno.Themes.DesignTokens#overriding-tokens) directly to the Toolkit theme; a separate underlying theme dictionary is unnecessary.
 
-Both toolkit themes inherit a `DefaultFontFamily` property that generates the root and derived type-scale font families:
-
-```xml
-<SimpleToolkitTheme xmlns="using:Uno.Toolkit.UI.Simple"
-                    DefaultFontFamily="ms-appx:///Fonts/MyFont.ttf#MyFont" />
-```
-
-Use a variable font or a font manifest to resolve the required weights from a single family. `FontOverrideSource` and `FontOverrideDictionary` still support individual overrides, and their explicit keys take precedence over corresponding generated keys. Toolkit aliases such as `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` retain their own override keys; the root property does not regenerate them. Material's legacy `MaterialLightFontFamily`, `MaterialMediumFontFamily`, and `MaterialRegularFontFamily` keys remain available.
-
-Changing `DefaultFontFamily` at runtime regenerates its resources. Existing text reading those resources through `ThemeResource` re-resolves after a theme-change pass or root-content recreation. Unstyled text keeps the framework's font default. See [font customization](simple-getting-started.md#customize-fonts) for details.
-
-### Separate spacing from density
-
-`DefaultSpacing` is the base spacing unit in pixels (default `4`). `DefaultDensity` now scales that unit: `Compact` ×0.75, `Regular` ×1, or `Comfy` ×1.25. Defaults still produce the previous 3 / 4 / 5 pixel spacing bases.
-
-```xml
-<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
-                      DefaultSpacing="6"
-                      DefaultDensity="Comfy" />
-```
-
-This produces an effective base of 7.5 pixels (`Space100=7.5`, `Space200=15`). Only styles that consume the spacing tokens follow this scale; fixed Toolkit padding, control heights, and icon sizes are unchanged.
-
-The numeric values of `Density.Compact`, `Density.Regular`, and `Density.Comfy` changed from `3`, `4`, and `5` to `0`, `1`, and `2`. Replace casts from spacing values with named enum members, and migrate any persisted numeric density values. XAML using the names needs no change.
-
-For runtime resource refresh behavior and precedence, see [Uno Themes design tokens](xref:Uno.Themes.DesignTokens).
+Toolkit's `NavigationBarFontFamily` and `DividerSubHeaderFontFamily` override keys remain available; `DefaultFontFamily` does not regenerate these aliases. Fixed Toolkit padding and margins also remain independent of the generated spacing scale. See [Material customization](material-getting-started.md#customization) and [Simple customization](simple-getting-started.md#customization) for Toolkit-specific considerations.
 
 ## Upgrading to Uno Toolkit 9.0
 

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<SkiaSharpVersion>3.119.2</SkiaSharpVersion>
-		<UnoThemesVersion>7.1.0-dev.1</UnoThemesVersion>
+		<UnoThemesVersion>8.0.0-dev.15</UnoThemesVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Uno.Core.Extensions.Compatibility" Version="4.0.1" />

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -4,3 +4,4 @@
 
 - Public migration guidance should describe release-level behavior without pinning the explanation to an exact prerelease NuGet build. Package provenance belongs in PR and validation notes.
 - Inherited APIs do not need a second usage guide in Toolkit. Keep Toolkit setup and control-specific caveats locally, and link shared `BaseTheme` behavior to Uno Themes so changes have one documentation owner.
+- Apply documentation ownership decisions to the entire branch diff, including XML summaries. Avoid maintaining lists of inherited members in Toolkit; link to their owner and retain only local integration details.

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -1,0 +1,6 @@
+# Lessons
+
+## Documentation ownership
+
+- Public migration guidance should describe release-level behavior without pinning the explanation to an exact prerelease NuGet build. Package provenance belongs in PR and validation notes.
+- Inherited APIs do not need a second usage guide in Toolkit. Keep Toolkit setup and control-specific caveats locally, and link shared `BaseTheme` behavior to Uno Themes so changes have one documentation owner.

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -5,3 +5,8 @@
 - Public migration guidance should describe release-level behavior without pinning the explanation to an exact prerelease NuGet build. Package provenance belongs in PR and validation notes.
 - Inherited APIs do not need a second usage guide in Toolkit. Keep Toolkit setup and control-specific caveats locally, and link shared `BaseTheme` behavior to Uno Themes so changes have one documentation owner.
 - Apply documentation ownership decisions to the entire branch diff, including XML summaries. Avoid maintaining lists of inherited members in Toolkit; link to their owner and retain only local integration details.
+
+## Compatibility test ownership
+
+- Test Toolkit's inheritance of upstream token generation against the upstream theme with identical inputs. Keep arithmetic tables and default asset names in the owning Themes tests.
+- Reuse Toolkit's existing visual-tree helpers in runtime tests instead of introducing a second traversal implementation.

--- a/specs/themes-compatibility/progress.md
+++ b/specs/themes-compatibility/progress.md
@@ -76,3 +76,31 @@ included in the total. Logs and XML results are in ignored
 - [x] Verify all 13 upstream cross-reference targets/anchors and local Markdown links; prepare the documentation follow-up for publication.
 
 `git diff --check` passes. Changes are limited to documentation and XML comments; no executable code changed, so builds and runtime tests were not rerun.
+
+## PR #1636 review follow-up
+
+- [x] Inventory all review threads, including resolved feedback and release coordination.
+- [x] Compare Toolkit spacing generation with plain MaterialTheme for identical inputs, using Border.Padding probes.
+- [x] Replace the local descendant iterator with the existing Toolkit extension.
+- [x] Build Release Desktop and WebAssembly and run ThemeCompatibilityTests.
+- [x] Audit CI notices and issue-link feedback; record remaining publication steps and validation results.
+
+Keep the PR targeting main. Merge, servicing/10.0 backport publication, and notifying
+Martin after merge remain release coordination steps requiring explicit authorization.
+
+### Review follow-up validation (2026-09-09)
+
+- `ThemeCompatibilityTests`: **Passed: 7, Failed: 0, Skipped: 0** on macOS Desktop, including all three density cases compared against plain MaterialTheme and all four existing font cases. The reference padding must also be positive so unresolved tokens cannot produce a vacuous comparison.
+- Standalone Release runtime-test project build passed with **0 warnings, 0 errors**.
+- Release Material sample builds passed for Desktop and WebAssembly (.NET SDK 10.0.103): 100 and 113 warnings respectively, matching the counts in the prior baseline audit above; zero errors. No warning suppressions were added. WebAssembly runtime tests were not rerun.
+- Launch from `samples/Uno.Toolkit.Samples.Material/bin/Release/net10.0-desktop`:
+
+  ```sh
+  UNO_RUNTIME_TESTS_RUN_TESTS='{"Filter":{"Value":"ThemeCompatibilityTests"},"Attempts":1}' UNO_RUNTIME_TESTS_OUTPUT_PATH="$PWD/results.xml" dotnet MaterialSampleApp.dll --runtime-tests="$PWD/results.xml"
+  ```
+
+  The initial launches without `UNO_RUNTIME_TESTS_OUTPUT_PATH` produced no results; setting the output environment variable required by the embedded runner enabled execution. Actual logs/XML are in ignored `artifacts/themes-review/`.
+- Review changes refactor existing tests; no product behavior changed and no test cases were removed.
+- Latest Azure CI run 232693 passes, superseding the older failure notices. Preview deployment is blocked by Azure's staging-environment quota. Copilot setup fails on a missing `Uno.Toolkit.UITest.csproj` solution entry also present on `origin/main`; neither failure calls for changing theme compatibility code.
+- The PR template permits GitHub or internal issues and does not require a Toolkit-repository issue. Verified related upstream issues: [Uno.Themes#1709](https://github.com/unoplatform/Uno.Themes/issues/1709) and [Uno.Themes#1688](https://github.com/unoplatform/Uno.Themes/issues/1688). An updated PR body is prepared in ignored `artifacts/themes-review/pr-body.md`.
+- Publication, review-thread updates, merge/backport, and post-merge notification have not been performed.

--- a/specs/themes-compatibility/progress.md
+++ b/specs/themes-compatibility/progress.md
@@ -68,3 +68,11 @@ included in the total. Logs and XML results are in ignored
 - XAML Styler was run on all five changed files. Its unrelated whole-file formatting changes were removed to preserve the minimal nine-reference diff.
 - Generated XAML build output was excluded from the change; final `git diff --check` passed.
 - Independent source/documentation/test review found no blocking issues. Toolkit-specific font aliases retain their override keys; their runtime regeneration limitation is documented.
+
+## Full-branch documentation review
+
+- [x] Review all public-documentation and XML-summary changes against origin/main.
+- [x] Remove inherited-member catalogs from getting-started pages and XML summaries; keep upstream links, Toolkit setup, migration actions, and control caveats.
+- [x] Verify all 13 upstream cross-reference targets/anchors and local Markdown links; prepare the documentation follow-up for publication.
+
+`git diff --check` passes. Changes are limited to documentation and XML comments; no executable code changed, so builds and runtime tests were not rerun.

--- a/specs/themes-compatibility/progress.md
+++ b/specs/themes-compatibility/progress.md
@@ -1,0 +1,62 @@
+# Uno Themes compatibility
+
+Adapt Toolkit's existing 10.0 development line to the latest breaking changes in
+`../uno.themes`. Keep Toolkit's version unchanged and add no new dependencies.
+
+## Plan
+
+- [x] Compare upstream breaking changes and audit Toolkit APIs/resources.
+- [x] Verify the published package contains the latest functional changes and update existing Themes version pins.
+- [x] Add and run regression coverage before replacing removed Simple font resources.
+- [x] Migrate affected styles and document DefaultFontFamily, DefaultSpacing, and density semantics.
+- [x] Build affected libraries and sample heads in Release for Desktop and WebAssembly; run relevant runtime tests.
+- [x] Review the final diff and prepare the requested PR against main.
+
+## Scope
+
+- Upstream #1701 separates DefaultSpacing from the Density mode.
+- Upstream #1710 replaces SimpleFontFamily and root typeface tokens with DefaultFontFamily.
+- Upstream #1707/#1716 adds runtime font overrides and theme-aware font reads.
+- Upstream #1715 makes generated spacing/shape reads dynamic; Toolkit has no direct Space*/Radius* reads to migrate.
+- Preserve Toolkit lightweight styling keys and existing public API.
+
+## Review and validation
+
+Validated on 2026-09-08 with .NET SDK 10.0.400.
+
+The latest published package, `8.0.0-dev.15`, records upstream commit
+`47d42c185764907a10d0dd5511eb1f0eddd8b6f1` in its nuspec. Comparing that commit
+with upstream HEAD `b592b87c` shows only the 9.0 version.json change. Both existing
+Themes pins now use that published package; Toolkit's `10.0-dev.{height}` is unchanged.
+
+### Runtime tests
+
+The new `ThemeCompatibilityTests` ran against the upgraded dependency before
+the XAML fix: 4 Simple font cases failed while resolving the removed resource,
+and 3 spacing cases passed. After the fix, all 7 passed.
+
+| Requirement | Evidence |
+| --- | --- |
+| Simple defaults and Divider/NavigationBar aliases in Light/Dark | `When_SimpleStylesLoaded_FontsResolveDefaultFontFamily` (2 passed) |
+| Scoped font override on Card/CardContentControl/Chip | `When_SimpleDefaultFontFamilySet_DirectControlStylesUseScopedFont` (2 passed) |
+| Spacing base scaled by each density mode | `When_MaterialDefaultSpacingSet_DensityScalesInheritedTokens` (3 passed) |
+| Existing theme/control regressions | `ThemeInitTests` (2), `CardContentControlTests` (3), `ChipGroupTests` (21), `NavigationBarTests` (8), all passed |
+
+Total: **Passed: 41, Failed: 0, Skipped: 0** on the Material Desktop runtime host.
+Each class was run separately with
+`UNO_RUNTIME_TESTS_RUN_TESTS='{"Filter":{"Value":"<class>"},"Attempts":1}'`
+and `MaterialSampleApp.exe --runtime-tests=<results.xml>`. A combined filter did
+not select the intended suite in this runner, so its duplicate 7 cases are not
+included in the total. Logs and XML results are in ignored
+`artifacts/themes-compatibility/`.
+
+### Builds and limits
+
+- Release Material Desktop and WebAssembly builds passed; Simple and Cupertino Desktop builds passed.
+- Standalone Release Material Markup (including base Markup/Material), Simple, and Cupertino library builds: zero warnings/errors.
+- Sample warnings: Material Desktop 100; Material WebAssembly 113; Simple/Cupertino Desktop 99 each. All warnings match clean `origin/main` (`d88a0c12`) builds in an isolated worktree, including message text and locations. The repository-wide zero-warning sample requirement remains unmet on main; no warning suppressions or unrelated fixes were added here.
+- Builds used `dotnet build <project> -c Release -p:TargetFrameworkOverride=<desktop|browserwasm>` and explicit `-f net10.0-<desktop|browserwasm>` for samples. Sample builds also used `-p:DisableMobileTargets=true`.
+- WebAssembly was build-validated; runtime execution was on Desktop. Mobile/WinUI and Debug hot-reload runs were not performed.
+- XAML Styler was run on all five changed files. Its unrelated whole-file formatting changes were removed to preserve the minimal nine-reference diff.
+- Generated XAML build output was excluded from the change; final `git diff --check` passed.
+- Independent source/documentation/test review found no blocking issues. Toolkit-specific font aliases retain their override keys; their runtime regeneration limitation is documented.

--- a/specs/themes-compatibility/progress.md
+++ b/specs/themes-compatibility/progress.md
@@ -20,6 +20,14 @@ Adapt Toolkit's existing 10.0 development line to the latest breaking changes in
 - Upstream #1715 makes generated spacing/shape reads dynamic; Toolkit has no direct Space*/Radius* reads to migrate.
 - Preserve Toolkit lightweight styling keys and existing public API.
 
+## Documentation follow-up
+
+- [x] Remove exact prerelease package versions from public migration guidance.
+- [x] Link shared BaseTheme API usage to Uno Themes; retain Toolkit setup, migration impact, and control-specific caveats.
+- [x] Record the documentation rule in shared agent guidance and lessons, verify links, and prepare the PR update.
+
+Follow-up validation: all 13 Uno Themes cross-reference targets/anchors and local Markdown links in the three revised guides resolve against the checked-out sources. `git diff --check` passes. This follow-up changes documentation only; the previous build/runtime results remain applicable and were not rerun.
+
 ## Review and validation
 
 Validated on 2026-09-08 with .NET SDK 10.0.400.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <UnoThemesVersion>7.1.0-dev.1</UnoThemesVersion>
+    <UnoThemesVersion>8.0.0-dev.15</UnoThemesVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.14" />

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ThemeCompatibilityTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ThemeCompatibilityTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Themes;
+using Uno.Toolkit.RuntimeTests.Helpers;
+using Uno.Toolkit.UI;
+using Uno.Toolkit.UI.Material;
+using Uno.Toolkit.UI.Simple;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Toolkit.RuntimeTests.Tests
+{
+	[TestClass]
+	[RunsOnUIThread]
+	internal sealed class ThemeCompatibilityTests
+	{
+		[TestCleanup]
+		public async Task Cleanup()
+		{
+			UnitTestsUIContentHelper.Content = null;
+			await UnitTestsUIContentHelper.WaitForIdle();
+		}
+
+		[TestMethod]
+		[DataRow(ElementTheme.Light)]
+		[DataRow(ElementTheme.Dark)]
+		public async Task When_SimpleStylesLoaded_FontsResolveDefaultFontFamily(ElementTheme requestedTheme)
+		{
+			var theme = new SimpleToolkitTheme();
+			var root = CreateRoot(theme, requestedTheme);
+			var card = new Card { HeaderContent = "Card", Style = (Style)theme["SimpleFilledCardStyle"] };
+			var contentCard = new CardContentControl { Content = "Content card", Style = (Style)theme["SimpleFilledCardContentControlStyle"] };
+			var chip = new Chip { Content = "Chip", Style = (Style)theme["SimpleChipStyle"] };
+			var divider = new Divider { SubHeader = "Divider", Style = (Style)theme["SimpleDividerStyle"] };
+			var navigationBar = new NavigationBar
+			{
+				Content = "Navigation",
+				Style = (Style)theme["SimpleNavigationBarStyle"],
+				// Exercise the shared XAML font aliases on mobile hosts as well.
+				Template = (ControlTemplate)theme["XamlSimpleNavigationBarTemplate"]
+			};
+			var ellipsisButton = new Button { Style = (Style)theme["SimpleEllipsisButton"] };
+			root.Children.Add(new StackPanel { Children = { card, contentCard, chip, divider, navigationBar, ellipsisButton } });
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+			var expected = ((FontFamily)theme["DefaultFontFamily"]).Source;
+			StringAssert.Contains(expected, "Inter.ttf", "The scoped Simple theme must supply its own default typeface.");
+			Assert.AreEqual(expected, card.FontFamily.Source, "Card");
+			Assert.AreEqual(expected, contentCard.FontFamily.Source, "CardContentControl");
+			Assert.AreEqual(expected, chip.FontFamily.Source, "Chip");
+			Assert.AreEqual(expected, Descendants<TextBlock>(divider).Single(x => x.Text == "Divider").FontFamily.Source, "Divider subheader alias");
+			Assert.AreEqual(expected, Descendants<ContentControl>(navigationBar).Single(x => x.Name == "ContentControl").FontFamily.Source, "NavigationBar content alias");
+			Assert.AreEqual(expected, ellipsisButton.FontFamily.Source, "NavigationBar ellipsis alias");
+		}
+
+		[TestMethod]
+		[DataRow(ElementTheme.Light)]
+		[DataRow(ElementTheme.Dark)]
+		public async Task When_SimpleDefaultFontFamilySet_DirectControlStylesUseScopedFont(ElementTheme requestedTheme)
+		{
+			var expected = new FontFamily("Arial");
+			var theme = new SimpleToolkitTheme { DefaultFontFamily = expected };
+			var root = CreateRoot(theme, requestedTheme);
+			var card = new Card { HeaderContent = "Card", Style = (Style)theme["SimpleFilledCardStyle"] };
+			var contentCard = new CardContentControl { Content = "Content card", Style = (Style)theme["SimpleFilledCardContentControlStyle"] };
+			var chip = new Chip { Content = "Chip", Style = (Style)theme["SimpleChipStyle"] };
+			root.Children.Add(new StackPanel { Children = { card, contentCard, chip } });
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+			Assert.AreEqual(expected.Source, card.FontFamily.Source, "Card");
+			Assert.AreEqual(expected.Source, contentCard.FontFamily.Source, "CardContentControl");
+			Assert.AreEqual(expected.Source, chip.FontFamily.Source, "Chip");
+		}
+
+		[TestMethod]
+		[DataRow(Density.Compact, 9d)]
+		[DataRow(Density.Regular, 12d)]
+		[DataRow(Density.Comfy, 15d)]
+		public async Task When_MaterialDefaultSpacingSet_DensityScalesInheritedTokens(Density density, double expected)
+		{
+			var theme = new MaterialToolkitTheme { DefaultSpacing = 6, DefaultDensity = density };
+			var root = CreateRoot(theme, ElementTheme.Light);
+			var probe = (TextBlock)XamlReader.Load("""
+				<TextBlock xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+				           FontSize="{ThemeResource Space200}" Text="Spacing token" />
+				""");
+			root.Children.Add(probe);
+
+			await UnitTestUIContentHelperEx.SetContentAndWait(root);
+
+			Assert.AreEqual(expected, probe.FontSize, "Space200 must equal DefaultSpacing × density factor × 2.");
+		}
+
+		private static Grid CreateRoot(ResourceDictionary theme, ElementTheme requestedTheme)
+		{
+			var root = new Grid { Width = 500, Height = 600, RequestedTheme = requestedTheme };
+			root.Resources.MergedDictionaries.Add(theme);
+			return root;
+		}
+
+		private static IEnumerable<T> Descendants<T>(DependencyObject parent) where T : DependencyObject
+		{
+			for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+			{
+				var child = VisualTreeHelper.GetChild(parent, i);
+				if (child is T match)
+				{
+					yield return match;
+				}
+				foreach (var descendant in Descendants<T>(child))
+				{
+					yield return descendant;
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ThemeCompatibilityTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ThemeCompatibilityTests.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Material;
 using Uno.Themes;
 using Uno.Toolkit.RuntimeTests.Helpers;
 using Uno.Toolkit.UI;
@@ -51,8 +51,8 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			Assert.AreEqual(expected, card.FontFamily.Source, "Card");
 			Assert.AreEqual(expected, contentCard.FontFamily.Source, "CardContentControl");
 			Assert.AreEqual(expected, chip.FontFamily.Source, "Chip");
-			Assert.AreEqual(expected, Descendants<TextBlock>(divider).Single(x => x.Text == "Divider").FontFamily.Source, "Divider subheader alias");
-			Assert.AreEqual(expected, Descendants<ContentControl>(navigationBar).Single(x => x.Name == "ContentControl").FontFamily.Source, "NavigationBar content alias");
+			Assert.AreEqual(expected, divider.GetDescendants().OfType<TextBlock>().Single(x => x.Text == "Divider").FontFamily.Source, "Divider subheader alias");
+			Assert.AreEqual(expected, navigationBar.GetDescendants().OfType<ContentControl>().Single(x => x.Name == "ContentControl").FontFamily.Source, "NavigationBar content alias");
 			Assert.AreEqual(expected, ellipsisButton.FontFamily.Source, "NavigationBar ellipsis alias");
 		}
 
@@ -77,22 +77,28 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 		}
 
 		[TestMethod]
-		[DataRow(Density.Compact, 9d)]
-		[DataRow(Density.Regular, 12d)]
-		[DataRow(Density.Comfy, 15d)]
-		public async Task When_MaterialDefaultSpacingSet_DensityScalesInheritedTokens(Density density, double expected)
+		[DataRow(Density.Compact)]
+		[DataRow(Density.Regular)]
+		[DataRow(Density.Comfy)]
+		public async Task When_MaterialDefaultSpacingSet_InheritsMaterialThemeTokens(Density density)
 		{
 			var theme = new MaterialToolkitTheme { DefaultSpacing = 6, DefaultDensity = density };
+			var referenceTheme = new MaterialTheme { DefaultSpacing = 6, DefaultDensity = density };
 			var root = CreateRoot(theme, ElementTheme.Light);
-			var probe = (TextBlock)XamlReader.Load("""
-				<TextBlock xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-				           FontSize="{ThemeResource Space200}" Text="Spacing token" />
-				""");
+			var referenceRoot = CreateRoot(referenceTheme, ElementTheme.Light);
+			const string probeXaml = """
+				<Border xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+				        Padding="{ThemeResource Space200}" />
+				""";
+			var probe = (Border)XamlReader.Load(probeXaml);
+			var referenceProbe = (Border)XamlReader.Load(probeXaml);
 			root.Children.Add(probe);
+			referenceRoot.Children.Add(referenceProbe);
 
-			await UnitTestUIContentHelperEx.SetContentAndWait(root);
+			await UnitTestUIContentHelperEx.SetContentAndWait(new Grid { Children = { root, referenceRoot } });
 
-			Assert.AreEqual(expected, probe.FontSize, "Space200 must equal DefaultSpacing × density factor × 2.");
+			Assert.IsTrue(referenceProbe.Padding.Left > 0, "The reference spacing token must resolve.");
+			Assert.AreEqual(referenceProbe.Padding, probe.Padding, "Toolkit must inherit MaterialTheme spacing generation for the same inputs.");
 		}
 
 		private static Grid CreateRoot(ResourceDictionary theme, ElementTheme requestedTheme)
@@ -100,22 +106,6 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			var root = new Grid { Width = 500, Height = 600, RequestedTheme = requestedTheme };
 			root.Resources.MergedDictionaries.Add(theme);
 			return root;
-		}
-
-		private static IEnumerable<T> Descendants<T>(DependencyObject parent) where T : DependencyObject
-		{
-			for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
-			{
-				var child = VisualTreeHelper.GetChild(parent, i);
-				if (child is T match)
-				{
-					yield return match;
-				}
-				foreach (var descendant in Descendants<T>(child))
-				{
-					yield return descendant;
-				}
-			}
 		}
 	}
 }

--- a/src/Uno.Toolkit.RuntimeTests/Tests/ThemeCompatibilityTests.cs
+++ b/src/Uno.Toolkit.RuntimeTests/Tests/ThemeCompatibilityTests.cs
@@ -47,7 +47,7 @@ namespace Uno.Toolkit.RuntimeTests.Tests
 			await UnitTestUIContentHelperEx.SetContentAndWait(root);
 
 			var expected = ((FontFamily)theme["DefaultFontFamily"]).Source;
-			StringAssert.Contains(expected, "Inter.ttf", "The scoped Simple theme must supply its own default typeface.");
+			Assert.IsFalse(string.IsNullOrWhiteSpace(expected), "Simple theme DefaultFontFamily must resolve to a non-empty FontFamily source.");
 			Assert.AreEqual(expected, card.FontFamily.Source, "Card");
 			Assert.AreEqual(expected, contentCard.FontFamily.Source, "CardContentControl");
 			Assert.AreEqual(expected, chip.FontFamily.Source, "Chip");

--- a/src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.csproj
+++ b/src/Uno.Toolkit.RuntimeTests/Uno.Toolkit.RuntimeTests.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Uno.Toolkit.UI\Uno.Toolkit.WinUI.csproj" />
     <ProjectReference Include="..\library\Uno.Toolkit.Material\Uno.Toolkit.WinUI.Material.csproj" />
+    <ProjectReference Include="..\library\Uno.Toolkit.Simple\Uno.Toolkit.WinUI.Simple.csproj" />
     <ProjectReference Include="..\Uno.Toolkit.Skia.WinUI\Uno.Toolkit.Skia.WinUI.csproj" />
   </ItemGroup>
   <Import Project="..\winappsdk-workaround.targets" />

--- a/src/library/Uno.Toolkit.Material/MaterialToolkitTheme.cs
+++ b/src/library/Uno.Toolkit.Material/MaterialToolkitTheme.cs
@@ -11,8 +11,8 @@ namespace Uno.Toolkit.UI.Material
 	/// <summary>
 	/// Material (Material Design 3) styles for the controls in the Uno.Toolkit.UI library.
 	/// Inherits from <see cref="MaterialTheme"/> so all theme properties
-	/// (Colors, DefaultDensity, DefaultCornerRadius, font/color overrides) are
-	/// available directly without manual forwarding.
+	/// (Colors, DefaultFontFamily, DefaultSpacing, DefaultDensity, DefaultCornerRadius,
+	/// font/color overrides) are available directly without manual forwarding.
 	/// </summary>
 	public class MaterialToolkitTheme : MaterialTheme
 	{

--- a/src/library/Uno.Toolkit.Material/MaterialToolkitTheme.cs
+++ b/src/library/Uno.Toolkit.Material/MaterialToolkitTheme.cs
@@ -10,9 +10,7 @@ namespace Uno.Toolkit.UI.Material
 {
 	/// <summary>
 	/// Material (Material Design 3) styles for the controls in the Uno.Toolkit.UI library.
-	/// Inherits from <see cref="MaterialTheme"/> so all theme properties
-	/// (Colors, DefaultFontFamily, DefaultSpacing, DefaultDensity, DefaultCornerRadius,
-	/// font/color overrides) are available directly without manual forwarding.
+	/// Inherits theme configuration from <see cref="MaterialTheme"/>.
 	/// </summary>
 	public class MaterialToolkitTheme : MaterialTheme
 	{

--- a/src/library/Uno.Toolkit.Simple/SimpleToolkitTheme.cs
+++ b/src/library/Uno.Toolkit.Simple/SimpleToolkitTheme.cs
@@ -5,9 +5,7 @@ namespace Uno.Toolkit.UI.Simple
 {
 	/// <summary>
 	/// Simple Design System styles for the controls in the Uno.Toolkit.UI library.
-	/// Inherits from <see cref="SimpleTheme"/> so all theme properties
-	/// (Colors, DefaultFontFamily, DefaultSpacing, DefaultDensity, DefaultCornerRadius,
-	/// font/color overrides) are available directly without manual forwarding.
+	/// Inherits theme configuration from <see cref="SimpleTheme"/>.
 	/// </summary>
 	public class SimpleToolkitTheme : SimpleTheme
 	{

--- a/src/library/Uno.Toolkit.Simple/SimpleToolkitTheme.cs
+++ b/src/library/Uno.Toolkit.Simple/SimpleToolkitTheme.cs
@@ -6,8 +6,8 @@ namespace Uno.Toolkit.UI.Simple
 	/// <summary>
 	/// Simple Design System styles for the controls in the Uno.Toolkit.UI library.
 	/// Inherits from <see cref="SimpleTheme"/> so all theme properties
-	/// (Colors, DefaultDensity, DefaultCornerRadius, font/color overrides) are
-	/// available directly without manual forwarding.
+	/// (Colors, DefaultFontFamily, DefaultSpacing, DefaultDensity, DefaultCornerRadius,
+	/// font/color overrides) are available directly without manual forwarding.
 	/// </summary>
 	public class SimpleToolkitTheme : SimpleTheme
 	{

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/Card.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/Card.xaml
@@ -136,7 +136,7 @@
 		<Setter Property="Padding" Value="{StaticResource SimpleCardPadding}" />
 		<Setter Property="Background" Value="{ThemeResource FilledCardBackground}" />
 		<Setter Property="Foreground" Value="{ThemeResource CardForeground}" />
-		<Setter Property="FontFamily" Value="{StaticResource SimpleFontFamily}" />
+		<Setter Property="FontFamily" Value="{ThemeResource DefaultFontFamily}" />
 		<Setter Property="FontSize" Value="16" />
 		<Setter Property="HeaderContentTemplate" Value="{StaticResource SimpleDefaultHeaderContentTemplate}" />
 		<Setter Property="SubHeaderContentTemplate" Value="{StaticResource SimpleDefaultSubHeaderContentTemplate}" />

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/CardContentControl.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/CardContentControl.xaml
@@ -34,7 +34,7 @@
 		<Setter Property="CornerRadius" Value="{StaticResource CardCornerRadius}" />
 		<Setter Property="Background" Value="{ThemeResource FilledCardContentBackground}" />
 		<Setter Property="Foreground" Value="{ThemeResource OnSurfaceBrush}" />
-		<Setter Property="FontFamily" Value="{StaticResource SimpleFontFamily}" />
+		<Setter Property="FontFamily" Value="{ThemeResource DefaultFontFamily}" />
 		<Setter Property="FontSize" Value="16" />
 		<Setter Property="HorizontalAlignment" Value="Center" />
 		<Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/Chip.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/Chip.xaml
@@ -112,7 +112,7 @@
 		<Setter Property="BorderBrush" Value="{ThemeResource ChipBorderBrush}" />
 		<Setter Property="BorderThickness" Value="{ThemeResource ChipBorderThickness}" />
 		<Setter Property="CornerRadius" Value="{ThemeResource ChipCornerRadius}" />
-		<Setter Property="FontFamily" Value="{StaticResource SimpleFontFamily}" />
+		<Setter Property="FontFamily" Value="{ThemeResource DefaultFontFamily}" />
 		<Setter Property="FontSize" Value="16" />
 		<Setter Property="VerticalAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Center" />

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/Divider.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/Divider.xaml
@@ -10,7 +10,7 @@
 			<StaticResource x:Key="DividerForeground" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="DividerSubHeaderForeground" ResourceKey="OnSurfaceBrush" />
 
-			<StaticResource x:Key="DividerSubHeaderFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="DividerSubHeaderFontFamily" ResourceKey="DefaultFontFamily" />
 			<FontWeight x:Key="DividerSubHeaderFontWeight">Normal</FontWeight>
 			<x:Double x:Key="DividerSubHeaderFontSize">14</x:Double>
 			<x:Int32 x:Key="DividerSubHeaderCharacterSpacing">0</x:Int32>
@@ -24,7 +24,7 @@
 			<StaticResource x:Key="DividerForeground" ResourceKey="OutlineBrush" />
 			<StaticResource x:Key="DividerSubHeaderForeground" ResourceKey="OnSurfaceBrush" />
 
-			<StaticResource x:Key="DividerSubHeaderFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="DividerSubHeaderFontFamily" ResourceKey="DefaultFontFamily" />
 			<FontWeight x:Key="DividerSubHeaderFontWeight">Normal</FontWeight>
 			<x:Double x:Key="DividerSubHeaderFontSize">14</x:Double>
 			<x:Int32 x:Key="DividerSubHeaderCharacterSpacing">0</x:Int32>

--- a/src/library/Uno.Toolkit.Simple/Styles/Controls/NavigationBar.xaml
+++ b/src/library/Uno.Toolkit.Simple/Styles/Controls/NavigationBar.xaml
@@ -34,7 +34,7 @@
 			<StaticResource x:Key="NavigationBarForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarBackground" ResourceKey="SurfaceBrush" />
 			<Thickness x:Key="NavigationBarPadding">4,0,0,0</Thickness>
-			<StaticResource x:Key="NavigationBarFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="NavigationBarFontFamily" ResourceKey="DefaultFontFamily" />
 			<FontWeight x:Key="NavigationBarFontWeight">Normal</FontWeight>
 			<x:Double x:Key="NavigationBarFontSize">24</x:Double>
 
@@ -70,7 +70,7 @@
 			<Thickness x:Key="NavigationBarContentMargin">16,0</Thickness>
 			<Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
 
-			<StaticResource x:Key="NavigationBarEllipsisButtonFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="NavigationBarEllipsisButtonFontFamily" ResourceKey="DefaultFontFamily" />
 			<FontWeight x:Key="NavigationBarEllipsisButtonFontWeight">SemiBold</FontWeight>
 			<StaticResource x:Key="NavigationBarEllipsisButtonFontSize" ResourceKey="ControlContentThemeFontSize" />
 			<StaticResource x:Key="NavigationBarEllipsisButtonWidth" ResourceKey="AppBarExpandButtonThemeWidth" />
@@ -93,7 +93,7 @@
 			<StaticResource x:Key="NavigationBarForeground" ResourceKey="OnSurfaceBrush" />
 			<StaticResource x:Key="NavigationBarBackground" ResourceKey="SurfaceBrush" />
 			<Thickness x:Key="NavigationBarPadding">4,0,0,0</Thickness>
-			<StaticResource x:Key="NavigationBarFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="NavigationBarFontFamily" ResourceKey="DefaultFontFamily" />
 			<FontWeight x:Key="NavigationBarFontWeight">Normal</FontWeight>
 			<x:Double x:Key="NavigationBarFontSize">24</x:Double>
 
@@ -129,7 +129,7 @@
 			<Thickness x:Key="NavigationBarContentMargin">16,0</Thickness>
 			<Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
 
-			<StaticResource x:Key="NavigationBarEllipsisButtonFontFamily" ResourceKey="SimpleFontFamily" />
+			<StaticResource x:Key="NavigationBarEllipsisButtonFontFamily" ResourceKey="DefaultFontFamily" />
 			<FontWeight x:Key="NavigationBarEllipsisButtonFontWeight">SemiBold</FontWeight>
 			<StaticResource x:Key="NavigationBarEllipsisButtonFontSize" ResourceKey="ControlContentThemeFontSize" />
 			<StaticResource x:Key="NavigationBarEllipsisButtonWidth" ResourceKey="AppBarExpandButtonThemeWidth" />


### PR DESCRIPTION
Related issues: https://github.com/unoplatform/Uno.Themes/issues/1709, https://github.com/unoplatform/Uno.Themes/issues/1688

GitHub issue/PR: https://github.com/unoplatform/uno.themes/pull/1710, https://github.com/unoplatform/uno.themes/pull/1701

## PR Type

- Bugfix
- Documentation content changes

## What is the current behavior?

Updating Uno Themes removes `SimpleFontFamily`, causing Simple Toolkit styles to fail during resource resolution. Toolkit also documents density as a fixed spacing unit, whereas upstream now separates `DefaultSpacing` from the density mode.

## What is the new behavior?

Compare Toolkit spacing generation against a plain MaterialTheme with identical inputs using Border.Padding probes, and reuse the existing GetDescendants extension in font checks.

Update the existing library and sample Themes pins to `8.0.0-dev.15`, replace the nine removed font references with `DefaultFontFamily`, and use `ThemeResource` for the Card, CardContentControl, and Chip font setters. Preserve Divider/NavigationBar lightweight styling keys. Link inherited BaseTheme API usage to the authoritative Uno Themes guides. Keep Toolkit setup, override limitations, and migration actions here; public docs do not reference exact prerelease package builds.

The package's nuspec points to upstream `47d42c18`, containing all latest functional changes. Upstream HEAD differs only by its 9.0 version bump, which is not yet published. Toolkit remains on its existing `10.0-dev.{height}` version; no additional major bump or new package dependency.

## Validation

- Red/fix/green: 4 Simple font cases failed before the fix; all 7 new compatibility cases pass afterward.
- Desktop runtime tests: **41 passed, 0 failed, 0 skipped** across ThemeCompatibilityTests, ThemeInitTests, CardContentControlTests, ChipGroupTests, and NavigationBarTests.
- Release builds passed: Material Desktop/WebAssembly, Simple Desktop, Cupertino Desktop, and affected libraries including Material Markup.
- Standalone affected library builds: **0 warnings, 0 errors**.
- Sample builds retain warnings identical to isolated `origin/main` builds: Material Desktop 100, Material WebAssembly 113, Simple/Cupertino Desktop 99 each. No suppressions added.
- WebAssembly runtime tests, mobile/WinUI, and Debug hot-reload tests were not run.
- XAML Styler executed; unrelated formatting churn excluded. `git diff --check` passes.

## PR Checklist

- [x] Tested with the repository SDKs (.NET SDK 10.0.400)
- [x] Runtime regression tests added and run
- [x] General/migration documentation updated
- [x] Conventional Commit
- [x] Associated upstream changes linked
- [ ] Contains no breaking changes — inherited upstream font-resource and numeric density changes are documented for the existing Toolkit 10 major line

## Other information

Test scope, exact invocation pattern, package provenance, and verification limits are recorded in `specs/themes-compatibility/progress.md`.

## Review follow-up validation

- All 7 ThemeCompatibilityTests pass on macOS Desktop after the review changes (0 failed, 0 skipped).
- Release Material Desktop and WebAssembly builds pass (100/113 sample warnings, 0 errors).
- Review changes retain all three density cases without duplicating the upstream multiplier table.
