### PR TITLE
ci: Set version to '11.0-dev.{height}' for the Uno 7.0 line

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0-dev.{height}",
+  "version": "11.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

_Release-line coordination for the Uno Platform 7.0 major — no product issue, tracked with the rest of the 7.0 repo splits._

## PR Type

- Build or CI related changes

## Description

Moves `main` from `10.0-dev.{height}` to `11.0-dev.{height}`, so `main` becomes the Uno Platform **7.0** line for the Toolkit.

### Why 10.0 is no longer the 7.0 line

#1634 bumped `main` to `10.0-dev` on the assumption that 10.0 would carry the 7.0 retarget. That turned out to be wrong: **10.0 is needed on the Uno 6.x line first.**

Aligning the Toolkit to **Uno.Themes 8.0** (#1636) moves `UnoThemesVersion` from `7.1.0-dev.1` to `8.0.0-dev.15` and replaces the `SimpleFontFamily` references with `DefaultFontFamily`, the key Uno.Themes removed in unoplatform/Uno.Themes#1710. The Toolkit's *own* surface is unchanged — no Toolkit resource key is renamed or removed — but the dependency floor crosses a major, so anyone upgrading the Toolkit is pulled onto Themes 8.0 and its breaking resource changes. Shipping that under a minor would deliver a breaking change silently, so it needs a major of its own: **10.0**.

That alignment has to happen on the 6.x line because Uno 6.7 SR3 will pin Uno.Themes 8.0, so the Toolkit shipping alongside it must be Themes-8.0-compatible.

### Branch layout

| Branch | version.json | Packages | Consumers |
|---|---|---|---|
| `main` | `11.0-dev.{height}` | `11.0.0-dev.1` -> N | Uno Platform 7.0 |
| `servicing/10.0` | `10.0-dev.{height}` (unchanged) | `10.0.0-dev.2` -> N | Uno Platform 6.x + Themes 8.0 |
| `release/stable/10.0` *(later)* | `10.0` | `10.0.1` | Uno 6.7 SR3 |

This mirrors Uno.Themes exactly, where 8.0 stayed on the 6.x line as `servicing/8.0` and `master` moved to 9.0 (unoplatform/Uno.Themes#1723).

`servicing/9.2` is retired — its line predates the Themes 8.0 alignment, so nothing new belongs on it. No pull request has ever targeted it, and its only unique commit (`5fc9cbe1`, the servicing CI plumbing) is already on `main` via #1634. The published `9.2.0-dev.*` packages stay on nuget.org.

### Ordering

This merges **first**, before `servicing/10.0` is cut. `servicing/10.0` keeps the same `version` field, so while both branches share it they would compute the same height and could race on the same package version.

### Correction to #1634

#1634's body says *"Bump version to 10.0-dev for the Uno 7.0 line"*. That wording is superseded here rather than rewritten in history: `d88a0c12` is the base of two in-flight branches (`dev/sb/themes-changes`, `dev/sb/fluent`), so rewriting it would orphan them. #1634's description will carry a correction note instead.

## PR Checklist

- [x] Tested the changes where applicable: n/a — `version.json` only, no product code
- [x] Updated the documentation as needed: n/a
- [x] Contains **No** breaking changes

The version number itself is a breaking bump, but this PR carries no code change; the breaking work lands via #1635.

## Other information

- `publicReleaseRefSpec` already contains `^refs/heads/servicing/.*$` (added by #1634), so no refspec change is needed.
- Branch protection already has a `servicing/*` pattern rule, so `servicing/10.0` is protected on creation.
- #1635 (7.0 groundwork) does not touch `version.json`, so it will not conflict with this bump. It does share `src/Directory.Packages.props` and `samples/Directory.Packages.props` with #1636 — retargeting #1636 to `servicing/10.0` removes that overlap.
- #1635 still pins `UnoThemesVersion` at `7.1.0-dev.1`; the 7.0 line will need a `9.0.0-dev.*` Themes build once unoplatform/Uno.Themes#1722 lands.
